### PR TITLE
feat(devtools): add MCP integration and new skills

### DIFF
--- a/devtools/.claude-plugin/plugin.json
+++ b/devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devtools",
   "description": "Modern development tools for React, APIs, blockchain, databases, and testing. MCP-first skills with Context7 integration for up-to-date documentation.",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "author": {
     "name": "SettleMint",
     "email": "support@settlemint.com"

--- a/devtools/.mcp.json
+++ b/devtools/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "shadcn": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["shadcn@latest", "mcp"]
+    }
+  }
+}

--- a/devtools/skills/design-principles/SKILL.md
+++ b/devtools/skills/design-principles/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: design-principles
+description: Enforce a precise, minimal design system inspired by Linear, Notion, and Stripe. Use when building dashboards, admin interfaces, or any UI that needs Jony Ive-level precision - clean, modern, minimalist with taste. Every pixel matters.
+triggers:
+  [
+    "dashboard",
+    "admin",
+    "ui design",
+    "design system",
+    "spacing",
+    "typography",
+    "elevation",
+    "shadow",
+    "card",
+    "layout",
+  ]
+---
+
+<objective>
+Enforce precise, crafted design for enterprise software, SaaS dashboards, admin interfaces, and web applications. The philosophy is Jony Ive-level precision with intentional personality — every interface is polished, and each is designed for its specific context.
+</objective>
+
+<quick_start>
+**Before writing any code, commit to a design direction.** Don't default. Think about what this specific product needs to feel like.
+
+Ask these questions:
+
+- **What does this product do?** A finance tool needs different energy than a creative tool.
+- **Who uses it?** Power users want density. Occasional users want guidance.
+- **What's the emotional job?** Trust? Efficiency? Delight? Focus?
+- **What would make this memorable?** Every product has a chance to feel distinctive.
+  </quick_start>
+
+<design_directions>
+Enterprise/SaaS UI has more range than you think. Consider these directions:
+
+**Precision & Density** — Tight spacing, monochrome, information-forward. For power users who live in the tool. Think Linear, Raycast, terminal aesthetics.
+
+**Warmth & Approachability** — Generous spacing, soft shadows, friendly colors. For products that want to feel human. Think Notion, Coda, collaborative tools.
+
+**Sophistication & Trust** — Cool tones, layered depth, financial gravitas. For products handling money or sensitive data. Think Stripe, Mercury, enterprise B2B.
+
+**Boldness & Clarity** — High contrast, dramatic negative space, confident typography. For products that want to feel modern and decisive. Think Vercel, minimal dashboards.
+
+**Utility & Function** — Muted palette, functional density, clear hierarchy. For products where the work matters more than the chrome. Think GitHub, developer tools.
+
+**Data & Analysis** — Chart-optimized, technical but accessible, numbers as first-class citizens. For analytics, metrics, business intelligence.
+
+Pick one. Or blend two. But commit to a direction that fits the product.
+</design_directions>
+
+<color_foundation>
+**Don't default to warm neutrals.** Consider the product:
+
+- **Warm foundations** (creams, warm grays) — approachable, comfortable, human
+- **Cool foundations** (slate, blue-gray) — professional, trustworthy, serious
+- **Pure neutrals** (true grays, black/white) — minimal, bold, technical
+- **Tinted foundations** (slight color cast) — distinctive, memorable, branded
+
+**Light or dark?** Dark modes aren't just light modes inverted. Dark feels technical, focused, premium. Light feels open, approachable, clean. Choose based on context.
+
+**Accent color** — Pick ONE that means something. Blue for trust. Green for growth. Orange for energy. Violet for creativity. Don't just reach for the same accent every time.
+</color_foundation>
+
+<layout_approach>
+The content should drive the layout:
+
+- **Dense grids** for information-heavy interfaces where users scan and compare
+- **Generous spacing** for focused tasks where users need to concentrate
+- **Sidebar navigation** for multi-section apps with many destinations
+- **Top navigation** for simpler tools with fewer sections
+- **Split panels** for list-detail patterns where context matters
+  </layout_approach>
+
+<typography_choices>
+Typography sets tone. Don't always default:
+
+- **System fonts** — fast, native, invisible (good for utility-focused products)
+- **Geometric sans** (Geist, Inter) — modern, clean, technical
+- **Humanist sans** (SF Pro, Satoshi) — warmer, more approachable
+- **Monospace influence** — technical, developer-focused, data-heavy
+  </typography_choices>
+
+<core_craft_principles>
+These apply regardless of design direction. This is the quality floor.
+
+<the_4px_grid>
+All spacing uses a 4px base grid:
+
+- `4px` - micro spacing (icon gaps)
+- `8px` - tight spacing (within components)
+- `12px` - standard spacing (between related elements)
+- `16px` - comfortable spacing (section padding)
+- `24px` - generous spacing (between sections)
+- `32px` - major separation
+  </the_4px_grid>
+
+<symmetrical_padding>
+**TLBR must match.** If top padding is 16px, left/bottom/right must also be 16px. Exception: when content naturally creates visual balance.
+
+```css
+/* Good */
+padding: 16px;
+padding: 12px 16px; /* Only when horizontal needs more room */
+
+/* Bad */
+padding: 24px 16px 12px 16px;
+```
+
+</symmetrical_padding>
+
+<border_radius>
+Stick to the 4px grid. Sharper corners feel technical, rounder corners feel friendly. Pick a system and commit:
+
+- Sharp: 4px, 6px, 8px
+- Soft: 8px, 12px
+- Minimal: 2px, 4px, 6px
+
+Don't mix systems. Consistency creates coherence.
+</border_radius>
+
+<depth_strategy>
+**Match your depth approach to your design direction.** Depth is a tool, not a requirement.
+
+**Borders-only (flat)** — Clean, technical, dense. Works for utility-focused tools where information density matters more than visual lift. Linear, Raycast, and many developer tools use almost no shadows — just subtle borders to define regions. This isn't lazy; it's intentional restraint.
+
+**Subtle single shadows** — Soft lift without complexity. A simple `0 1px 3px rgba(0,0,0,0.08)` can be enough. Works for approachable products that want gentle depth without the weight of layered shadows.
+
+**Layered shadows** — Rich, premium, dimensional. Multiple shadow layers create realistic depth for products that want to feel substantial. Stripe and Mercury use this approach. Best for cards that need to feel like physical objects.
+
+**Surface color shifts** — Background tints establish hierarchy without any shadows. A card at `#fff` on a `#f8fafc` background already feels elevated. Shadows can reinforce this, but color does the heavy lifting.
+
+Choose ONE approach and commit. Mixing flat borders on some cards with heavy shadows on others creates visual inconsistency.
+
+```css
+/* Borders-only approach */
+--border: rgba(0, 0, 0, 0.08);
+--border-subtle: rgba(0, 0, 0, 0.05);
+border: 0.5px solid var(--border);
+
+/* Single shadow approach */
+--shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+/* Layered shadow approach (when appropriate) */
+--shadow-layered:
+  0 0 0 0.5px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.04),
+  0 2px 4px rgba(0, 0, 0, 0.03), 0 4px 8px rgba(0, 0, 0, 0.02);
+```
+
+**The craft is in the choice, not the complexity.** A flat interface with perfect spacing and typography is more polished than a shadow-heavy interface with sloppy details.
+</depth_strategy>
+
+<card_layouts>
+Monotonous card layouts are lazy design. A metric card doesn't have to look like a plan card doesn't have to look like a settings card. One might have a sparkline, another an avatar stack, another a progress ring, another a two-column split.
+
+Design each card's internal structure for its specific content — but keep the surface treatment consistent: same border weight, shadow depth, corner radius, padding scale, typography. Cohesion comes from the container chrome, not from forcing every card into the same layout template.
+</card_layouts>
+
+<isolated_controls>
+UI controls deserve container treatment. Date pickers, filters, dropdowns — these should feel like crafted objects sitting on the page, not plain text with click handlers.
+
+**Never use native form elements for styled UI.** Native `<select>`, `<input type="date">`, and similar elements render OS-native dropdowns and pickers that cannot be styled. Build custom components instead:
+
+- Custom select: trigger button + positioned dropdown menu
+- Custom date picker: input + calendar popover
+- Custom checkbox/radio: styled div with state management
+
+**Custom select triggers must use `display: inline-flex` with `white-space: nowrap`** to keep text and chevron icons on the same row. Without this, flex children can wrap to new lines.
+</isolated_controls>
+
+<typography_hierarchy>
+
+- Headlines: 600 weight, tight letter-spacing (-0.02em)
+- Body: 400-500 weight, standard tracking
+- Labels: 500 weight, slight positive tracking for uppercase
+- Scale: 11px, 12px, 13px, 14px (base), 16px, 18px, 24px, 32px
+  </typography_hierarchy>
+
+<monospace_for_data>
+Numbers, IDs, codes, timestamps belong in monospace. Use `tabular-nums` for columnar alignment. Mono signals "this is data."
+</monospace_for_data>
+
+<iconography>
+Use **Phosphor Icons** (`@phosphor-icons/react`). Icons clarify, not decorate — if removing an icon loses no meaning, remove it.
+
+Give standalone icons presence with subtle background containers.
+</iconography>
+
+<animation>
+- 150ms for micro-interactions, 200-250ms for larger transitions
+- Easing: `cubic-bezier(0.25, 1, 0.5, 1)`
+- No spring/bouncy effects in enterprise UI
+</animation>
+
+<contrast_hierarchy>
+Build a four-level system: foreground (primary) → secondary → muted → faint. Use all four consistently.
+</contrast_hierarchy>
+
+<color_for_meaning>
+Gray builds structure. Color only appears when it communicates: status, action, error, success. Decorative color is noise.
+
+When building data-heavy interfaces, ask whether each use of color is earning its place. Score bars don't need to be color-coded by performance — a single muted color works. Grade badges don't need traffic-light colors — typography can do the hierarchy work. Look at how GitHub renders tables and lists: almost entirely monochrome, with color reserved for status indicators and actionable elements.
+</color_for_meaning>
+</core_craft_principles>
+
+<navigation_context>
+Screens need grounding. A data table floating in space feels like a component demo, not a product. Consider including:
+
+- **Navigation** — sidebar or top nav showing where you are in the app
+- **Location indicator** — breadcrumbs, page title, or active nav state
+- **User context** — who's logged in, what workspace/org
+
+When building sidebars, consider using the same background as the main content area. Tools like Supabase, Linear, and Vercel rely on a subtle border for separation rather than different background colors. This reduces visual weight and feels more unified.
+</navigation_context>
+
+<dark_mode>
+Dark interfaces have different needs:
+
+**Borders over shadows** — Shadows are less visible on dark backgrounds. Lean more on borders for definition. A border at 10-15% white opacity might look nearly invisible but it's doing its job — resist the urge to make it more prominent.
+
+**Adjust semantic colors** — Status colors (success, warning, error) often need to be slightly desaturated or adjusted for dark backgrounds to avoid feeling harsh.
+
+**Same structure, different values** — The hierarchy system (foreground → secondary → muted → faint) still applies, just with inverted values.
+</dark_mode>
+
+<anti_patterns>
+<never_do>
+
+- Dramatic drop shadows (`box-shadow: 0 25px 50px...`)
+- Large border radius (16px+) on small elements
+- Asymmetric padding without clear reason
+- Pure white cards on colored backgrounds
+- Thick borders (2px+) for decoration
+- Excessive spacing (margins > 48px between sections)
+- Spring/bouncy animations
+- Gradients for decoration
+- Multiple accent colors in one interface
+  </never_do>
+
+<always_question>
+
+- "Did I think about what this product needs, or did I default?"
+- "Does this direction fit the context and users?"
+- "Does this element feel crafted?"
+- "Is my depth strategy consistent and intentional?"
+- "Are all elements on the grid?"
+  </always_question>
+  </anti_patterns>
+
+<success_criteria>
+Every interface should look designed by a team that obsesses over 1-pixel differences. Not stripped — _crafted_. And designed for its specific context.
+
+- [ ] Design direction explicitly chosen (not defaulted)
+- [ ] Color foundation matches product context
+- [ ] All spacing on 4px grid
+- [ ] Symmetrical padding applied
+- [ ] Single depth strategy used consistently
+- [ ] Typography hierarchy established
+- [ ] No anti-patterns present
+- [ ] Color used for meaning only
+      </success_criteria>

--- a/devtools/skills/shadcn/SKILL.md
+++ b/devtools/skills/shadcn/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: shadcn
+description: shadcn/ui component library with MCP server integration. Use when adding UI components, building forms, or working with shadcn primitives. Triggers on shadcn, @/components/ui, cn(), radix, cva, component variants.
+triggers:
+  [
+    "shadcn",
+    "components/ui",
+    "cn(",
+    "radix",
+    "cva",
+    "buttonVariants",
+    "CardHeader",
+    "DialogContent",
+  ]
+---
+
+<objective>
+Build and customize shadcn/ui components using the shadcn MCP server for discovery and installation. This skill provides patterns for component usage, customization with CVA variants, form integration, and theming.
+</objective>
+
+<mcp_first>
+**CRITICAL: Use the shadcn MCP server for component discovery and installation.**
+
+The shadcn MCP server enables browsing, searching, and installing components via natural language. Always use it before manually creating components.
+</mcp_first>
+
+<quick_start>
+**Step 1: Use MCP for component operations**
+
+The shadcn MCP server is auto-configured via the devtools plugin. Use natural language:
+
+```
+"Show me all available components in the shadcn registry"
+"Add button, dialog and card components"
+"Create a contact form using shadcn components"
+"Search for a date picker component"
+```
+
+**Step 2: Import and use components**
+
+```typescript
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export function MyComponent() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Button variant="outline">Click me</Button>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+</quick_start>
+
+<cn_utility>
+**Always use `cn()` for class management.**
+
+```typescript
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+Usage patterns:
+
+```typescript
+// Conditional classes
+className={cn("base-class", isActive && "active-class")}
+
+// Override with custom classes
+className={cn(buttonVariants({ variant, size }), className)}
+
+// Multiple conditions
+className={cn(
+  "rounded-lg border p-4",
+  variant === "compact" && "p-2",
+  isDisabled && "opacity-50 cursor-not-allowed"
+)}
+```
+
+</cn_utility>
+
+<cva_variants>
+**Use CVA (Class Variance Authority) for component variants.**
+
+```typescript
+import { cva, type VariantProps } from "class-variance-authority";
+
+const buttonVariants = cva(
+  // Base styles (always applied)
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+interface ButtonProps
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+```
+
+</cva_variants>
+
+<compound_components>
+**Build compound components with data-slot attributes.**
+
+```typescript
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"h3">) {
+  return (
+    <h3
+      data-slot="card-title"
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("p-6 pt-0", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardTitle, CardContent };
+```
+
+</compound_components>
+
+<as_child_pattern>
+**Support polymorphic rendering with asChild and Radix Slot.**
+
+```typescript
+import { Slot } from "@radix-ui/react-slot";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+function Button({ className, variant, size, asChild = false, ...props }: ButtonProps) {
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+// Usage: render as link
+<Button asChild>
+  <a href="/dashboard">Go to Dashboard</a>
+</Button>
+```
+
+</as_child_pattern>
+
+<common_components>
+**Core components and their exports:**
+
+| Component    | Exports                                                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| Button       | `Button`, `buttonVariants`                                                                                                    |
+| Card         | `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, `CardFooter`                                             |
+| Dialog       | `Dialog`, `DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `DialogClose` |
+| Select       | `Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, `SelectItem`, `SelectGroup`, `SelectLabel`                         |
+| Input        | `Input`                                                                                                                       |
+| Checkbox     | `Checkbox`                                                                                                                    |
+| Tabs         | `Tabs`, `TabsList`, `TabsTrigger`, `TabsContent`                                                                              |
+| Accordion    | `Accordion`, `AccordionItem`, `AccordionTrigger`, `AccordionContent`                                                          |
+| Alert        | `Alert`, `AlertTitle`, `AlertDescription`                                                                                     |
+| Badge        | `Badge`, `badgeVariants`                                                                                                      |
+| Sheet        | `Sheet`, `SheetTrigger`, `SheetContent`, `SheetHeader`, `SheetTitle`, `SheetDescription`                                      |
+| Command      | `Command`, `CommandInput`, `CommandList`, `CommandEmpty`, `CommandGroup`, `CommandItem`                                       |
+| Popover      | `Popover`, `PopoverTrigger`, `PopoverContent`                                                                                 |
+| DropdownMenu | `DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuSeparator`                     |
+
+</common_components>
+
+<theming>
+**shadcn uses CSS variables for theming.**
+
+```css
+/* app.css or globals.css */
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  /* ... dark mode values */
+}
+```
+
+Reference in Tailwind:
+
+```typescript
+className = "bg-background text-foreground border-border";
+className = "bg-primary text-primary-foreground";
+className = "bg-muted text-muted-foreground";
+```
+
+</theming>
+
+<accessibility>
+**Built-in accessibility patterns:**
+
+```typescript
+// Focus rings
+className =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+// Invalid state
+className = "aria-invalid:border-destructive aria-invalid:ring-destructive/20";
+
+// Disabled state
+className = "disabled:pointer-events-none disabled:opacity-50";
+
+// Screen reader only
+className = "sr-only";
+
+// Focus within group
+className = "group-focus-within:ring-2";
+```
+
+ARIA attributes:
+
+```typescript
+<Input aria-invalid={!!errors} aria-describedby={`${id}-error`} />
+<div role="alert" id={`${id}-error`}>{error}</div>
+```
+
+</accessibility>
+
+<icons>
+**Use lucide-react for icons.**
+
+```typescript
+import { ChevronDown, Check, X, Search, Settings } from "lucide-react";
+
+// In components
+<Button>
+  <Settings className="mr-2 h-4 w-4" />
+  Settings
+</Button>
+
+// Icon sizing pattern in shadcn components
+className="[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+```
+
+</icons>
+
+<form_integration>
+**Wrap shadcn components for form fields.**
+
+```typescript
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface TextFieldProps {
+  label: string;
+  name: string;
+  error?: string;
+  required?: boolean;
+}
+
+export function TextField({ label, name, error, required, ...props }: TextFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={name}>
+        {label}
+        {required && <span className="text-destructive ml-1">*</span>}
+      </Label>
+      <Input
+        id={name}
+        name={name}
+        aria-invalid={!!error}
+        aria-describedby={error ? `${name}-error` : undefined}
+        className={cn(error && "border-destructive")}
+        {...props}
+      />
+      {error && (
+        <p id={`${name}-error`} className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+</form_integration>
+
+<directory_structure>
+**Standard component organization:**
+
+```
+src/components/
+├── ui/                    # shadcn primitives (47+ components)
+│   ├── button.tsx
+│   ├── card.tsx
+│   ├── dialog.tsx
+│   ├── input.tsx
+│   ├── select.tsx
+│   └── ...
+├── form/                  # Form field wrappers
+│   ├── text-field.tsx
+│   ├── select-field.tsx
+│   └── checkbox-field.tsx
+└── [feature]/             # Feature-specific compositions
+```
+
+</directory_structure>
+
+<constraints>
+**Required:**
+- Import from `@/components/ui/[component]`
+- Use `cn()` for all className composition
+- Export prop types for custom components
+- Support className override in all components
+
+**Banned:**
+
+- Inline styles (use Tailwind)
+- Native form elements in styled UI (use custom components)
+- Hardcoded colors (use CSS variables)
+- Components > 150 lines
+  </constraints>
+
+<anti_patterns>
+<pitfall name="wrong_imports">
+
+```typescript
+// Wrong - barrel imports
+import { Button, Card } from "@/components/ui";
+
+// Correct - direct imports
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+```
+
+</pitfall>
+
+<pitfall name="missing_cn">
+```typescript
+// Wrong - string concatenation
+className={`base-class ${isActive ? "active" : ""}`}
+
+// Correct - cn utility
+className={cn("base-class", isActive && "active")}
+
+````
+</pitfall>
+
+<pitfall name="native_form_elements">
+```typescript
+// Wrong - native select (can't be styled)
+<select>{options}</select>
+
+// Correct - shadcn Select
+<Select>
+  <SelectTrigger>
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    {options.map(opt => <SelectItem key={opt} value={opt}>{opt}</SelectItem>)}
+  </SelectContent>
+</Select>
+````
+
+</pitfall>
+</anti_patterns>
+
+<success_criteria>
+
+- [ ] shadcn MCP server used for component discovery/installation
+- [ ] Components imported from `@/components/ui/[name]`
+- [ ] `cn()` used for all className composition
+- [ ] CVA used for variant-based components
+- [ ] CSS variables used for theming (no hardcoded colors)
+- [ ] Accessibility attributes included (aria-\*, focus-visible)
+- [ ] Component under 150 lines
+      </success_criteria>


### PR DESCRIPTION
## Summary

Add MCP server configuration with Context7 integration and introduce two new skills:
- design-principles: Enforce precise, minimalist design system for enterprise UIs
- shadcn: shadcn/ui component library with MCP server integration

## Changes

- Add .mcp.json for Context7 and shadcn MCP server configuration
- Create design-principles skill with comprehensive design system guidance
- Create shadcn skill with component patterns and best practices
- Bump devtools plugin version to 1.4.0

## Testing

Configuration is documented and ready for use via MCP server integration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MCP integration (Context7 and shadcn) and ship two skills to speed up UI work. This makes shadcn/ui component workflows MCP-first and codifies precise design guidance.

- New Features
  - Configure MCP servers in devtools/.mcp.json: Context7 (HTTP) and shadcn (npx stdio)
  - New skill: design-principles (spacing grid, depth strategy, typography, anti‑patterns)
  - New skill: shadcn (MCP discovery/install, cn utility, CVA variants, theming, accessibility)

- Dependencies
  - Bump devtools plugin to 1.4.0

<sup>Written for commit eb6ea9a50484af24d76451b391df5d0e258a35f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

