### PR TITLE
feat(crew): add machete context to design, build, check, and git commands

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/build.md
+++ b/crew/commands/build.md
@@ -5,6 +5,14 @@ argument-hint: "[plan] [--loop] [--max-iterations N]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
+</stack_context>
+
 <prerequisite>
 
 **Load patterns skill first:**

--- a/crew/commands/check.md
+++ b/crew/commands/check.md
@@ -5,6 +5,14 @@ argument-hint: "[PR number, GitHub URL, branch name, or latest]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
+</stack_context>
+
 <prerequisite>
 
 **Load patterns skill first:**

--- a/crew/commands/design.md
+++ b/crew/commands/design.md
@@ -5,6 +5,14 @@ argument-hint: "[feature description, bug report, or improvement idea]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
+</stack_context>
+
 <prerequisite>
 
 **Load patterns skill first:**

--- a/crew/commands/git/clean.md
+++ b/crew/commands/git/clean.md
@@ -4,6 +4,14 @@ description: Clean up stale branches (deleted on remote)
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
+</stack_context>
+
 <clean_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/clean-context.sh`
 </clean_context>

--- a/crew/commands/git/commit.md
+++ b/crew/commands/git/commit.md
@@ -4,6 +4,14 @@ description: Create a conventional commit
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
+</stack_context>
+
 <commit_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/commit-context.sh`
 </commit_context>


### PR DESCRIPTION
## Summary

This PR adds worktree status and machete stack context inclusions to key crew commands that were missing them. Commands now display the git-machete stack state and worktree warnings upfront, preventing issues where branch sync status isn't visible before operations.

## Why

When running `/crew:design` or `/crew:build`, the machete context wasn't being shown. This led to situations where:
- Manual rebases were performed instead of using `/crew:git:sync`
- Worktree safety warnings weren't visible
- Branch sync status with parent wasn't apparent before creating commits

## What changed

Added `<worktree_status>` and `<stack_context>` inclusions to:

| Command | Purpose |
|---------|---------|
| `design.md` | See stack before creating branches |
| `build.md` | See stack before executing work |
| `check.md` | See stack when reviewing code |
| `git/commit.md` | See sync status before committing |
| `git/clean.md` | See machete layout before cleanup |

These match the pattern already used in other git commands like `sync.md`, `traverse.md`, and `pr.md`.

## Test plan

- [ ] Run `/crew:design` and verify machete context appears
- [ ] Run `/crew:build` and verify worktree status appears
- [ ] Run `/crew:check` and verify stack context is shown
- [ ] Run `/crew:git:commit` and verify sync status visible
- [ ] Run `/crew:git:clean` and verify machete layout shown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show worktree status and git-machete stack context before running key crew commands. This makes branch sync state and worktree warnings visible upfront to avoid bad commits and manual rebases.

- **New Features**
  - Added <worktree_status> and <stack_context> via scripts/git/worktree-context.sh and scripts/git/machete-context.sh.
  - Applied to: design.md, build.md, check.md, git/commit.md, git/clean.md.

- **Dependencies**
  - Bumped crew plugin version to 1.22.0.

<sup>Written for commit b1a8735696b7636c3f28d954b6d255f6f58c8bab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

