### PR TITLE
fix(crew): only create branch when on main/master, don't commit plans

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/design.md
+++ b/crew/commands/design.md
@@ -74,9 +74,9 @@ TodoWrite({
       activeForm: "Generating tasks",
     },
     {
-      content: "Create branch",
+      content: "Set up branch (if needed)",
       status: "pending",
-      activeForm: "Creating branch",
+      activeForm: "Setting up branch",
     },
   ],
 });
@@ -747,12 +747,25 @@ depends_on: []
 ### Phase 11: Branch Setup
 
 ```javascript
-// Note: Branch uses slash (feature/slug), but folder uses hyphen (feature-slug)
-Bash({ command: `git checkout -b feature/${slug}` });
-Bash({
-  command: `git add .claude/plans/${slug}.md .claude/branches/${branchSlug}/tasks/`,
-});
-Bash({ command: `git commit -m "docs(plan): add plan and tasks for ${slug}"` });
+// Check if already on a feature branch (not main/master)
+const currentBranch = Bash({ command: "git branch --show-current" }).trim();
+const isMainBranch = currentBranch === "main" || currentBranch === "master";
+
+if (isMainBranch) {
+  // Create new feature branch only if on main/master
+  // Note: Branch uses slash (feature/slug), but folder uses hyphen (feature-slug)
+  Bash({
+    command: `git checkout -b feature/${slug}`,
+    description: "Create feature branch",
+  });
+} else {
+  // Already on a feature branch - stay on it
+  console.log(`Staying on current branch: ${currentBranch}`);
+}
+
+// Note: Plans and task files are NOT committed to git
+// - .claude/plans/ contains local working documents
+// - .claude/branches/ is gitignored
 ```
 
 ### Phase 12: Next Steps
@@ -810,5 +823,5 @@ AskUserQuestion({
 - [ ] Task files follow naming: `{order}-{status}-{priority}-{story}-{slug}.md`
 - [ ] Each task file has acceptance criteria
 - [ ] Parallel tasks marked with `parallel: true`
-- [ ] Branch created and files committed
+- [ ] Branch created (only if on main/master)
 - [ ] AskUserQuestion confirms next steps

--- a/crew/commands/git/branch.md
+++ b/crew/commands/git/branch.md
@@ -20,7 +20,9 @@ allowed-tools: Bash(git checkout:*), Bash(git fetch:*), Bash(git branch:*)
 
 ## Task
 
-1. `git fetch origin main`
-2. `git checkout -b <type>/<name> origin/main`
+1. Check current branch: `git branch --show-current`
+2. **If NOT on main/master**: Warn user they're on a feature branch and ask to confirm switching
+3. `git fetch origin main`
+4. `git checkout -b <type>/<name> origin/main`
 
 If no name provided, ask user what they're working on.

--- a/crew/commands/git/pr.md
+++ b/crew/commands/git/pr.md
@@ -20,10 +20,11 @@ allowed-tools: Bash(git checkout:*), Bash(git add:*), Bash(git status:*), Bash(g
 
 ## Task
 
-1. **If on main**: `git checkout -b feat/<name>`
-2. **Stage & commit**: `git add . && git commit -m "type(scope): msg"`
-3. **Push**: `git push -u origin $(git branch --show-current)`
-4. **Create PR**: Use HEREDOC for body:
+1. Check current branch: `git branch --show-current`
+2. **If on main/master**: Create feature branch with `git checkout -b feat/<name>` (otherwise stay on current branch)
+3. **Stage & commit**: `git add . && git commit -m "type(scope): msg"`
+4. **Push**: `git push -u origin $(git branch --show-current)`
+5. **Create PR**: Use HEREDOC for body:
    ```bash
    gh pr create --title "..." --body "$(cat <<'EOF'
    ## Summary


### PR DESCRIPTION
## Summary

- Commands now check if already on a feature branch before creating a new one
- Removed git add/commit for plans in design.md (plans stay local, `.claude/branches/` is gitignored)
- Added warning in git/branch.md when user is already on a feature branch
- Made branch check explicit in git/pr.md

## Test plan

- [ ] Run `/crew:design` while on a feature branch - should stay on current branch
- [ ] Run `/crew:design` while on main - should create new feature branch
- [ ] Run `/crew:git:branch` while on feature branch - should warn before switching

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commands now only create a feature branch when you’re on main or master, and design plans are no longer committed. This improves branch hygiene and keeps local planning files out of git.

- **Bug Fixes**
  - Design: Create feature branch only from main/master; don’t stage/commit plans; .claude/branches stays gitignored.
  - git:branch: Warn when already on a feature branch and ask to confirm before switching.
  - git:pr: Explicitly check current branch; only create a new branch from main/master.

- **Dependencies**
  - Bump crew plugin version to 1.3.9.

<sup>Written for commit eae7418ba3f57bd579c59c5508a75fd5c847980e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

