### PR TITLE
fix(crew): prevent /crew:ci hook recursion with subagent marker

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/ci.md
+++ b/crew/commands/ci.md
@@ -30,12 +30,14 @@ const pm = Bash({
 }).trim();
 
 // Map check type to command (supports eslint/prettier and biome)
+// Prefix with CREW_CI_SUBAGENT=1 to bypass the PreToolUse hook that would otherwise
+// intercept these commands and cause recursion
 const commands = {
-  test: `${pm} run test || ${pm} exec vitest run`,
-  lint: `${pm} run lint || ${pm} exec biome lint .`,
-  format: `${pm} run format:check || ${pm} run format --check || ${pm} exec biome format . --check`,
-  typecheck: `${pm} run typecheck || ${pm} exec tsc --noEmit`,
-  all: `${pm} run ci || (${pm} run lint && ${pm} run test && ${pm} run typecheck)`,
+  test: `CREW_CI_SUBAGENT=1 ${pm} run test || CREW_CI_SUBAGENT=1 ${pm} exec vitest run`,
+  lint: `CREW_CI_SUBAGENT=1 ${pm} run lint || CREW_CI_SUBAGENT=1 ${pm} exec biome lint .`,
+  format: `CREW_CI_SUBAGENT=1 ${pm} run format:check || CREW_CI_SUBAGENT=1 ${pm} run format --check || CREW_CI_SUBAGENT=1 ${pm} exec biome format . --check`,
+  typecheck: `CREW_CI_SUBAGENT=1 ${pm} run typecheck || CREW_CI_SUBAGENT=1 ${pm} exec tsc --noEmit`,
+  all: `CREW_CI_SUBAGENT=1 ${pm} run ci || (CREW_CI_SUBAGENT=1 ${pm} run lint && CREW_CI_SUBAGENT=1 ${pm} run test && CREW_CI_SUBAGENT=1 ${pm} run typecheck)`,
 };
 
 const checkType = "$ARGUMENTS" || "all";

--- a/crew/scripts/hooks/pre-tool/check-ci-commands.sh
+++ b/crew/scripts/hooks/pre-tool/check-ci-commands.sh
@@ -14,6 +14,12 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 # Only check Bash tool
 [[ $TOOL_NAME != "Bash" ]] && exit 0
 
+# Skip if this is a subagent running via /crew:ci (prevents recursion)
+# The ci.md skill prefixes commands with CREW_CI_SUBAGENT=1
+if [[ $COMMAND == *"CREW_CI_SUBAGENT=1"* ]]; then
+  exit 0
+fi
+
 # Extract just the command portion (before any heredoc or quoted string body)
 # This prevents matching tool names in PR bodies, commit messages, etc.
 CMD_FIRST_LINE="${COMMAND%%$'\n'*}"


### PR DESCRIPTION
The check-ci-commands.sh hook was intercepting CI commands from both the main thread AND from haiku subagents spawned by /crew:ci, causing infinite recursion. Added CREW_CI_SUBAGENT=1 env var prefix as an escape hatch - the hook now skips commands with this marker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent infinite recursion in /crew:ci by marking subagent commands and skipping them in the pre-tool hook. CI runs no longer loop and remain stable.

- **Bug Fixes**
  - Prefix CI commands in ci.md with CREW_CI_SUBAGENT=1 to mark subagent runs.
  - Update check-ci-commands.sh to exit early when the marker is present for Bash commands.
  - Bump plugin version to 1.5.5.

<sup>Written for commit 77b81b60121ea5b17470ed09aaaceecac8e6fffe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

