### PR TITLE
feat(crew): granular commits and mandatory CI validation in build

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.3.9",
+  "version": "1.3.12",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"


### PR DESCRIPTION
## Summary

- Add granular commits after each task completion for detailed git history and traceability
- Enforce mandatory `bun run ci` and `bun run test:integration` from repository root with requirement to fix ALL issues (even unrelated)
- Remove automatic push/PR creation - these are now manual actions via `/crew:git:push` and `/crew:git:pr`

## Test plan

- [ ] Run `/crew:build` and verify each task creates its own commit
- [ ] Verify Phase 7 runs CI and integration tests from root
- [ ] Verify build does not automatically push or create PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-task commits to /crew:build for detailed history and makes root-level CI and integration tests mandatory before finishing. Push and PR creation are no longer automatic; use manual commands when ready.

- **New Features**
  - Create a commit right after each task with scoped conventional message and task metadata.
  - Phase 7 runs bun run ci and bun run test:integration from the repo root; you must fix all failures (type, lint, unit, integration), even if unrelated, and re-run until clean.
  - Phase 8 shows a commit summary instead of shipping; pushing and PR are manual via /crew:git:push and /crew:git:pr.
  - Bump plugin version to 1.3.12.

- **Migration**
  - Expect one commit per task when running /crew:build.
  - Ensure bun run ci and bun run test:integration pass from the repo root; fix all errors, including pre-existing ones.
  - Manually push and open a PR when ready using /crew:git:push and /crew:git:pr (or git/gh).

<sup>Written for commit 4974b0ed3b15ff716b6de80f28b08d7c8a8bc6fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

