### PR TITLE
feat(crew): add explicit Skill() calls to hook outputs

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/scripts/git/gh-pr-scope-check.sh
+++ b/crew/scripts/git/gh-pr-scope-check.sh
@@ -10,8 +10,8 @@ set -uo pipefail
 # Check if we have a PR for this branch
 PR_JSON=$(gh pr view --json number,title,body,commits 2>/dev/null)
 if [[ -z $PR_JSON ]]; then
-	# No PR exists, nothing to check
-	exit 0
+  # No PR exists, nothing to check
+  exit 0
 fi
 
 PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
@@ -49,55 +49,50 @@ REASONS=()
 
 # Multiple commits but title only mentions one thing
 if [[ $COMMIT_COUNT -gt 1 ]]; then
-	# Check if title seems too narrow for the scope
-	if [[ ${#SCOPE_PARTS[@]} -gt 1 ]]; then
-		NEEDS_UPDATE="true"
-		REASONS+=("PR has ${COMMIT_COUNT} commits spanning multiple types: ${SCOPE_PARTS[*]}")
-	fi
+  # Check if title seems too narrow for the scope
+  if [[ ${#SCOPE_PARTS[@]} -gt 1 ]]; then
+    NEEDS_UPDATE="true"
+    REASONS+=("PR has ${COMMIT_COUNT} commits spanning multiple types: ${SCOPE_PARTS[*]}")
+  fi
 fi
 
 # Check if body is too short for the scope
 BODY_LENGTH=${#PR_BODY}
 if [[ $BODY_LENGTH -lt 100 && $COMMIT_COUNT -gt 2 ]]; then
-	NEEDS_UPDATE="true"
-	REASONS+=("PR body is short ($BODY_LENGTH chars) but has $COMMIT_COUNT commits")
+  NEEDS_UPDATE="true"
+  REASONS+=("PR body is short ($BODY_LENGTH chars) but has $COMMIT_COUNT commits")
 fi
 
 # Check if significant files changed but not mentioned
 if [[ $FILE_COUNT -gt 10 ]]; then
-	NEEDS_UPDATE="true"
-	REASONS+=("$FILE_COUNT files changed - ensure PR description covers the scope")
+  NEEDS_UPDATE="true"
+  REASONS+=("$FILE_COUNT files changed - ensure PR description covers the scope")
 fi
 
 # Output results
 if [[ $NEEDS_UPDATE == "true" ]]; then
-	echo ""
-	echo "## PR Scope Review (PR #${PR_NUMBER})"
-	echo ""
-	echo "**Current title:** $PR_TITLE"
-	echo ""
-	echo "**Commits in PR ($COMMIT_COUNT):**"
-	echo '```'
-	echo "$COMMIT_MESSAGES" | head -10
-	[[ $COMMIT_COUNT -gt 10 ]] && echo "... and $((COMMIT_COUNT - 10)) more"
-	echo '```'
-	echo ""
-	echo "**Scope:** ${SCOPE_PARTS[*]:-"(no conventional commits)"}"
-	echo "**Files changed:** $FILE_COUNT"
-	echo ""
-	echo "### Suggestions"
-	for reason in "${REASONS[@]}"; do
-		echo "- $reason"
-	done
-	echo ""
-	echo "**Consider updating the PR:**"
-	echo '```bash'
-	echo "gh pr edit $PR_NUMBER --title \"new title\" --body \"new body\""
-	echo '```'
-	echo ""
-	echo "⚠️  **Preserve any git-machete generated sections** (<!-- start git-machete generated --> ... <!-- end git-machete generated -->)"
-	echo ""
-	echo "Or use AskUserQuestion to confirm if PR description needs updating."
+  echo ""
+  echo "## PR Scope Review (PR #${PR_NUMBER})"
+  echo ""
+  echo "**Current title:** $PR_TITLE"
+  echo ""
+  echo "**Commits in PR ($COMMIT_COUNT):**"
+  echo '```'
+  echo "$COMMIT_MESSAGES" | head -10
+  [[ $COMMIT_COUNT -gt 10 ]] && echo "... and $((COMMIT_COUNT - 10)) more"
+  echo '```'
+  echo ""
+  echo "**Scope:** ${SCOPE_PARTS[*]:-"(no conventional commits)"}"
+  echo "**Files changed:** $FILE_COUNT"
+  echo ""
+  echo "### Suggestions"
+  for reason in "${REASONS[@]}"; do
+    echo "- $reason"
+  done
+  echo ""
+  echo "**ACTION REQUIRED:** Use Skill(skill: \"crew:git:update-pr\") to update title and body"
+  echo ""
+  echo "This will preserve git-machete generated sections automatically."
 fi
 
 exit 0

--- a/crew/scripts/hooks/post-tool/sync-machete-stack.sh
+++ b/crew/scripts/hooks/post-tool/sync-machete-stack.sh
@@ -15,7 +15,7 @@ INPUT=$(cat)
 # Check tool_input.command for "git commit" pattern
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 if [[ ! $COMMAND =~ git[[:space:]]+commit ]]; then
-	exit 0
+  exit 0
 fi
 
 # Only proceed if git-machete is installed
@@ -27,33 +27,35 @@ git rev-parse --git-dir &>/dev/null 2>&1 || exit 0
 # Only proceed if machete layout exists
 machete_file=".git/machete"
 if [[ ! -f "$machete_file" ]]; then
-	exit 0
+  exit 0
 fi
 
 # Get current branch
 branch=$(git branch --show-current 2>/dev/null || echo "")
 if [[ -z "$branch" ]]; then
-	exit 0
+  exit 0
 fi
 
 # Only proceed if current branch is in machete layout
 if ! git machete is-managed "$branch" 2>/dev/null; then
-	exit 0
+  exit 0
 fi
 
 # Check if branch is out of sync with parent
 parent=$(git machete show up 2>/dev/null || echo "")
 if [[ -z "$parent" ]]; then
-	# Root branch, no sync needed
-	exit 0
+  # Root branch, no sync needed
+  exit 0
 fi
 
 # Check sync status - if out of sync, notify user
 if ! git merge-base --is-ancestor "$parent" HEAD 2>/dev/null; then
-	echo ""
-	echo "📊 **Machete Stack Status**"
-	echo "Branch \`$branch\` may be out of sync with parent \`$parent\`"
-	echo "Run \`git machete update\` to rebase, or \`/crew:git:traverse\` to sync all."
+  echo ""
+  echo "⚠️ **STACK OUT OF SYNC**"
+  echo "Branch \`$branch\` is behind parent \`$parent\`"
+  echo ""
+  echo "**ACTION REQUIRED:** Use Skill(skill: \"crew:git:sync\") to rebase on parent"
+  echo "Or use Skill(skill: \"crew:git:traverse\") to sync entire stack"
 fi
 
 exit 0

--- a/crew/scripts/hooks/pre-compact/save-session-state.sh
+++ b/crew/scripts/hooks/pre-compact/save-session-state.sh
@@ -11,8 +11,8 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Get branch info (handle detached HEAD where --show-current returns empty)
 BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo '')
 if [[ -z $BRANCH ]]; then
-	# Detached HEAD - use short commit hash instead
-	BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
+  # Detached HEAD - use short commit hash instead
+  BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
 fi
 SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
 
@@ -29,26 +29,26 @@ WIP_TASK_CREATED="false"
 
 # Get uncommitted changes (staged + unstaged + untracked)
 if git -C "$PROJECT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-	# Count modified/staged files
-	STAGED=$(git -C "$PROJECT_DIR" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
-	UNSTAGED=$(git -C "$PROJECT_DIR" diff --name-only 2>/dev/null | wc -l | tr -d ' ')
-	UNTRACKED=$(git -C "$PROJECT_DIR" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
-	UNCOMMITTED_COUNT=$((STAGED + UNSTAGED + UNTRACKED))
+  # Count modified/staged files
+  STAGED=$(git -C "$PROJECT_DIR" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+  UNSTAGED=$(git -C "$PROJECT_DIR" diff --name-only 2>/dev/null | wc -l | tr -d ' ')
+  UNTRACKED=$(git -C "$PROJECT_DIR" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+  UNCOMMITTED_COUNT=$((STAGED + UNSTAGED + UNTRACKED))
 
-	if [[ $UNCOMMITTED_COUNT -gt 0 ]]; then
-		# Get file list for WIP task (limit to 20 files)
-		UNCOMMITTED_FILES=$(git -C "$PROJECT_DIR" status --porcelain 2>/dev/null | head -20 | sed 's/^/  /')
+  if [[ $UNCOMMITTED_COUNT -gt 0 ]]; then
+    # Get file list for WIP task (limit to 20 files)
+    UNCOMMITTED_FILES=$(git -C "$PROJECT_DIR" status --porcelain 2>/dev/null | head -20 | sed 's/^/  /')
 
-		# Create WIP task for next session
-		TASKS_DIR="$BRANCH_DIR/tasks"
-		mkdir -p "$TASKS_DIR"
+    # Create WIP task for next session
+    TASKS_DIR="$BRANCH_DIR/tasks"
+    mkdir -p "$TASKS_DIR"
 
-		# Find next available order number (start at 000 for WIP - highest priority)
-		WIP_FILE="$TASKS_DIR/000-pending-p1-found-commit-wip-changes.md"
+    # Find next available order number (start at 000 for WIP - highest priority)
+    WIP_FILE="$TASKS_DIR/000-pending-p1-found-commit-wip-changes.md"
 
-		# Only create if doesn't already exist (avoid duplicates)
-		if [[ ! -f $WIP_FILE ]]; then
-			cat >"$WIP_FILE" <<EOF
+    # Only create if doesn't already exist (avoid duplicates)
+    if [[ ! -f $WIP_FILE ]]; then
+      cat >"$WIP_FILE" <<EOF
 ---
 status: pending
 priority: p1
@@ -77,9 +77,9 @@ $UNCOMMITTED_FILES
 **By:** PreCompact hook
 **Status:** Auto-generated due to uncommitted work
 EOF
-			WIP_TASK_CREATED="true"
-		fi
-	fi
+      WIP_TASK_CREATED="true"
+    fi
+  fi
 fi
 
 # Get plan file content (first 100 lines)
@@ -94,29 +94,29 @@ PLAN_EXISTS="false"
 
 # First try: branch-based with slashes preserved (creates subdirectories)
 if [[ -f "$PROJECT_DIR/.claude/plans/${BRANCH}.plan.md" ]]; then
-	PLAN_FILE="$PROJECT_DIR/.claude/plans/${BRANCH}.plan.md"
+  PLAN_FILE="$PROJECT_DIR/.claude/plans/${BRANCH}.plan.md"
 # Second try: sanitized branch name (flat structure)
 elif [[ -f "$PROJECT_DIR/.claude/plans/${SAFE_BRANCH}.plan.md" ]]; then
-	PLAN_FILE="$PROJECT_DIR/.claude/plans/${SAFE_BRANCH}.plan.md"
+  PLAN_FILE="$PROJECT_DIR/.claude/plans/${SAFE_BRANCH}.plan.md"
 # Third try: find most recently modified .md file in plans directory
 # Use ls -t for cross-platform sorting by modification time
 else
-	PLAN_FILE=$(find "$PROJECT_DIR/.claude/plans" -maxdepth 1 -name "*.md" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || echo '')
+  PLAN_FILE=$(find "$PROJECT_DIR/.claude/plans" -maxdepth 1 -name "*.md" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || echo '')
 fi
 
 if [[ -n $PLAN_FILE && -f $PLAN_FILE ]]; then
-	PLAN_CONTENT=$(head -100 "$PLAN_FILE" 2>/dev/null || echo "")
-	PLAN_EXISTS="true"
+  PLAN_CONTENT=$(head -100 "$PLAN_FILE" 2>/dev/null || echo "")
+  PLAN_EXISTS="true"
 fi
 
 # Get active workflow
 WORKFLOW_FILE="$BRANCH_DIR/current-workflow.json"
 if [[ -f $WORKFLOW_FILE ]]; then
-	ACTIVE_WORKFLOW=$(jq -r '.workflow // empty' "$WORKFLOW_FILE" 2>/dev/null)
-	WORKFLOW_ARGS=$(jq -r '.args // empty' "$WORKFLOW_FILE" 2>/dev/null)
+  ACTIVE_WORKFLOW=$(jq -r '.workflow // empty' "$WORKFLOW_FILE" 2>/dev/null)
+  WORKFLOW_ARGS=$(jq -r '.args // empty' "$WORKFLOW_FILE" 2>/dev/null)
 else
-	ACTIVE_WORKFLOW=""
-	WORKFLOW_ARGS=""
+  ACTIVE_WORKFLOW=""
+  WORKFLOW_ARGS=""
 fi
 
 # Get pending todos from .claude/todos/ directory
@@ -127,11 +127,11 @@ PENDING_COUNT=0
 COMPLETED_COUNT=0
 
 if [[ -d $TODO_DIR ]]; then
-	TODOS_ARRAY="[]"
-	while IFS= read -r -d '' file; do
-		filename=$(basename "$file")
-		# Extract title from todo file (skip YAML frontmatter if present)
-		title=$(awk '
+  TODOS_ARRAY="[]"
+  while IFS= read -r -d '' file; do
+    filename=$(basename "$file")
+    # Extract title from todo file (skip YAML frontmatter if present)
+    title=$(awk '
         BEGIN { in_frontmatter=0; found=0 }
         /^---$/ && NR==1 { in_frontmatter=1; next }
         /^---$/ && in_frontmatter { in_frontmatter=0; next }
@@ -140,28 +140,28 @@ if [[ -d $TODO_DIR ]]; then
         !found && NF { print; found=1; exit }
       ' "$file" 2>/dev/null)
 
-		# Determine status based on filename
-		if [[ $filename == *complete* ]]; then
-			status="completed"
-			((COMPLETED_COUNT++)) || true
-		else
-			status="pending"
-			((PENDING_COUNT++)) || true
-		fi
+    # Determine status based on filename
+    if [[ $filename == *complete* ]]; then
+      status="completed"
+      ((COMPLETED_COUNT++)) || true
+    else
+      status="pending"
+      ((PENDING_COUNT++)) || true
+    fi
 
-		# Add to todos array (TodoWrite format: content, status, activeForm)
-		# For activeForm, prefix with "Working on: " to avoid malformed gerunds
-		TODOS_ARRAY=$(echo "$TODOS_ARRAY" | jq --arg content "$title" --arg status "$status" --arg activeForm "Working on: $title" \
-			'. + [{"content": $content, "status": $status, "activeForm": $activeForm}]' 2>/dev/null || echo "$TODOS_ARRAY")
-	done < <(find "$TODO_DIR" -name '*.md' -print0 2>/dev/null)
-	TODOS_JSON="$TODOS_ARRAY"
+    # Add to todos array (TodoWrite format: content, status, activeForm)
+    # For activeForm, prefix with "Working on: " to avoid malformed gerunds
+    TODOS_ARRAY=$(echo "$TODOS_ARRAY" | jq --arg content "$title" --arg status "$status" --arg activeForm "Working on: $title" \
+      '. + [{"content": $content, "status": $status, "activeForm": $activeForm}]' 2>/dev/null || echo "$TODOS_ARRAY")
+  done < <(find "$TODO_DIR" -name '*.md' -print0 2>/dev/null)
+  TODOS_JSON="$TODOS_ARRAY"
 fi
 
 # Get loop state from legacy locations (check both old formats)
 LOOP_STATE='{"active":false,"iteration":0,"maxIterations":10}'
 OLD_LOOP_FILE="$PROJECT_DIR/.claude/handoffs/$SAFE_BRANCH/loop-state.json"
 if [[ -f $OLD_LOOP_FILE ]]; then
-	LOOP_STATE=$(cat "$OLD_LOOP_FILE" 2>/dev/null || echo "$LOOP_STATE")
+  LOOP_STATE=$(cat "$OLD_LOOP_FILE" 2>/dev/null || echo "$LOOP_STATE")
 fi
 
 # Get handoff info from legacy location
@@ -169,8 +169,8 @@ HANDOFF_DIR="$PROJECT_DIR/.claude/handoffs/$SAFE_BRANCH"
 HANDOFF_COUNT=0
 LAST_HANDOFF=""
 if [[ -d $HANDOFF_DIR ]]; then
-	HANDOFF_COUNT=$(find "$HANDOFF_DIR" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
-	LAST_HANDOFF=$(find "$HANDOFF_DIR" -maxdepth 1 -name "*.md" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || echo "")
+  HANDOFF_COUNT=$(find "$HANDOFF_DIR" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+  LAST_HANDOFF=$(find "$HANDOFF_DIR" -maxdepth 1 -name "*.md" -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || echo "")
 fi
 
 # Scan task files in .claude/branches/{branch}/tasks/
@@ -183,49 +183,49 @@ TASKS_P3=0
 NEXT_TASK=""
 
 if [[ -d $TASKS_DIR ]]; then
-	# Count pending tasks by priority from filenames
-	while IFS= read -r filename; do
-		# Match pattern: ###-pending-p#-*
-		if [[ $filename =~ ^[0-9]+-pending-p([123])- ]]; then
-			((TASKS_PENDING++)) || true
-			priority="${BASH_REMATCH[1]}"
-			case $priority in
-			1) ((TASKS_P1++)) || true ;;
-			2) ((TASKS_P2++)) || true ;;
-			3) ((TASKS_P3++)) || true ;;
-			esac
-			# Track first pending task (lowest order number)
-			if [[ -z $NEXT_TASK ]]; then
-				NEXT_TASK="$filename"
-			fi
-		fi
-	done < <(find "$TASKS_DIR" -maxdepth 1 -name "*.md" -type f -exec basename {} \; 2>/dev/null | sort)
+  # Count pending tasks by priority from filenames
+  while IFS= read -r filename; do
+    # Match pattern: ###-pending-p#-*
+    if [[ $filename =~ ^[0-9]+-pending-p([123])- ]]; then
+      ((TASKS_PENDING++)) || true
+      priority="${BASH_REMATCH[1]}"
+      case $priority in
+        1) ((TASKS_P1++)) || true ;;
+        2) ((TASKS_P2++)) || true ;;
+        3) ((TASKS_P3++)) || true ;;
+      esac
+      # Track first pending task (lowest order number)
+      if [[ -z $NEXT_TASK ]]; then
+        NEXT_TASK="$filename"
+      fi
+    fi
+  done < <(find "$TASKS_DIR" -maxdepth 1 -name "*.md" -type f -exec basename {} \; 2>/dev/null | sort)
 fi
 
 # Build the unified state JSON
 jq -n \
-	--arg branch "$BRANCH" \
-	--arg session "${CLAUDE_SESSION_ID:-unknown}" \
-	--arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-	--arg plan_exists "$PLAN_EXISTS" \
-	--arg plan_file "$PLAN_FILE" \
-	--arg plan_content "$PLAN_CONTENT" \
-	--argjson todos "$TODOS_JSON" \
-	--argjson pending_count "$PENDING_COUNT" \
-	--argjson completed_count "$COMPLETED_COUNT" \
-	--arg active_workflow "$ACTIVE_WORKFLOW" \
-	--arg workflow_args "$WORKFLOW_ARGS" \
-	--argjson loop "$LOOP_STATE" \
-	--argjson handoff_count "$HANDOFF_COUNT" \
-	--arg last_handoff "$LAST_HANDOFF" \
-	--argjson tasks_pending "$TASKS_PENDING" \
-	--argjson tasks_p1 "$TASKS_P1" \
-	--argjson tasks_p2 "$TASKS_P2" \
-	--argjson tasks_p3 "$TASKS_P3" \
-	--arg next_task "$NEXT_TASK" \
-	--argjson uncommitted_count "$UNCOMMITTED_COUNT" \
-	--arg wip_task_created "$WIP_TASK_CREATED" \
-	'{
+  --arg branch "$BRANCH" \
+  --arg session "${CLAUDE_SESSION_ID:-unknown}" \
+  --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg plan_exists "$PLAN_EXISTS" \
+  --arg plan_file "$PLAN_FILE" \
+  --arg plan_content "$PLAN_CONTENT" \
+  --argjson todos "$TODOS_JSON" \
+  --argjson pending_count "$PENDING_COUNT" \
+  --argjson completed_count "$COMPLETED_COUNT" \
+  --arg active_workflow "$ACTIVE_WORKFLOW" \
+  --arg workflow_args "$WORKFLOW_ARGS" \
+  --argjson loop "$LOOP_STATE" \
+  --argjson handoff_count "$HANDOFF_COUNT" \
+  --arg last_handoff "$LAST_HANDOFF" \
+  --argjson tasks_pending "$TASKS_PENDING" \
+  --argjson tasks_p1 "$TASKS_P1" \
+  --argjson tasks_p2 "$TASKS_P2" \
+  --argjson tasks_p3 "$TASKS_P3" \
+  --arg next_task "$NEXT_TASK" \
+  --argjson uncommitted_count "$UNCOMMITTED_COUNT" \
+  --arg wip_task_created "$WIP_TASK_CREATED" \
+  '{
     branch: $branch,
     session: $session,
     compacted_at: $time,
@@ -272,13 +272,13 @@ echo "  - Pending tasks: $TASKS_PENDING (P1:$TASKS_P1 P2:$TASKS_P2 P3:$TASKS_P3)
 
 # Session Completion Discipline: Warn about uncommitted work
 if [[ $UNCOMMITTED_COUNT -gt 0 ]]; then
-	echo ""
-	echo "⚠️  SESSION COMPLETION WARNING: $UNCOMMITTED_COUNT uncommitted files"
-	echo "    Work is NOT complete until git commit succeeds."
-	if [[ $WIP_TASK_CREATED == "true" ]]; then
-		echo "    Created WIP task: 000-pending-p1-found-commit-wip-changes.md"
-	fi
-	echo ""
-	echo "    To complete session properly, run: /crew:git:commit"
-	echo ""
+  echo ""
+  echo "⚠️  SESSION COMPLETION WARNING: $UNCOMMITTED_COUNT uncommitted files"
+  echo "    Work is NOT complete until git commit succeeds."
+  if [[ $WIP_TASK_CREATED == "true" ]]; then
+    echo "    Created WIP task: 000-pending-p1-found-commit-wip-changes.md"
+  fi
+  echo ""
+  echo "    **ACTION REQUIRED:** Use Skill(skill: \"crew:git:commit\") to complete session"
+  echo ""
 fi

--- a/crew/scripts/hooks/pre-tool/suggest-skill.sh
+++ b/crew/scripts/hooks/pre-tool/suggest-skill.sh
@@ -20,24 +20,24 @@ SUGGESTION=""
 
 # Git commit - suggest git skill
 if [[ $CMD_LINE =~ ^git\ commit ]]; then
-	SUGGESTION="Tip: Use /crew:git:commit for guided commits with context, or check the git skill for conventions."
+  SUGGESTION="⚠️ **USE SKILL:** Use Skill(skill: \"crew:git:commit\") for guided commits with conventions."
 fi
 
 # Direct test/lint commands - suggest /crew:ci
 if [[ $CMD_LINE =~ (npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(test|lint|format|typecheck)([[:space:]]|$) ]] ||
-	[[ $CMD_LINE =~ ^[[:space:]]*(vitest|jest|biome|eslint|prettier|tsc)[[:space:]] ]]; then
-	SUGGESTION="Tip: Use /crew:ci to run CI in a background haiku agent (keeps main thread responsive)."
+  [[ $CMD_LINE =~ ^[[:space:]]*(vitest|jest|biome|eslint|prettier|tsc)[[:space:]] ]]; then
+  SUGGESTION="⚠️ **USE SKILL:** Use Skill(skill: \"crew:ci\") to run CI in background (keeps main thread responsive)."
 fi
 
 # Git push - remind about CI
 if [[ $CMD_LINE =~ ^git\ push ]]; then
-	SUGGESTION="Tip: Run /crew:ci before pushing to catch issues early."
+  SUGGESTION="⚠️ **BEFORE PUSHING:** Use Skill(skill: \"crew:ci\") to catch issues early."
 fi
 
 # Output suggestion if we have one
 if [[ -n $SUGGESTION ]]; then
-	# Use jq to properly escape the suggestion for JSON
-	jq -n --arg msg "$SUGGESTION" '{
+  # Use jq to properly escape the suggestion for JSON
+  jq -n --arg msg "$SUGGESTION" '{
     "hookSpecificOutput": {
       "hookEventName": "PreToolUse",
       "message": $msg

--- a/crew/scripts/hooks/session-start/check-stack-status.sh
+++ b/crew/scripts/hooks/session-start/check-stack-status.sh
@@ -9,13 +9,13 @@ set +e
 
 # Check if in a git repo
 if ! git rev-parse --git-dir &>/dev/null 2>&1; then
-	exit 0
+  exit 0
 fi
 
 # Get branch info
 BRANCH=$(git branch --show-current 2>/dev/null || echo '')
 if [[ -z $BRANCH ]]; then
-	exit 0
+  exit 0
 fi
 
 # Detect worktree status
@@ -23,31 +23,30 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 IS_WORKTREE="false"
 if [[ "$GIT_DIR" != "$GIT_COMMON_DIR" ]]; then
-	IS_WORKTREE="true"
+  IS_WORKTREE="true"
 fi
 
 # Check if git-machete is available and branch is managed
 if ! command -v git-machete &>/dev/null; then
-	# No machete - just show worktree status if applicable
-	if [[ $IS_WORKTREE == "true" ]]; then
-		echo ""
-		echo "CONTEXT: Running in worktree (branch: $BRANCH)"
-		echo "  - Branch-switching commands are dangerous in worktrees"
-		echo "  - Use \`git machete update\` instead of \`git machete traverse\`"
-		echo ""
-	fi
-	exit 0
+  # No machete - just show worktree status if applicable
+  if [[ $IS_WORKTREE == "true" ]]; then
+    echo ""
+    echo "📂 **WORKTREE CONTEXT** (branch: $BRANCH)"
+    echo "  ⚠️ **IMPORTANT:** Do NOT use branch-switching commands (checkout, switch)"
+    echo ""
+  fi
+  exit 0
 fi
 
 # Check machete file location (worktree-aware)
 MACHETE_FILE="${GIT_COMMON_DIR}/machete"
 if [[ ! -f "$MACHETE_FILE" ]]; then
-	exit 0
+  exit 0
 fi
 
 # Check if current branch is in machete layout
 if ! git machete is-managed "$BRANCH" 2>/dev/null; then
-	exit 0
+  exit 0
 fi
 
 # Get parent branch
@@ -60,24 +59,24 @@ FETCH_PID=$!
 # Check sync status with parent
 SYNC_STATUS=""
 if [[ -n $PARENT ]]; then
-	# Count commits behind parent
-	BEHIND_PARENT=$(git rev-list --count "$BRANCH".."$PARENT" 2>/dev/null || echo "0")
-	if [[ $BEHIND_PARENT -gt 0 ]]; then
-		SYNC_STATUS="⚠️  Branch is $BEHIND_PARENT commits behind parent ($PARENT)"
-	fi
+  # Count commits behind parent
+  BEHIND_PARENT=$(git rev-list --count "$BRANCH".."$PARENT" 2>/dev/null || echo "0")
+  if [[ $BEHIND_PARENT -gt 0 ]]; then
+    SYNC_STATUS="⚠️  Branch is $BEHIND_PARENT commits behind parent ($PARENT)"
+  fi
 fi
 
 # Wait for fetch (with timeout)
 if kill -0 $FETCH_PID 2>/dev/null; then
-	# Still running, wait up to 2 seconds
-	for _ in {1..20}; do
-		if ! kill -0 $FETCH_PID 2>/dev/null; then
-			break
-		fi
-		sleep 0.1
-	done
-	# Kill if still running
-	kill $FETCH_PID 2>/dev/null || true
+  # Still running, wait up to 2 seconds
+  for _ in {1..20}; do
+    if ! kill -0 $FETCH_PID 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  # Kill if still running
+  kill $FETCH_PID 2>/dev/null || true
 fi
 
 # Check if remote is ahead
@@ -89,35 +88,38 @@ HAS_ISSUES="false"
 OUTPUT=""
 
 if [[ $IS_WORKTREE == "true" ]]; then
-	OUTPUT="${OUTPUT}CONTEXT: Running in worktree\n"
-	OUTPUT="${OUTPUT}  Branch: $BRANCH\n"
-	if [[ -n $PARENT ]]; then
-		OUTPUT="${OUTPUT}  Parent: $PARENT (stacked branch)\n"
-	fi
-	HAS_ISSUES="true"
+  OUTPUT="${OUTPUT}📂 **WORKTREE CONTEXT**\n"
+  OUTPUT="${OUTPUT}  Branch: $BRANCH\n"
+  if [[ -n $PARENT ]]; then
+    OUTPUT="${OUTPUT}  Parent: $PARENT (stacked branch)\n"
+  fi
+  OUTPUT="${OUTPUT}  ⚠️ **IMPORTANT:** Do NOT use branch-switching commands (checkout, switch)\n"
+  OUTPUT="${OUTPUT}  Use Skill(skill: \"crew:git:sync\") instead of traverse\n"
+  HAS_ISSUES="true"
 fi
 
 if [[ -n $SYNC_STATUS ]]; then
-	OUTPUT="${OUTPUT}${SYNC_STATUS}\n"
-	OUTPUT="${OUTPUT}  Run: git machete update\n"
-	HAS_ISSUES="true"
+  OUTPUT="${OUTPUT}${SYNC_STATUS}\n"
+  OUTPUT="${OUTPUT}  **ACTION REQUIRED:** Use Skill(skill: \"crew:git:sync\") to rebase on parent\n"
+  HAS_ISSUES="true"
 fi
 
 if [[ $BEHIND_REMOTE -gt 0 ]]; then
-	OUTPUT="${OUTPUT}⚠️  Branch is $BEHIND_REMOTE commits behind origin/$BRANCH\n"
-	OUTPUT="${OUTPUT}  Run: git pull --rebase\n"
-	HAS_ISSUES="true"
+  OUTPUT="${OUTPUT}⚠️  Branch is $BEHIND_REMOTE commits behind origin/$BRANCH\n"
+  OUTPUT="${OUTPUT}  **ACTION REQUIRED:** Use Skill(skill: \"crew:git:sync\") to pull remote changes\n"
+  HAS_ISSUES="true"
 fi
 
 if [[ $AHEAD_REMOTE -gt 0 ]]; then
-	OUTPUT="${OUTPUT}📤 Branch is $AHEAD_REMOTE commits ahead of origin/$BRANCH (unpushed)\n"
-	HAS_ISSUES="true"
+  OUTPUT="${OUTPUT}📤 Branch is $AHEAD_REMOTE commits ahead of origin/$BRANCH (unpushed)\n"
+  OUTPUT="${OUTPUT}  **REMINDER:** Use Skill(skill: \"crew:git:push\") when ready to push\n"
+  HAS_ISSUES="true"
 fi
 
 # Only output if there are issues or we're in a worktree
 if [[ $HAS_ISSUES == "true" ]]; then
-	echo ""
-	echo -e "$OUTPUT"
+  echo ""
+  echo -e "$OUTPUT"
 fi
 
 exit 0

--- a/crew/scripts/hooks/session-start/inject-skills.sh
+++ b/crew/scripts/hooks/session-start/inject-skills.sh
@@ -29,8 +29,8 @@ cat <<'EOF'
 
 ### Best Practices
 - **Git commits**: Use conventional format `type(scope): description`
-- **CI checks**: Use `/crew:ci` to run in background (keeps main thread free)
-- **Planning**: Use `/crew:design` before implementing complex features
+- **CI checks**: Use Skill(skill: "crew:ci") to run in background (keeps main thread free)
+- **Planning**: Use Skill(skill: "crew:design") before implementing complex features
 - **Progress**: Use TodoWrite to track multi-step tasks
 EOF
 

--- a/crew/scripts/hooks/session-start/restore-session-state.sh
+++ b/crew/scripts/hooks/session-start/restore-session-state.sh
@@ -22,7 +22,7 @@ EVENT_TYPE=$(echo "$INPUT" | jq -r '.type // "unknown"' 2>/dev/null)
 # Get branch info (handle detached HEAD)
 BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo '')
 if [[ -z $BRANCH ]]; then
-	BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
+  BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
 fi
 SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
 
@@ -33,13 +33,13 @@ STATE_FILE="$BRANCH_DIR/state.json"
 # On fresh startup, skip - user should run /crew:restart manually
 # Hook output on startup is not actionable by Claude
 if [[ $EVENT_TYPE == "startup" ]]; then
-	exit 0
+  exit 0
 fi
 
 # For compact/resume events, also restore from state.json
 # Exit if file doesn't exist or contains invalid JSON
 if [[ ! -f $STATE_FILE ]] || ! jq empty "$STATE_FILE" 2>/dev/null; then
-	exit 0
+  exit 0
 fi
 
 # PERFORMANCE: Single jq call extracts all fields at once
@@ -68,15 +68,15 @@ STATE_DATA=$(jq -r '
 
 # Parse tab-separated values into variables
 IFS=$'\t' read -r COMPACTED_AT PLAN_EXISTS PLAN_FILE PLAN_PREVIEW_ESC PENDING_COUNT TODOS_JSON \
-	ACTIVE_WORKFLOW WORKFLOW_ARGS LOOP_ACTIVE LOOP_ITERATION LOOP_MAX LOOP_PROMISE \
-	TASKS_PENDING TASKS_P1 TASKS_P2 TASKS_P3 NEXT_TASK <<<"$STATE_DATA"
+  ACTIVE_WORKFLOW WORKFLOW_ARGS LOOP_ACTIVE LOOP_ITERATION LOOP_MAX LOOP_PROMISE \
+  TASKS_PENDING TASKS_P1 TASKS_P2 TASKS_P3 NEXT_TASK <<<"$STATE_DATA"
 
 # Unescape newlines in plan preview
 PLAN_PREVIEW=$(echo -e "$PLAN_PREVIEW_ESC")
 
 # Exit if no compaction timestamp (invalid state file)
 if [[ -z $COMPACTED_AT ]]; then
-	exit 0
+  exit 0
 fi
 
 # Output structured recovery context
@@ -86,91 +86,91 @@ echo ""
 
 # Show active workflow first (highest priority)
 if [[ -n $ACTIVE_WORKFLOW ]]; then
-	echo "ACTION REQUIRED: Resume active workflow"
-	echo "  Skill({skill: \"$ACTIVE_WORKFLOW\"${WORKFLOW_ARGS:+, args: \"$WORKFLOW_ARGS\"}})"
-	echo ""
+  echo "ACTION REQUIRED: Resume active workflow"
+  echo "  Skill({skill: \"$ACTIVE_WORKFLOW\"${WORKFLOW_ARGS:+, args: \"$WORKFLOW_ARGS\"}})"
+  echo ""
 fi
 
 # Show plan context if exists (include preview to avoid file read)
 if [[ $PLAN_EXISTS == "true" && -n $PLAN_PREVIEW ]]; then
-	echo "CONTEXT: Active plan at $PLAN_FILE"
-	echo "─────────────────────────────────────────"
-	echo "$PLAN_PREVIEW"
-	echo "─────────────────────────────────────────"
-	echo ""
+  echo "CONTEXT: Active plan at $PLAN_FILE"
+  echo "─────────────────────────────────────────"
+  echo "$PLAN_PREVIEW"
+  echo "─────────────────────────────────────────"
+  echo ""
 fi
 
 # Show todos in TodoWrite-ready format (TodoWrite takes array directly, not object)
 if [[ $PENDING_COUNT -gt 0 && $TODOS_JSON != "[]" ]]; then
-	echo "CONTEXT: Restore todos with TodoWrite($TODOS_JSON)"
-	echo ""
+  echo "CONTEXT: Restore todos with TodoWrite($TODOS_JSON)"
+  echo ""
 fi
 
 # Propulsion: Surface pending tasks for autonomous continuation
 if [[ $TASKS_PENDING -gt 0 ]]; then
-	# Build priority breakdown string
-	PRIORITY_BREAKDOWN=""
-	[[ $TASKS_P1 -gt 0 ]] && PRIORITY_BREAKDOWN="${TASKS_P1} P1"
-	[[ $TASKS_P2 -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${TASKS_P2} P2"
-	[[ $TASKS_P3 -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${TASKS_P3} P3"
+  # Build priority breakdown string
+  PRIORITY_BREAKDOWN=""
+  [[ $TASKS_P1 -gt 0 ]] && PRIORITY_BREAKDOWN="${TASKS_P1} P1"
+  [[ $TASKS_P2 -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${TASKS_P2} P2"
+  [[ $TASKS_P3 -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${TASKS_P3} P3"
 
-	echo "ACTION REQUIRED: Found $TASKS_PENDING pending tasks ($PRIORITY_BREAKDOWN)"
-	echo "  Next: $NEXT_TASK"
-	echo "  Resume with: /crew:build"
-	echo ""
+  echo "ACTION REQUIRED: Found $TASKS_PENDING pending tasks ($PRIORITY_BREAKDOWN)"
+  echo "  Next: $NEXT_TASK"
+  echo "  **Resume with:** Skill(skill: \"crew:build\")"
+  echo ""
 fi
 
 # Show active loop state if loop is in progress
 if [[ $LOOP_ACTIVE == "true" ]]; then
-	echo "ACTION REQUIRED: Resume iteration loop (iteration $LOOP_ITERATION of $LOOP_MAX)"
-	echo "  Completion promise: <promise>$LOOP_PROMISE</promise>"
-	echo ""
+  echo "ACTION REQUIRED: Resume iteration loop (iteration $LOOP_ITERATION of $LOOP_MAX)"
+  echo "  Completion promise: <promise>$LOOP_PROMISE</promise>"
+  echo ""
 fi
 
 # Witness: Check for stuck agents from previous session
 AGENTS_FILE="$BRANCH_DIR/agents.json"
 if [[ -f $AGENTS_FILE ]] && jq empty "$AGENTS_FILE" 2>/dev/null; then
-	CURRENT_EPOCH=$(date +%s)
-	TIMEOUT_SECONDS=300 # 5 minutes
+  CURRENT_EPOCH=$(date +%s)
+  TIMEOUT_SECONDS=300 # 5 minutes
 
-	# Count running agents
-	RUNNING_AGENTS=$(jq -r '[.agents[] | select(.status == "running")] | length' "$AGENTS_FILE" 2>/dev/null)
+  # Count running agents
+  RUNNING_AGENTS=$(jq -r '[.agents[] | select(.status == "running")] | length' "$AGENTS_FILE" 2>/dev/null)
 
-	if [[ $RUNNING_AGENTS -gt 0 ]]; then
-		echo "WITNESS: $RUNNING_AGENTS agents were running when session ended"
+  if [[ $RUNNING_AGENTS -gt 0 ]]; then
+    echo "WITNESS: $RUNNING_AGENTS agents were running when session ended"
 
-		# Check for stuck agents
-		STUCK_AGENTS=$(jq -r --argjson now "$CURRENT_EPOCH" --argjson timeout "$TIMEOUT_SECONDS" \
-			'[.agents[] | select(.status == "running" and ($now - .spawned_epoch) > $timeout)] | length' "$AGENTS_FILE" 2>/dev/null)
+    # Check for stuck agents
+    STUCK_AGENTS=$(jq -r --argjson now "$CURRENT_EPOCH" --argjson timeout "$TIMEOUT_SECONDS" \
+      '[.agents[] | select(.status == "running" and ($now - .spawned_epoch) > $timeout)] | length' "$AGENTS_FILE" 2>/dev/null)
 
-		if [[ $STUCK_AGENTS -gt 0 ]]; then
-			echo "  ⚠️  $STUCK_AGENTS agents exceeded timeout threshold"
-			echo ""
+    if [[ $STUCK_AGENTS -gt 0 ]]; then
+      echo "  ⚠️  $STUCK_AGENTS agents exceeded timeout threshold"
+      echo ""
 
-			# List stuck agents
-			jq -r --argjson now "$CURRENT_EPOCH" --argjson timeout "$TIMEOUT_SECONDS" \
-				'.agents[] | select(.status == "running" and ($now - .spawned_epoch) > $timeout) |
+      # List stuck agents
+      jq -r --argjson now "$CURRENT_EPOCH" --argjson timeout "$TIMEOUT_SECONDS" \
+        '.agents[] | select(.status == "running" and ($now - .spawned_epoch) > $timeout) |
         "  - \(.description) (ID: \(.id), running \((($now - .spawned_epoch) / 60 | floor))m)"' "$AGENTS_FILE" 2>/dev/null
 
-			echo ""
-			echo "  Recovery options:"
-			echo "    TaskOutput({task_id: \"<id>\", block: true}) - Wait for completion"
-			echo "    KillShell({shell_id: \"<id>\"}) - Terminate stuck agent"
-			echo ""
+      echo ""
+      echo "  Recovery options:"
+      echo "    TaskOutput({task_id: \"<id>\", block: true}) - Wait for completion"
+      echo "    KillShell({shell_id: \"<id>\"}) - Terminate stuck agent"
+      echo ""
 
-			# Mark as stuck in the file (suppress errors to avoid polluting context)
-			if jq --argjson now "$CURRENT_EPOCH" --argjson timeout "$TIMEOUT_SECONDS" \
-				'(.agents[] | select(.status == "running" and ($now - .spawned_epoch) > $timeout)) |= . + {"status": "stuck"}' \
-				"$AGENTS_FILE" >"${AGENTS_FILE}.tmp" 2>/dev/null; then
-				mv "${AGENTS_FILE}.tmp" "$AGENTS_FILE"
-			else
-				rm -f "${AGENTS_FILE}.tmp"
-			fi
-		fi
+      # Mark as stuck in the file (suppress errors to avoid polluting context)
+      if jq --argjson now "$CURRENT_EPOCH" --argjson timeout "$TIMEOUT_SECONDS" \
+        '(.agents[] | select(.status == "running" and ($now - .spawned_epoch) > $timeout)) |= . + {"status": "stuck"}' \
+        "$AGENTS_FILE" >"${AGENTS_FILE}.tmp" 2>/dev/null; then
+        mv "${AGENTS_FILE}.tmp" "$AGENTS_FILE"
+      else
+        rm -f "${AGENTS_FILE}.tmp"
+      fi
+    fi
 
-		# Show agent stats
-		STATS=$(jq -r '.stats | "Spawned: \(.total_spawned), Completed: \(.completed), Failed: \(.failed)"' "$AGENTS_FILE" 2>/dev/null)
-		echo "  Stats: $STATS"
-		echo ""
-	fi
+    # Show agent stats
+    STATS=$(jq -r '.stats | "Spawned: \(.total_spawned), Completed: \(.completed), Failed: \(.failed)"' "$AGENTS_FILE" 2>/dev/null)
+    echo "  Stats: $STATS"
+    echo ""
+  fi
 fi

--- a/crew/scripts/hooks/stop/check-loop.sh
+++ b/crew/scripts/hooks/stop/check-loop.sh
@@ -12,14 +12,14 @@ cd "$CLAUDE_PROJECT_DIR" || exit 0
 # Get current branch for state file location
 BRANCH=$(git branch --show-current 2>/dev/null || echo '')
 if [[ -z $BRANCH ]]; then
-	BRANCH=$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')
+  BRANCH=$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')
 fi
 SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
 STATE_FILE=".claude/branches/$SAFE_BRANCH/state.json"
 
 # No state file or invalid JSON - allow normal exit
 if [ ! -f "$STATE_FILE" ] || ! jq empty "$STATE_FILE" 2>/dev/null; then
-	exit 0
+  exit 0
 fi
 
 # PERFORMANCE: Single jq call extracts all loop fields at once
@@ -35,56 +35,56 @@ IFS=$'\t' read -r ACTIVE ITERATION MAX_ITERATIONS COMPLETION_PROMISE PROMPT <<<"
 
 # Loop not active - allow exit
 if [ "$ACTIVE" != "true" ]; then
-	exit 0
+  exit 0
 fi
 
 # Check if we've hit max iterations
 if [ "$ITERATION" -ge "$MAX_ITERATIONS" ]; then
-	# Clear loop state (set inactive, preserve other state)
-	if jq '.loop.active = false' "$STATE_FILE" >"${STATE_FILE}.tmp" 2>/dev/null; then
-		mv "${STATE_FILE}.tmp" "$STATE_FILE"
-	else
-		rm -f "${STATE_FILE}.tmp"
-	fi
+  # Clear loop state (set inactive, preserve other state)
+  if jq '.loop.active = false' "$STATE_FILE" >"${STATE_FILE}.tmp" 2>/dev/null; then
+    mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  else
+    rm -f "${STATE_FILE}.tmp"
+  fi
 
-	echo ""
-	echo "═══════════════════════════════════════════════════════════"
-	echo "LOOP ENDED - Maximum iterations reached ($MAX_ITERATIONS)"
-	echo "═══════════════════════════════════════════════════════════"
-	echo ""
-	echo "The loop has completed its maximum iterations."
-	echo "Review progress and decide next steps:"
-	echo "  - Continue manually with /crew:build"
-	echo "  - Commit progress: /crew:git:commit"
-	echo "  - Review code: /crew:check"
-	echo ""
-	exit 0
+  echo ""
+  echo "═══════════════════════════════════════════════════════════"
+  echo "LOOP ENDED - Maximum iterations reached ($MAX_ITERATIONS)"
+  echo "═══════════════════════════════════════════════════════════"
+  echo ""
+  echo "The loop has completed its maximum iterations."
+  echo "Review progress and decide next steps:"
+  echo "  - Continue manually: Skill(skill: \"crew:build\")"
+  echo "  - Commit progress: Skill(skill: \"crew:git:commit\")"
+  echo "  - Review code: Skill(skill: \"crew:check\")"
+  echo ""
+  exit 0
 fi
 
 # Check if completion promise was output (check recent conversation context)
 # Note: In Claude Code, the Stop hook receives CLAUDE_STOP_TRANSCRIPT with recent output
 if [ -n "${CLAUDE_STOP_TRANSCRIPT:-}" ]; then
-	if echo "$CLAUDE_STOP_TRANSCRIPT" | grep -qF "<promise>$COMPLETION_PROMISE</promise>"; then
-		# Completion detected - clear loop state (set inactive, preserve other state)
-		if jq '.loop.active = false' "$STATE_FILE" >"${STATE_FILE}.tmp" 2>/dev/null; then
-			mv "${STATE_FILE}.tmp" "$STATE_FILE"
-		else
-			rm -f "${STATE_FILE}.tmp"
-		fi
+  if echo "$CLAUDE_STOP_TRANSCRIPT" | grep -qF "<promise>$COMPLETION_PROMISE</promise>"; then
+    # Completion detected - clear loop state (set inactive, preserve other state)
+    if jq '.loop.active = false' "$STATE_FILE" >"${STATE_FILE}.tmp" 2>/dev/null; then
+      mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    else
+      rm -f "${STATE_FILE}.tmp"
+    fi
 
-		echo ""
-		echo "═══════════════════════════════════════════════════════════"
-		echo "LOOP COMPLETE - Promise fulfilled!"
-		echo "═══════════════════════════════════════════════════════════"
-		echo ""
-		echo "Completion promise detected: <promise>$COMPLETION_PROMISE</promise>"
-		echo ""
-		echo "Next steps:"
-		echo "  - Commit progress: /crew:git:commit"
-		echo "  - Create PR: /crew:git:pr"
-		echo ""
-		exit 0
-	fi
+    echo ""
+    echo "═══════════════════════════════════════════════════════════"
+    echo "LOOP COMPLETE - Promise fulfilled!"
+    echo "═══════════════════════════════════════════════════════════"
+    echo ""
+    echo "Completion promise detected: <promise>$COMPLETION_PROMISE</promise>"
+    echo ""
+    echo "Next steps:"
+    echo "  - Commit progress: Skill(skill: \"crew:git:commit\")"
+    echo "  - Create PR: Skill(skill: \"crew:git:pr\")"
+    echo ""
+    exit 0
+  fi
 fi
 
 # Loop should continue - increment iteration
@@ -92,9 +92,9 @@ NEXT_ITERATION=$((ITERATION + 1))
 
 # Update loop iteration in unified state file
 if jq --argjson iter "$NEXT_ITERATION" '.loop.iteration = $iter' "$STATE_FILE" >"${STATE_FILE}.tmp" 2>/dev/null; then
-	mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  mv "${STATE_FILE}.tmp" "$STATE_FILE"
 else
-	rm -f "${STATE_FILE}.tmp"
+  rm -f "${STATE_FILE}.tmp"
 fi
 
 # Re-feed the prompt (BLOCK exit by outputting continuation)
@@ -131,7 +131,7 @@ echo "STRICT REQUIREMENT:"
 echo "  Do NOT output the promise until ALL criteria are met."
 echo "  The promise MUST be TRUE - all tasks complete, CI passing."
 echo ""
-echo "To stop early: /crew:cancel-loop"
+echo "To stop early: Skill(skill: \"crew:cancel-loop\")"
 echo "═══════════════════════════════════════════════════════════"
 echo ""
 

--- a/crew/scripts/hooks/user-prompt-submit/enforce-task-first.sh
+++ b/crew/scripts/hooks/user-prompt-submit/enforce-task-first.sh
@@ -19,12 +19,12 @@ USER_MESSAGE=$(echo "$INPUT" | jq -r '.content // ""' 2>/dev/null)
 
 # Skip empty messages
 if [[ -z $USER_MESSAGE ]]; then
-	exit 0
+  exit 0
 fi
 
 # Skip very short messages (likely steering or acknowledgments)
 if [[ ${#USER_MESSAGE} -lt 25 ]]; then
-	exit 0
+  exit 0
 fi
 
 # Convert to lowercase for pattern matching
@@ -32,22 +32,22 @@ MSG_LOWER=$(echo "$USER_MESSAGE" | tr '[:upper:]' '[:lower:]')
 
 # Skip questions and explanations (not change requests)
 if echo "$MSG_LOWER" | grep -qE '^(what|how|why|where|when|explain|show|describe|tell me|can you explain|could you explain)'; then
-	exit 0
+  exit 0
 fi
 
 # Skip if message looks like steering/feedback (short and directional)
 if echo "$MSG_LOWER" | grep -qE '^(yes|no|ok|okay|sure|good|great|thanks|perfect|correct|right|wrong|try|use|do|looks good|lgtm|approved)'; then
-	exit 0
+  exit 0
 fi
 
 # Skip slash commands - they have their own workflows
 if echo "$USER_MESSAGE" | grep -qE '^/'; then
-	exit 0
+  exit 0
 fi
 
 # Skip messages that are primarily code or file paths
 if echo "$USER_MESSAGE" | grep -qE '^\s*```|^[a-zA-Z0-9_/-]+\.(ts|js|py|sh|md|json|yaml|yml)$'; then
-	exit 0
+  exit 0
 fi
 
 # Detect change request keywords
@@ -60,28 +60,28 @@ IS_CHANGE_REQUEST=false
 CHANGE_TYPE=""
 
 if echo "$MSG_LOWER" | grep -qE "$CHANGE_KEYWORDS"; then
-	IS_CHANGE_REQUEST=true
-	CHANGE_TYPE="feature"
+  IS_CHANGE_REQUEST=true
+  CHANGE_TYPE="feature"
 elif echo "$MSG_LOWER" | grep -qE "$FIX_KEYWORDS"; then
-	IS_CHANGE_REQUEST=true
-	CHANGE_TYPE="bugfix"
+  IS_CHANGE_REQUEST=true
+  CHANGE_TYPE="bugfix"
 elif echo "$MSG_LOWER" | grep -qE "$MODIFY_KEYWORDS"; then
-	IS_CHANGE_REQUEST=true
-	CHANGE_TYPE="modification"
+  IS_CHANGE_REQUEST=true
+  CHANGE_TYPE="modification"
 elif echo "$MSG_LOWER" | grep -qE "$REMOVE_KEYWORDS"; then
-	IS_CHANGE_REQUEST=true
-	CHANGE_TYPE="removal"
+  IS_CHANGE_REQUEST=true
+  CHANGE_TYPE="removal"
 fi
 
 # Exit if not a change request
 if [[ $IS_CHANGE_REQUEST != true ]]; then
-	exit 0
+  exit 0
 fi
 
 # Get branch info
 BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo '')
 if [[ -z $BRANCH ]]; then
-	BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
+  BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
 fi
 SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
 
@@ -89,12 +89,12 @@ SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
 TASKS_DIR="$PROJECT_DIR/.claude/branches/$SAFE_BRANCH/tasks"
 PENDING_TASKS=0
 if [[ -d $TASKS_DIR ]]; then
-	PENDING_TASKS=$(find "$TASKS_DIR" -maxdepth 1 -name '*-pending-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+  PENDING_TASKS=$(find "$TASKS_DIR" -maxdepth 1 -name '*-pending-*' -type f 2>/dev/null | wc -l | tr -d ' ')
 fi
 
 # If there are pending tasks, assume work is already planned
 if [[ $PENDING_TASKS -gt 0 ]]; then
-	exit 0
+  exit 0
 fi
 
 # Determine recommended review agents based on change domain
@@ -102,36 +102,36 @@ DOMAIN_AGENTS=""
 
 # Detect domain-specific keywords for agent selection
 if echo "$MSG_LOWER" | grep -qE '(security|auth|permission|access|token|password|secret|encrypt|sanitize|xss|sql|injection)'; then
-	DOMAIN_AGENTS="$DOMAIN_AGENTS security-reviewer"
+  DOMAIN_AGENTS="$DOMAIN_AGENTS security-reviewer"
 fi
 
 if echo "$MSG_LOWER" | grep -qE '(performance|speed|fast|slow|optimize|cache|memory|latency|throughput|scale)'; then
-	DOMAIN_AGENTS="$DOMAIN_AGENTS performance-reviewer"
+  DOMAIN_AGENTS="$DOMAIN_AGENTS performance-reviewer"
 fi
 
 if echo "$MSG_LOWER" | grep -qE '(api|endpoint|route|rest|graphql|request|response|schema|contract)'; then
-	DOMAIN_AGENTS="$DOMAIN_AGENTS api-interface-analyst"
+  DOMAIN_AGENTS="$DOMAIN_AGENTS api-interface-analyst"
 fi
 
 if echo "$MSG_LOWER" | grep -qE '(ui|ux|component|page|form|button|modal|layout|style|css|tailwind|design)'; then
-	DOMAIN_AGENTS="$DOMAIN_AGENTS ux-workflow-analyst"
+  DOMAIN_AGENTS="$DOMAIN_AGENTS ux-workflow-analyst"
 fi
 
 if echo "$MSG_LOWER" | grep -qE '(data|database|model|schema|migration|table|entity|relation|query|orm|drizzle)'; then
-	DOMAIN_AGENTS="$DOMAIN_AGENTS data-model-architect"
+  DOMAIN_AGENTS="$DOMAIN_AGENTS data-model-architect"
 fi
 
 if echo "$MSG_LOWER" | grep -qE '(test|spec|coverage|mock|stub|assert|expect|vitest|playwright)'; then
-	DOMAIN_AGENTS="$DOMAIN_AGENTS correctness-reviewer"
+  DOMAIN_AGENTS="$DOMAIN_AGENTS correctness-reviewer"
 fi
 
 if echo "$MSG_LOWER" | grep -qE '(error|exception|retry|fallback|timeout|resilient|recover|graceful)'; then
-	DOMAIN_AGENTS="$DOMAIN_AGENTS resilience-reviewer"
+  DOMAIN_AGENTS="$DOMAIN_AGENTS resilience-reviewer"
 fi
 
 # Default agents if no specific domain detected
 if [[ -z $DOMAIN_AGENTS ]]; then
-	DOMAIN_AGENTS="correctness-reviewer elegance-reviewer"
+  DOMAIN_AGENTS="correctness-reviewer elegance-reviewer"
 fi
 
 # Trim leading space
@@ -189,23 +189,23 @@ Based on the request keywords, these review agents are recommended:
 | Agent | Reason |
 |-------|--------|
 $(for agent in $DOMAIN_AGENTS; do
-	case $agent in
-	security-reviewer) echo "| security-reviewer | Security-related keywords detected |" ;;
-	performance-reviewer) echo "| performance-reviewer | Performance-related keywords detected |" ;;
-	api-interface-analyst) echo "| api-interface-analyst | API/endpoint keywords detected |" ;;
-	ux-workflow-analyst) echo "| ux-workflow-analyst | UI/UX keywords detected |" ;;
-	data-model-architect) echo "| data-model-architect | Data/schema keywords detected |" ;;
-	correctness-reviewer) echo "| correctness-reviewer | Logic correctness review |" ;;
-	resilience-reviewer) echo "| resilience-reviewer | Error handling keywords detected |" ;;
-	elegance-reviewer) echo "| elegance-reviewer | Code quality review |" ;;
-	esac
+  case $agent in
+    security-reviewer) echo "| security-reviewer | Security-related keywords detected |" ;;
+    performance-reviewer) echo "| performance-reviewer | Performance-related keywords detected |" ;;
+    api-interface-analyst) echo "| api-interface-analyst | API/endpoint keywords detected |" ;;
+    ux-workflow-analyst) echo "| ux-workflow-analyst | UI/UX keywords detected |" ;;
+    data-model-architect) echo "| data-model-architect | Data/schema keywords detected |" ;;
+    correctness-reviewer) echo "| correctness-reviewer | Logic correctness review |" ;;
+    resilience-reviewer) echo "| resilience-reviewer | Error handling keywords detected |" ;;
+    elegance-reviewer) echo "| elegance-reviewer | Code quality review |" ;;
+  esac
 done)
 
 ### Quick Actions
 
 1. **Create task now**: Write the task file, then implement
 2. **Skip for trivial change**: If this is truly trivial (< 10 lines, single file), proceed without task
-3. **Use /crew:design**: For complex features requiring full research
+3. **For complex features**: Use Skill(skill: "crew:design") for full research and planning
 
 </task-first-workflow>
 

--- a/crew/scripts/workflow/restart-context.sh
+++ b/crew/scripts/workflow/restart-context.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Get branch info (handle detached HEAD)
 BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo '')
 if [[ -z $BRANCH ]]; then
-	BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
+  BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
 fi
 SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
 
@@ -27,31 +27,31 @@ FOUND_WORK=false
 
 # Check for pending task files
 if [[ -d $TASKS_DIR ]]; then
-	PENDING_FILES=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
-	if [[ $PENDING_FILES -gt 0 ]]; then
-		FOUND_WORK=true
+  PENDING_FILES=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+  if [[ $PENDING_FILES -gt 0 ]]; then
+    FOUND_WORK=true
 
-		# Count by priority
-		P1_COUNT=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-p1-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
-		P2_COUNT=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-p2-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
-		P3_COUNT=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-p3-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+    # Count by priority
+    P1_COUNT=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-p1-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+    P2_COUNT=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-p2-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+    P3_COUNT=$(find "$TASKS_DIR" -maxdepth 1 -name "*-pending-p3-*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
 
-		# Build priority breakdown
-		PRIORITY_BREAKDOWN=""
-		[[ $P1_COUNT -gt 0 ]] && PRIORITY_BREAKDOWN="${P1_COUNT} P1"
-		[[ $P2_COUNT -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${P2_COUNT} P2"
-		[[ $P3_COUNT -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${P3_COUNT} P3"
+    # Build priority breakdown
+    PRIORITY_BREAKDOWN=""
+    [[ $P1_COUNT -gt 0 ]] && PRIORITY_BREAKDOWN="${P1_COUNT} P1"
+    [[ $P2_COUNT -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${P2_COUNT} P2"
+    [[ $P3_COUNT -gt 0 ]] && PRIORITY_BREAKDOWN="${PRIORITY_BREAKDOWN:+$PRIORITY_BREAKDOWN, }${P3_COUNT} P3"
 
-		echo "### Pending Tasks"
-		echo ""
-		echo "Found **$PENDING_FILES pending tasks** ($PRIORITY_BREAKDOWN)"
-		echo ""
+    echo "### Pending Tasks"
+    echo ""
+    echo "Found **$PENDING_FILES pending tasks** ($PRIORITY_BREAKDOWN)"
+    echo ""
 
-		# List first 5 pending tasks
-		echo "| Order | Priority | Task |"
-		echo "|-------|----------|------|"
-		find "$TASKS_DIR" -maxdepth 1 -name "*-pending-*.md" -type f 2>/dev/null | sort | head -5 | while read -r file; do
-			basename "$file" | sed 's/\.md$//' | awk -F'-' '{
+    # List first 5 pending tasks
+    echo "| Order | Priority | Task |"
+    echo "|-------|----------|------|"
+    find "$TASKS_DIR" -maxdepth 1 -name "*-pending-*.md" -type f 2>/dev/null | sort | head -5 | while read -r file; do
+      basename "$file" | sed 's/\.md$//' | awk -F'-' '{
         order=$1
         priority=$3
         # Join remaining parts as task name
@@ -59,77 +59,77 @@ if [[ -d $TASKS_DIR ]]; then
         for(i=5;i<=NF;i++) task=task (task?"-":"") $i
         printf "| %s | %s | %s |\n", order, toupper(priority), task
       }'
-		done
-		echo ""
-		echo "**Action**: Run \`/crew:build\` to resume"
-		echo ""
-	fi
+    done
+    echo ""
+    echo "**ACTION REQUIRED:** Use Skill(skill: \"crew:build\") to resume"
+    echo ""
+  fi
 fi
 
 # Check for state.json with active workflow or todos
 if [[ -f $STATE_FILE ]]; then
-	# Check for active workflow
-	ACTIVE_WORKFLOW=$(jq -r '.workflow.active // .active_workflow // empty' "$STATE_FILE" 2>/dev/null)
-	WORKFLOW_ARGS=$(jq -r '.workflow.args // .workflow_args // empty' "$STATE_FILE" 2>/dev/null)
+  # Check for active workflow
+  ACTIVE_WORKFLOW=$(jq -r '.workflow.active // .active_workflow // empty' "$STATE_FILE" 2>/dev/null)
+  WORKFLOW_ARGS=$(jq -r '.workflow.args // .workflow_args // empty' "$STATE_FILE" 2>/dev/null)
 
-	if [[ -n $ACTIVE_WORKFLOW ]]; then
-		FOUND_WORK=true
-		echo "### Active Workflow"
-		echo ""
-		echo "Workflow: \`$ACTIVE_WORKFLOW\`"
-		[[ -n $WORKFLOW_ARGS ]] && echo "Args: \`$WORKFLOW_ARGS\`"
-		echo ""
-		echo "**Action**: \`Skill({skill: \"$ACTIVE_WORKFLOW\"${WORKFLOW_ARGS:+, args: \"$WORKFLOW_ARGS\"}})\`"
-		echo ""
-	fi
+  if [[ -n $ACTIVE_WORKFLOW ]]; then
+    FOUND_WORK=true
+    echo "### Active Workflow"
+    echo ""
+    echo "Workflow: \`$ACTIVE_WORKFLOW\`"
+    [[ -n $WORKFLOW_ARGS ]] && echo "Args: \`$WORKFLOW_ARGS\`"
+    echo ""
+    echo "**Action**: \`Skill({skill: \"$ACTIVE_WORKFLOW\"${WORKFLOW_ARGS:+, args: \"$WORKFLOW_ARGS\"}})\`"
+    echo ""
+  fi
 
-	# Check for pending todos
-	PENDING_COUNT=$(jq -r '.execution.pending_count // .todos.pending_count // 0' "$STATE_FILE" 2>/dev/null)
-	TODOS_JSON=$(jq -c '.execution.todos // .todos.items // []' "$STATE_FILE" 2>/dev/null)
+  # Check for pending todos
+  PENDING_COUNT=$(jq -r '.execution.pending_count // .todos.pending_count // 0' "$STATE_FILE" 2>/dev/null)
+  TODOS_JSON=$(jq -c '.execution.todos // .todos.items // []' "$STATE_FILE" 2>/dev/null)
 
-	if [[ $PENDING_COUNT -gt 0 && $TODOS_JSON != "[]" ]]; then
-		FOUND_WORK=true
-		echo "### Saved Todos"
-		echo ""
-		echo "Found **$PENDING_COUNT pending todos** to restore"
-		echo ""
-		echo "**Action**: \`TodoWrite($TODOS_JSON)\`"
-		echo ""
-	fi
+  if [[ $PENDING_COUNT -gt 0 && $TODOS_JSON != "[]" ]]; then
+    FOUND_WORK=true
+    echo "### Saved Todos"
+    echo ""
+    echo "Found **$PENDING_COUNT pending todos** to restore"
+    echo ""
+    echo "**Action**: \`TodoWrite($TODOS_JSON)\`"
+    echo ""
+  fi
 
-	# Check for active loop
-	LOOP_ACTIVE=$(jq -r '.loop.active // false' "$STATE_FILE" 2>/dev/null)
-	if [[ $LOOP_ACTIVE == "true" ]]; then
-		FOUND_WORK=true
-		LOOP_ITERATION=$(jq -r '.loop.iteration // 0' "$STATE_FILE" 2>/dev/null)
-		LOOP_MAX=$(jq -r '.loop.maxIterations // 10' "$STATE_FILE" 2>/dev/null)
-		LOOP_PROMISE=$(jq -r '.loop.completionPromise // empty' "$STATE_FILE" 2>/dev/null)
-		echo "### Active Iteration Loop"
-		echo ""
-		echo "Iteration $LOOP_ITERATION of $LOOP_MAX"
-		echo "Promise: $LOOP_PROMISE"
-		echo ""
-	fi
+  # Check for active loop
+  LOOP_ACTIVE=$(jq -r '.loop.active // false' "$STATE_FILE" 2>/dev/null)
+  if [[ $LOOP_ACTIVE == "true" ]]; then
+    FOUND_WORK=true
+    LOOP_ITERATION=$(jq -r '.loop.iteration // 0' "$STATE_FILE" 2>/dev/null)
+    LOOP_MAX=$(jq -r '.loop.maxIterations // 10' "$STATE_FILE" 2>/dev/null)
+    LOOP_PROMISE=$(jq -r '.loop.completionPromise // empty' "$STATE_FILE" 2>/dev/null)
+    echo "### Active Iteration Loop"
+    echo ""
+    echo "Iteration $LOOP_ITERATION of $LOOP_MAX"
+    echo "Promise: $LOOP_PROMISE"
+    echo ""
+  fi
 fi
 
 # Check for plan files
 PLAN_FILES=$(find "$PROJECT_DIR/.claude/plans" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
 if [[ $PLAN_FILES -gt 0 ]]; then
-	echo "### Available Plans"
-	echo ""
-	find "$PROJECT_DIR/.claude/plans" -name "*.md" -type f 2>/dev/null | while read -r file; do
-		echo "- \`$(basename "$file")\`"
-	done
-	echo ""
+  echo "### Available Plans"
+  echo ""
+  find "$PROJECT_DIR/.claude/plans" -name "*.md" -type f 2>/dev/null | while read -r file; do
+    echo "- \`$(basename "$file")\`"
+  done
+  echo ""
 fi
 
 if [[ $FOUND_WORK == "false" ]]; then
-	echo "### No Pending Work"
-	echo ""
-	echo "No pending tasks, active workflows, or saved state found for branch \`$BRANCH\`."
-	echo ""
-	echo "To start new work:"
-	echo "- \`/crew:design\` - Create a new implementation plan"
-	echo "- \`/crew:build <plan>\` - Execute an existing plan"
-	echo ""
+  echo "### No Pending Work"
+  echo ""
+  echo "No pending tasks, active workflows, or saved state found for branch \`$BRANCH\`."
+  echo ""
+  echo "To start new work:"
+  echo "- Use Skill(skill: \"crew:design\") - Create a new implementation plan"
+  echo "- Use Skill(skill: \"crew:build\", args: \"<plan>\") - Execute an existing plan"
+  echo ""
 fi


### PR DESCRIPTION
## Summary

This PR updates hook outputs to use explicit `Skill(skill: "...")` syntax with strong action-oriented wording. This ensures Claude recognizes hook suggestions as actionable directives rather than passive information.

## What changed

**Session start hooks:**
- `check-stack-status.sh`: Machete sync warnings now use `Skill(skill: "crew:git:sync")` format
- `inject-skills.sh`: Best practices section uses Skill() format
- `restore-session-state.sh`: Resume actions use Skill() format

**Post-tool hooks:**
- `sync-machete-stack.sh`: Stack out-of-sync messages use `**ACTION REQUIRED:**` with Skill() calls
- `suggest-skill.sh`: Commit and CI suggestions use `⚠️ **USE SKILL:**` format

**Other hooks:**
- `check-loop.sh`: Loop continuation and completion actions use Skill() format
- `save-session-state.sh`: Session completion warnings use Skill() format
- `enforce-task-first.sh`: Design action uses Skill() format

**Git scripts:**
- `gh-pr-scope-check.sh`: PR update suggestions use `Skill(skill: "crew:git:update-pr")`

**Workflow scripts:**
- `restart-context.sh`: Resume and start actions use Skill() format

## Why

Hook outputs were using passive wording like "Run: git machete update" or "Tip: Use /crew:ci". Claude would often ignore these as informational rather than treating them as actionable directives. By using explicit `Skill(skill: "...")` syntax with strong wording like `**ACTION REQUIRED:**`, Claude now recognizes and acts on these suggestions.

## How to test

1. Create a branch that's out of sync with its parent
2. Start a new Claude session and observe the session start output
3. Verify the output includes `Skill(skill: "crew:git:sync")` format
4. Make a git commit and observe the post-tool hook output
5. Verify stack sync warnings use the new format

## Checklist

- [x] Code follows project conventions
- [x] Shell scripts pass shellcheck and shfmt
- [x] Version bumped to 1.23.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted hook outputs to explicit Skill(skill: "...") directives with clear action cues, making suggestions actionable instead of passive tips. Improves session continuity, git stack syncing, PR updates, and CI guidance.

- **New Features**
  - Session start: worktree context, stack sync, and resume actions now use Skill() (e.g., crew:git:sync, crew:build).
  - Post/pre hooks: commit, CI, and stack sync recommendations use Skill() with ACTION REQUIRED messaging.
  - Loop handling: continue/complete/cancel flows show Skill() and clearer next steps.
  - PR scope check: prompts now use Skill(skill: "crew:git:update-pr") to edit title/body safely.

- **Dependencies**
  - Bumped crew plugin version to 1.23.0.

<sup>Written for commit 88f2b1158bd77d0c28afa9650af5bd1b89b99ba6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

