### PR TITLE
fix(crew): make git commit hook seamless with directive message

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/scripts/hooks/pre-tool/check-git-commit.sh
+++ b/crew/scripts/hooks/pre-tool/check-git-commit.sh
@@ -8,14 +8,14 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 # Block direct git commit
 if echo "$cmd" | grep -qE '^git commit'; then
-	cat <<'EOF'
+  cat <<'EOF'
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "Use the /crew:git:commit skill for proper conventional commit format.\n\nInvoke: Skill({skill: \"crew:git:commit\"})\n\nThis ensures consistent commit messages and runs pre-commit validation."
+    "permissionDecisionReason": "REDIRECT: Invoke Skill({skill: \"crew:git:commit\"}) now"
   }
 }
 EOF
-	exit 0
+  exit 0
 fi


### PR DESCRIPTION
## Summary

- Replace verbose blocking error in git commit hook with minimal "REDIRECT: Invoke Skill..." directive
- Matches the pattern used in the CI redirect hook (commit 5bcd2ec)
- Claude now auto-invokes `/crew:git:commit` without commentary

## Test plan

- [ ] Try running `git commit` directly and verify it redirects to `/crew:git:commit` skill seamlessly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the git commit pre-tool hook to a minimal redirect message that sends commits to /crew:git:commit, removing the verbose block and making the flow seamless. Bump plugin version to 1.5.8.

<sup>Written for commit b61c7aed4a89464ad7c5fd81e4cbdff8ff1be7c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

