### PR TITLE
fix(crew): gracefully skip already-installed marketplaces in setup script

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/scripts/hooks/session-start/setup-plugins.sh
+++ b/crew/scripts/hooks/session-start/setup-plugins.sh
@@ -27,29 +27,29 @@ info() { echo -e "${ARROW} $1"; }
 success() { echo -e "${CHECK} $1"; }
 warn() { echo -e "${WARN} $1"; }
 error() {
-	echo -e "${CROSS} $1" >&2
-	ERRORS+=("$1")
+  echo -e "${CROSS} $1" >&2
+  ERRORS+=("$1")
 }
 
 # Check if running as hook - skip on compact/resume events
 # Only attempt to read stdin if CLAUDE_HOOK environment variable is set
 # This avoids consuming stdin when run via "curl ... | bash"
 if [[ -n "${CLAUDE_HOOK:-}" ]] && [[ ! -t 0 ]]; then
-	# Running as Claude hook with piped input
-	INPUT=$(cat)
-	EVENT_TYPE=$(echo "$INPUT" | jq -r '.type // "unknown"' 2>/dev/null || echo "direct")
+  # Running as Claude hook with piped input
+  INPUT=$(cat)
+  EVENT_TYPE=$(echo "$INPUT" | jq -r '.type // "unknown"' 2>/dev/null || echo "direct")
 
-	if [[ $EVENT_TYPE == "compact" || $EVENT_TYPE == "resume" ]]; then
-		# Skip on compact/resume - only run on fresh startup or direct execution
-		exit 0
-	fi
+  if [[ $EVENT_TYPE == "compact" || $EVENT_TYPE == "resume" ]]; then
+    # Skip on compact/resume - only run on fresh startup or direct execution
+    exit 0
+  fi
 fi
 
 # Check if claude CLI is available
 if ! command -v claude &>/dev/null; then
-	error "Claude CLI not found. Please install Claude Code first."
-	echo "  Visit: https://claude.ai/code"
-	exit 1
+  error "Claude CLI not found. Please install Claude Code first."
+  echo "  Visit: https://claude.ai/code"
+  exit 1
 fi
 
 echo ""
@@ -60,90 +60,90 @@ echo ""
 
 # Function to add marketplace
 add_marketplace() {
-	local repo="$1"
-	local name="$2"
+  local repo="$1"
+  local name="$2"
 
-	info "Adding marketplace: $name"
+  info "Adding marketplace: $name"
 
-	output=$(claude plugin marketplace add "$repo" 2>&1) || true
+  output=$(claude plugin marketplace add "$repo" 2>&1) || true
 
-	if echo "$output" | grep -qi "already added\|already exists\|already registered"; then
-		success "$name marketplace already configured"
-		return 0
-	elif echo "$output" | grep -qi "added\|success"; then
-		success "$name marketplace added"
-		return 0
-	elif [[ -z "$output" ]]; then
-		success "$name marketplace configured"
-		return 0
-	else
-		# Check if it's a real error
-		if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
-			error "Failed to add $name marketplace: $output"
-			return 1
-		else
-			# Unknown output, assume success
-			success "$name marketplace configured"
-			return 0
-		fi
-	fi
+  if echo "$output" | grep -qi "already added\|already exists\|already registered\|already installed"; then
+    success "$name marketplace already configured"
+    return 0
+  elif echo "$output" | grep -qi "added\|success"; then
+    success "$name marketplace added"
+    return 0
+  elif [[ -z "$output" ]]; then
+    success "$name marketplace configured"
+    return 0
+  else
+    # Check if it's a real error
+    if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
+      error "Failed to add $name marketplace: $output"
+      return 1
+    else
+      # Unknown output, assume success
+      success "$name marketplace configured"
+      return 0
+    fi
+  fi
 }
 
 # Function to update marketplace
 update_marketplace() {
-	local name="$1"
+  local name="$1"
 
-	info "Updating marketplace: $name"
+  info "Updating marketplace: $name"
 
-	output=$(claude plugin marketplace update "$name" 2>&1) || true
+  output=$(claude plugin marketplace update "$name" 2>&1) || true
 
-	if echo "$output" | grep -qi "up to date\|already up\|no updates"; then
-		success "$name is up to date"
-		return 0
-	elif echo "$output" | grep -qi "updated\|success"; then
-		success "$name updated"
-		return 0
-	elif [[ -z "$output" ]]; then
-		success "$name checked"
-		return 0
-	else
-		if echo "$output" | grep -qi "error\|fail\|not found"; then
-			warn "Could not update $name: $output"
-			return 0 # Non-fatal
-		else
-			success "$name checked"
-			return 0
-		fi
-	fi
+  if echo "$output" | grep -qi "up to date\|already up\|no updates"; then
+    success "$name is up to date"
+    return 0
+  elif echo "$output" | grep -qi "updated\|success"; then
+    success "$name updated"
+    return 0
+  elif [[ -z "$output" ]]; then
+    success "$name checked"
+    return 0
+  else
+    if echo "$output" | grep -qi "error\|fail\|not found"; then
+      warn "Could not update $name: $output"
+      return 0 # Non-fatal
+    else
+      success "$name checked"
+      return 0
+    fi
+  fi
 }
 
 # Function to install plugin
 install_plugin() {
-	local plugin="$1"
-	local display_name="${2:-$plugin}"
+  local plugin="$1"
+  local display_name="${2:-$plugin}"
 
-	info "Installing plugin: $display_name"
+  info "Installing plugin: $display_name"
 
-	output=$(claude plugin install "$plugin" 2>&1) || true
+  output=$(claude plugin install "$plugin" 2>&1) || true
 
-	if echo "$output" | grep -qi "already installed\|already enabled"; then
-		success "$display_name already installed"
-		return 0
-	elif echo "$output" | grep -qi "installed\|enabled\|success"; then
-		success "$display_name installed"
-		return 0
-	elif [[ -z "$output" ]]; then
-		success "$display_name configured"
-		return 0
-	else
-		if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
-			error "Failed to install $display_name: $output"
-			return 1
-		else
-			success "$display_name configured"
-			return 0
-		fi
-	fi
+  if echo "$output" | grep -qi "already installed\|already enabled"; then
+    success "$display_name already installed"
+    return 0
+  elif echo "$output" | grep -qi "installed\|enabled\|success"; then
+    success "$display_name installed"
+    return 0
+  elif [[ -z "$output" ]]; then
+    success "$display_name configured"
+    return 0
+  else
+    if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
+      error "Failed to install $display_name: $output"
+      return 1
+    else
+      success "$display_name configured"
+      return 0
+    fi
+  fi
 }
 
 echo "Step 1: Adding Marketplaces"
@@ -176,26 +176,26 @@ echo ""
 # Summary
 echo "================================"
 if [[ ${#ERRORS[@]} -eq 0 ]]; then
-	echo -e "${GREEN}Setup complete!${NC}"
-	echo ""
-	echo "Installed plugins:"
-	echo "  • crew@settlemint - Work orchestration (/design, /build, /check)"
-	echo "  • devtools@settlemint - Development skills (React, API, etc.)"
-	echo "  • typescript-lsp - TypeScript language server"
-	echo "  • frontend-design - UI/UX assistance"
-	echo "  • dev-browser - Browser automation"
-	echo ""
-	echo "Get started:"
-	echo "  /crew:design <feature>  - Plan a feature"
-	echo "  /crew:build             - Execute the plan"
-	echo "  /crew:check             - Review code quality"
-	echo "================================"
-	exit 0
+  echo -e "${GREEN}Setup complete!${NC}"
+  echo ""
+  echo "Installed plugins:"
+  echo "  • crew@settlemint - Work orchestration (/design, /build, /check)"
+  echo "  • devtools@settlemint - Development skills (React, API, etc.)"
+  echo "  • typescript-lsp - TypeScript language server"
+  echo "  • frontend-design - UI/UX assistance"
+  echo "  • dev-browser - Browser automation"
+  echo ""
+  echo "Get started:"
+  echo "  /crew:design <feature>  - Plan a feature"
+  echo "  /crew:build             - Execute the plan"
+  echo "  /crew:check             - Review code quality"
+  echo "================================"
+  exit 0
 else
-	echo -e "${RED}Setup completed with ${#ERRORS[@]} error(s):${NC}"
-	for err in "${ERRORS[@]}"; do
-		echo -e "  ${CROSS} $err"
-	done
-	echo "================================"
-	exit 1
+  echo -e "${RED}Setup completed with ${#ERRORS[@]} error(s):${NC}"
+  for err in "${ERRORS[@]}"; do
+    echo -e "  ${CROSS} $err"
+  done
+  echo "================================"
+  exit 1
 fi


### PR DESCRIPTION
## Summary

- Add `already installed` pattern to marketplace detection in `setup-plugins.sh`
- Script now shows success message instead of error when marketplace is pre-existing
- Bump version to 1.5.1

## Test plan

- [ ] Run setup script on machine with marketplace already installed
- [ ] Verify output shows success instead of error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates setup-plugins.sh to treat pre-installed marketplaces as success by matching “already installed,” preventing false errors during setup.

- **Bug Fixes**
  - Marketplace add now recognizes “already installed” and reports success instead of error.

- **Dependencies**
  - Bumped crew plugin version from 1.5.0 to 1.5.1.

<sup>Written for commit 143085092d8f3bd0822d7926b40a56616475a8bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

