### PR TITLE
feat(crew): add stacking question to /crew:git:pr command

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"


### PR DESCRIPTION
## Summary

This PR adds a stacking question to the `/crew:git:pr` command. When a branch is not in the machete layout, the command now asks whether to add it to a stack before asking about PR type, reviewers, and auto-merge.

## Why

Users weren't getting prompted about stacking their branches, leading to confusion when they wanted to create stacked PRs. The question "Do you want to add this to a stack?" was missing from the flow, so users had to manually specify stacking after the fact.

## Design decisions

- Added stacking as the first question (step 6) when branch is not in machete layout
- Enhanced `machete-context.sh` to output available parent branches as JSON, including open PRs with their numbers and titles
- The stacking question shows "No" (standalone PR) plus available parent branches as options
- After adding to stack, the note explains that step 12 will update all related PR bodies

## What changed

- `crew/commands/git/pr.md`: Added step 6 for stacking question with AskUserQuestion example, renumbered subsequent steps
- `crew/scripts/git/machete-context.sh`: Added "Available Parent Branches" JSON output listing main and open PRs
- `crew/.claude-plugin/plugin.json`: Version bump 1.23.0 → 1.24.0

## How to test

1. Run `/crew:git:pr` on a branch that is NOT in machete layout
2. Verify you see a "Stacking" question with options for "No" and available parent branches
3. Select a parent branch and verify `git machete add --onto <parent>` is run

## Checklist

- [x] Self-reviewed the diff
- [ ] Added or updated tests
- [ ] Ran `bun run ci` locally
- [x] Updated documentation (if applicable)
- [x] No console.log or debug code left behind

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stacking step to /crew:git:pr when the branch isn’t in a Git Machete layout, so users can easily create stacked PRs.

- **New Features**
  - Ask "Add this to a stack?" before PR details if the branch isn’t in machete.
  - Populate options with "No" and parent branches from machete-context JSON (main + open PRs with numbers/titles).
  - If a parent is chosen, run git machete add --onto <parent> and later update related PR descriptions.

- **Dependencies**
  - crew plugin version bumped to 1.24.0.

<sup>Written for commit 1b9eaa54e36b89d572d486a20898f0fc95ecb218. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

