### PR TITLE
feat(crew): remove plan mode tools, auto-sync machete on session start

### DIFF
--- a/crew/agents/workflow/content-style-editor.md
+++ b/crew/agents/workflow/content-style-editor.md
@@ -2,7 +2,7 @@
 name: content-style-editor
 description: Use this agent when you need to review and edit text content to conform to SettleMint's style guide, or create/edit DALP documentation. This includes reviewing articles, blog posts, newsletters, documentation, MDX files, or any written content that needs to follow SettleMint's editorial standards. The agent will systematically check for title case in headlines, sentence case elsewhere, company singular/plural usage, overused words, passive voice, number formatting, punctuation rules, Fumadocs patterns, and other style guide requirements.
 skills: content-style-editor
-tools: Task, Glob, Grep, LS, ExitPlanMode, Read, Edit, MultiEdit, Write, NotebookRead, NotebookEdit, WebFetch, TodoWrite, WebSearch
+tools: Task, Glob, Grep, LS, Read, Edit, MultiEdit, Write, NotebookRead, NotebookEdit, WebFetch, TodoWrite, WebSearch
 model: inherit
 ---
 

--- a/crew/commands/design.md
+++ b/crew/commands/design.md
@@ -2,7 +2,7 @@
 name: crew:design
 description: Create validated implementation plans with research
 argument-hint: "[feature description, bug report, or improvement idea]"
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill, EnterPlanMode, ExitPlanMode
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
 <prerequisite>
@@ -31,7 +31,6 @@ This provides: `<pattern name="research-agents"/>`, `<pattern name="task-file"/>
 <constraints>
 
 - **NEVER CODE** - This command researches and writes plans only
-- **EnterPlanMode first** - Call before any research
 - **Branch early** - Set up before research so state writes to correct directory
 - **9 agents + Codex** - Launch ALL research in single message
 - **spec-flow-analyzer last** - Runs after all research collected
@@ -56,12 +55,6 @@ AskUserQuestion({
     multiSelect: false
   }]
 });
-```
-</phase>
-
-<phase name="enter-plan-mode">
-```javascript
-EnterPlanMode();
 ```
 </phase>
 
@@ -164,11 +157,7 @@ Bash({ command: `mkdir -p .claude/branches/${slugBranch}/tasks` });
 Story labels: `setup`, `found`, `us1`, `us2`, `us3`, `polish`
 </phase>
 
-<phase name="exit-plan-mode">
-```javascript
-ExitPlanMode();
-```
-
+<phase name="present-plan">
 Output:
 
 ```
@@ -191,7 +180,6 @@ Skill({ skill: "crew:build", args: "<slug>" });
 
 <success_criteria>
 
-- [ ] EnterPlanMode called at start
 - [ ] Branch created before research
 - [ ] All 9 research agents launched in single message
 - [ ] Codex MCP called directly for synthesis
@@ -201,6 +189,6 @@ Skill({ skill: "crew:build", args: "<slug>" });
 - [ ] Plan contains all 6 dimension analyses
 - [ ] Task files follow naming convention
 - [ ] Each task has acceptance criteria
-- [ ] ExitPlanMode called at end
+- [ ] Plan presented to user before offering to build
 
 </success_criteria>


### PR DESCRIPTION
## Summary

Two changes to improve the crew plugin workflow:

1. **Remove EnterPlanMode/ExitPlanMode tools** - These interfere with the crew plugin's own planning flow
2. **Auto-sync machete stack on session start** - Automatically syncs branch with parent and remote, blocks on conflicts

## Changes

### EnterPlanMode/ExitPlanMode removal
- Removed from `crew/commands/design.md` allowed-tools and process phases
- Removed from `crew/agents/workflow/content-style-editor.md` tools list
- Renamed `exit-plan-mode` phase to `present-plan` (preserves output behavior)

### Auto-sync on session start
- `check-stack-status.sh` now runs `git machete update` when behind parent
- Runs `git pull --rebase` when behind remote
- On failure, outputs blocking message with resolution steps
- Claude must resolve conflicts before proceeding with any other task

## Why

- Plan mode tools conflict with crew's design command flow
- Manual sync was easy to forget, causing stale branch issues