### PR TITLE
fix(crew): remove CI commands blocking hook

### DIFF
--- a/crew/hooks/hooks.json
+++ b/crew/hooks/hooks.json
@@ -51,10 +51,6 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/check-gh-pr-create.sh"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/check-ci-commands.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Removes the check-ci-commands.sh hook from PreToolUse configuration
- Allows CI commands to run directly in the main thread without being blocked

## Verification

- [ ] Confirm CI commands can now run in main thread
- [ ] Confirm other PreToolUse hooks (git commit, gh pr create) still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the check-ci-commands.sh PreToolUse hook so CI/test commands can run on the main thread without being blocked. Other PreToolUse hooks (git commit and gh pr create) continue to work as before.

<sup>Written for commit c2086cc6e15ec9525b3b1501ae2b215e8a1ad946. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

