### PR TITLE
fix(crew): only create branch when on main/master

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/build.md
+++ b/crew/commands/build.md
@@ -208,11 +208,20 @@ for (const file of taskFiles) {
 ### Phase 3: Environment Setup
 
 ```javascript
-// Ensure on feature branch
-Bash({
-  command:
-    "git checkout feature/${slug} 2>/dev/null || git checkout -b feature/${slug}",
-});
+// Check if already on a feature branch (not main/master)
+const currentBranch = Bash({ command: "git branch --show-current" }).trim();
+const isMainBranch = currentBranch === "main" || currentBranch === "master";
+
+if (isMainBranch) {
+  // Create new feature branch only if on main/master
+  Bash({
+    command: `git checkout -b feature/${slug}`,
+    description: "Create feature branch",
+  });
+} else {
+  // Already on a feature branch - stay on it
+  console.log(`Staying on current branch: ${currentBranch}`);
+}
 
 // Update progress
 TodoWrite({


### PR DESCRIPTION
Improves the build command's branching logic to avoid creating unnecessary feature branches when already on a feature branch.

When executing the build command from an existing feature branch, it now stays on that branch instead of attempting to create a new one. This prevents disruptions to ongoing work and simplifies the workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update build command to only create feature/{slug} when on main or master. If already on a feature branch, it stays on the current branch to avoid disrupting ongoing work.

- **Bug Fixes**
  - Adds an explicit current-branch check and only creates a feature branch when on main/master.

- **Dependencies**
  - Bumps crew plugin version to 1.3.8.

<sup>Written for commit 68d38fdb8e8450d08424f399ca6fd45123c95a09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

