### PR TITLE
fix(crew): add explicit Skill tool calls to command files

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/build.md
+++ b/crew/commands/build.md
@@ -4,6 +4,18 @@ description: Execute work plans with iteration loops and progress tracking
 argument-hint: "[plan] [--loop] [--max-iterations N]"
 ---
 
+<prerequisite>
+
+**Load patterns skill first:**
+
+```javascript
+Skill({ skill: "crew:crew-patterns" });
+```
+
+This provides: `<pattern name="test-runner"/>`, `<pattern name="spawn-batch"/>`, `<pattern name="collect-results"/>`, `<pattern name="todo-progress"/>`, `<pattern name="task-file"/>`, `<pattern name="quality-agents"/>`, `<pattern name="branch-state"/>`.
+
+</prerequisite>
+
 <critical_rules>
 
 **NEVER use Bash for CI commands.** These are BLOCKED by PreToolUse hook:

--- a/crew/commands/check.md
+++ b/crew/commands/check.md
@@ -4,6 +4,18 @@ description: Multi-agent code review with automatic triage
 argument-hint: "[PR number, GitHub URL, branch name, or latest]"
 ---
 
+<prerequisite>
+
+**Load patterns skill first:**
+
+```javascript
+Skill({ skill: "crew:crew-patterns" });
+```
+
+This provides: `<pattern name="quality-agents"/>`, `<pattern name="task-file"/>`.
+
+</prerequisite>
+
 !`${CLAUDE_PLUGIN_ROOT}/scripts/workflow/check-context.sh`
 
 <input>

--- a/crew/commands/design.md
+++ b/crew/commands/design.md
@@ -4,6 +4,18 @@ description: Create validated implementation plans with research
 argument-hint: "[feature description, bug report, or improvement idea]"
 ---
 
+<prerequisite>
+
+**Load patterns skill first:**
+
+```javascript
+Skill({ skill: "crew:crew-patterns" });
+```
+
+This provides: `<pattern name="research-agents"/>`, `<pattern name="task-file"/>`.
+
+</prerequisite>
+
 <input>
 <feature_description>$ARGUMENTS</feature_description>
 </input>
@@ -188,6 +200,12 @@ Plan approved. To start building, run: /crew:build
 Files created:
 - Plan: .claude/plans/<slug>.md
 - Tasks: .claude/branches/<branch>/tasks/*.md (X tasks)
+```
+
+**If user confirms to start building:**
+
+```javascript
+Skill({ skill: "crew:build", args: "<slug>" });
 ```
 
 </phase>

--- a/crew/commands/restart.md
+++ b/crew/commands/restart.md
@@ -7,12 +7,48 @@ description: Resume pending work from a previous session
 
 <process>
 
-Based on context above:
+Based on context above, determine the appropriate action:
 
-1. **Pending tasks** → `/crew:build`
-2. **Active workflow** → Resume via Skill tool
-3. **state.json exists** → Restore TodoWrite, continue
-4. **Nothing pending** → Inform user
+<phase name="detect-state">
+```javascript
+// Check what needs to be resumed based on script output
+const hasPendingTasks = /* task files found */;
+const hasActiveWorkflow = /* state.json has activeWorkflow */;
+const hasStateFile = /* state.json exists */;
+```
+</phase>
+
+<phase name="resume-work">
+
+**If pending task files found:**
+
+```javascript
+Skill({ skill: "crew:build" });
+```
+
+**If active workflow in state.json:**
+
+```javascript
+// Invoke the workflow skill from state
+const workflow = state.activeWorkflow; // e.g., "crew:design", "crew:check"
+Skill({ skill: workflow });
+```
+
+**If state.json exists with todos:**
+
+```javascript
+// Restore TodoWrite state and continue
+TodoWrite({ todos: state.todos });
+// Resume from last in_progress item
+```
+
+**If nothing pending:**
+
+```javascript
+// Inform user - no pending work to resume
+```
+
+</phase>
 
 Execute immediately without confirmation.
 


### PR DESCRIPTION
## Summary

- Added explicit `Skill({ skill: "..." })` calls to command files that reference other skills
- Commands now properly invoke the `crew:crew-patterns` skill to load patterns before using them
- `restart.md` now correctly triggers `crew:build` and workflow resume via Skill tool

## Test plan

- [ ] Run `/crew:restart` with pending tasks - should trigger `/crew:build`
- [ ] Run `/crew:design` - should load patterns skill first
- [ ] Run `/crew:build` - should load patterns skill first  
- [ ] Run `/crew:check` - should load patterns skill first

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit Skill() calls to ensure pattern skills load and workflows resume reliably across crew commands. Fixes cases where commands referenced skills by name but didn’t actually invoke them.

- **Bug Fixes**
  - build, check, and design now load crew:crew-patterns before using pattern tags.
  - design triggers crew:build via Skill when the user confirms starting implementation.
  - restart detects pending tasks or active workflow and resumes via Skill calls (crew:build or the saved workflow); restores TodoWrite when state.json has todos.

<sup>Written for commit a21a7a2dd4159d46565b1c15ae923ba5ed6aff2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

