### PR TITLE
feat(crew): enhance /crew:design plan presentation with interactive options

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.24.0",
+  "version": "1.24.3",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"


### PR DESCRIPTION
## Summary

- Prints full plan content at end of design phase instead of a brief summary
- Adds interactive AskUserQuestion prompt with build workflow options
- Supports stacking configuration and loop mode selection before starting build

## What changed

**`crew/commands/design.md`** - Enhanced `<phase name="present-plan">`:
- Read and display complete plan file content
- Three-question interactive prompt:
  - **Next step**: Start building, Edit plan first, Just save
  - **Stacking**: Stack on main, Stack on current, No stacking  
  - **Loop mode**: With loop (`--loop` flag), Single pass
- Response handling executes machete commands and passes appropriate flags to `/crew:build`

**`crew/.claude-plugin/plugin.json`** - Version bump 1.24.0 → 1.24.3

## Why

The previous design command ended with a brief summary and a suggestion to run `/crew:build`. This required users to:
1. Manually inspect the plan file to see what was created
2. Remember to set up stacking separately
3. Know about the `--loop` flag for iteration

Now users see the full plan inline and can configure all build options in one interactive prompt.

## How to test

1. Run `/crew:design` with a feature description
2. Verify the full plan content is printed (not just file paths)
3. Confirm AskUserQuestion appears with three questions
4. Select options and verify correct commands are executed

## Checklist

- [x] Version bumped in plugin.json
- [x] No breaking changes to existing behavior
- [x] Follows existing command patterns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances /crew:design to show the full plan and offer interactive build options, so users can configure stacking and loop mode before starting /crew:build.

- **New Features**
  - Print the complete plan from .claude/plans/<slug>.md.
  - AskUserQuestion with three choices: Next step (build, edit, save), Stacking (on main/current/none), Loop mode (loop/single pass).
  - If building: run machete add when stacking is chosen, then call /crew:build with --loop when enabled.

- **Dependencies**
  - Bump crew plugin version to 1.24.3.

<sup>Written for commit 142fea13205713aea1c9d2fed01a4f67c7d27b38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

