### PR TITLE
feat(crew): add comprehensive git-machete integration with 8 new commands

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/git/advance.md
+++ b/crew/commands/git/advance.md
@@ -1,0 +1,209 @@
+---
+name: crew:git:advance
+description: Fast-forward merge child into current branch, then slide out child
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<constraints>
+
+**CRITICAL: NEVER output plain text questions. Use AskUserQuestion tool for all user choices.**
+
+</constraints>
+
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
+</stack_context>
+
+<objective>
+Fast-forward merge a child branch into the current branch, then slide out the child.
+This is useful when you want to incorporate a child's changes without creating a merge commit.
+</objective>
+
+<when_to_use>
+
+- Child branch is fully reviewed and ready
+- You want to merge child into parent locally (not via GitHub PR)
+- You want a linear history
+- The child is a direct descendant (fast-forward is possible)
+
+</when_to_use>
+
+<process>
+
+## Step 1: Validate State
+
+```bash
+# Check current branch has children
+current=$(git branch --show-current)
+children=$(git machete show down 2>/dev/null || echo "")
+
+if [[ -z "$children" ]]; then
+    echo "No child branches to advance into $current"
+    exit 1
+fi
+
+echo "Current branch: $current"
+echo "Child branch(es): $children"
+```
+
+## Step 2: Check Fast-Forward Possibility
+
+```bash
+# Get first child
+child=$(git machete show down | head -1)
+
+# Check if fast-forward is possible
+if git merge-base --is-ancestor "$current" "$child" 2>/dev/null; then
+    echo "✓ Fast-forward merge is possible"
+else
+    echo "⚠️ Fast-forward not possible - child has diverged"
+fi
+```
+
+If not fast-forward possible:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question:
+        "Fast-forward not possible. The child branch has diverged. What to do?",
+      header: "Diverged",
+      options: [
+        {
+          label: "Rebase child first",
+          description: "Run git machete update on child, then advance",
+        },
+        {
+          label: "Cancel",
+          description: "Don't advance, keep branches separate",
+        },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 3: Confirm Advance
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: `Advance will merge '${child}' into '${current}' and slide out '${child}'. Continue?`,
+      header: "Confirm",
+      options: [
+        {
+          label: "Yes (Recommended)",
+          description: "Fast-forward merge and slide out child",
+        },
+        { label: "No", description: "Cancel advance" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 4: Execute Advance
+
+```bash
+git machete advance --yes
+```
+
+**What happens:**
+
+1. Current branch fast-forwards to child's HEAD
+2. Child branch is slid out of the layout
+3. Child's children (if any) become children of current branch
+
+## Step 5: Push Changes
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Push the advanced branch to remote?",
+      header: "Push",
+      options: [
+        { label: "Yes", description: "Push to origin" },
+        { label: "Force push", description: "Push with --force-with-lease" },
+        { label: "No", description: "Don't push yet" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If push:
+
+```bash
+git push origin $(git branch --show-current)
+```
+
+If force push:
+
+```bash
+git push --force-with-lease origin $(git branch --show-current)
+```
+
+## Step 6: Clean Up (Optional)
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Delete the local child branch?",
+      header: "Cleanup",
+      options: [
+        { label: "Yes", description: "Delete local branch" },
+        { label: "No", description: "Keep local branch" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If yes:
+
+```bash
+git branch -d "$child"
+```
+
+## Step 7: Show Result
+
+```bash
+git machete status --list-commits
+```
+
+</process>
+
+<advance_vs_merge>
+
+| Aspect           | `advance`         | GitHub PR merge       |
+| ---------------- | ----------------- | --------------------- |
+| Merge type       | Fast-forward only | Squash/merge/rebase   |
+| History          | Linear            | Depends on merge type |
+| Where it happens | Local             | Remote (GitHub)       |
+| PR required      | No                | Yes                   |
+| Review           | No formal review  | Code review possible  |
+| Best for         | Local development | Team collaboration    |
+
+</advance_vs_merge>
+
+<success_criteria>
+
+- [ ] Child branch merged into current via fast-forward
+- [ ] Child branch slid out of machete layout
+- [ ] Child's children (if any) re-parented to current
+- [ ] Changes pushed to remote (optional)
+- [ ] Local child branch deleted (optional)
+
+</success_criteria>

--- a/crew/commands/git/checkout-prs.md
+++ b/crew/commands/git/checkout-prs.md
@@ -1,0 +1,200 @@
+---
+name: crew:git:checkout-prs
+description: Checkout PR branches from GitHub and add to machete layout
+argument-hint: "[--mine | --all | --by=<user> | PR numbers]"
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<constraints>
+
+**CRITICAL: NEVER output plain text questions. Use AskUserQuestion tool for all user choices.**
+
+</constraints>
+
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
+</stack_context>
+
+<objective>
+Checkout PR branches from GitHub locally and optionally add them to the machete layout.
+Useful for reviewing someone's stacked PRs or resuming work on your own PRs.
+</objective>
+
+<process>
+
+## Step 1: Determine Which PRs to Checkout
+
+If no argument provided:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which PRs do you want to checkout?",
+      header: "PRs",
+      options: [
+        {
+          label: "My PRs (Recommended)",
+          description: "All open PRs authored by you",
+        },
+        {
+          label: "All open PRs",
+          description: "All open PRs in the repository",
+        },
+        { label: "Specific PRs", description: "Enter PR numbers" },
+        { label: "By author", description: "PRs by a specific user" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 2: List Available PRs
+
+```bash
+# Show available PRs based on selection
+case "$selection" in
+    "My PRs")
+        gh pr list --author @me --state open --json number,title,headRefName
+        ;;
+    "All open PRs")
+        gh pr list --state open --limit 20 --json number,title,headRefName,author
+        ;;
+    "By author")
+        # Prompt for username
+        gh pr list --author "$username" --state open --json number,title,headRefName
+        ;;
+esac
+```
+
+## Step 3: Checkout PRs
+
+**For your own PRs:**
+
+```bash
+git machete github checkout-prs --mine
+```
+
+**For all open PRs:**
+
+```bash
+git machete github checkout-prs --all
+```
+
+**For specific PRs:**
+
+```bash
+git machete github checkout-prs 123 456 789
+```
+
+**For PRs by a specific author:**
+
+```bash
+git machete github checkout-prs --by=username
+```
+
+## Step 4: What Happens
+
+When checking out PRs, git-machete:
+
+1. Fetches PR branches from GitHub
+2. Creates local tracking branches
+3. Adds branches to the machete layout (preserving stack structure)
+4. Adds `rebase=no push=no` qualifiers for branches not authored by you
+
+## Step 5: Review the Layout
+
+```bash
+git machete status --list-commits
+```
+
+## Step 6: Optionally Sync the Stack
+
+After checkout, you may want to sync:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Sync the checked-out stack with latest changes?",
+      header: "Sync",
+      options: [
+        { label: "Yes", description: "Run traverse to sync all branches" },
+        { label: "No", description: "Keep branches as-is" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If yes:
+
+```javascript
+Skill({ skill: "crew:git:traverse" });
+```
+
+</process>
+
+<qualifiers>
+
+When checking out someone else's PRs, branches are automatically annotated:
+
+```
+feature-branch  PR #123 rebase=no push=no
+```
+
+**Qualifiers meaning:**
+
+- `rebase=no` — Don't rebase this branch during traverse (you don't own it)
+- `push=no` — Don't push this branch during traverse (you don't own it)
+
+**To remove qualifiers** (if you take ownership):
+
+```bash
+git machete anno <branch> ""
+# Or keep just the PR annotation:
+git machete anno <branch> "PR #123"
+```
+
+</qualifiers>
+
+<use_cases>
+
+**Review someone's stacked PRs:**
+
+```bash
+git machete github checkout-prs --by=colleague
+git machete status --list-commits
+```
+
+**Resume work on your own PRs from another machine:**
+
+```bash
+git machete github checkout-prs --mine
+git machete traverse -W -y
+```
+
+**Checkout a specific PR chain:**
+
+```bash
+# Checkout PR and its dependencies
+git machete github checkout-prs 456
+```
+
+</use_cases>
+
+<success_criteria>
+
+- [ ] PR branches checked out locally
+- [ ] Branches added to machete layout
+- [ ] Qualifiers set appropriately (rebase=no push=no for others' PRs)
+- [ ] Stack structure preserved from GitHub PR base relationships
+- [ ] `git machete status` shows correct tree
+
+</success_criteria>

--- a/crew/commands/git/cleanup-unmanaged.md
+++ b/crew/commands/git/cleanup-unmanaged.md
@@ -1,0 +1,191 @@
+---
+name: crew:git:cleanup-unmanaged
+description: Delete local branches not in machete layout
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<constraints>
+
+**CRITICAL: NEVER output plain text questions. Use AskUserQuestion tool for all user choices.**
+
+</constraints>
+
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
+</stack_context>
+
+<objective>
+Clean up local branches that are not tracked in the machete layout file.
+Useful for removing stale feature branches after PRs are merged.
+</objective>
+
+<process>
+
+## Step 1: Identify Unmanaged Branches
+
+```bash
+echo "=== Branches in machete layout ==="
+git machete list managed 2>/dev/null || cat .git/machete
+
+echo
+echo "=== Local branches NOT in layout ==="
+git machete list unmanaged 2>/dev/null || {
+    # Fallback: manual comparison
+    all_branches=$(git branch --format='%(refname:short)')
+    managed=$(cat .git/machete 2>/dev/null | grep -v '^[[:space:]]*$' | sed 's/^[[:space:]]*//' | cut -d' ' -f1)
+    comm -23 <(echo "$all_branches" | sort) <(echo "$managed" | sort)
+}
+```
+
+## Step 2: Dry Run First
+
+```bash
+# Show what would be deleted (dry run)
+git machete delete-unmanaged --dry-run
+```
+
+## Step 3: Review and Confirm
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Delete the unmanaged branches listed above?",
+      header: "Delete",
+      options: [
+        {
+          label: "Yes, delete all",
+          description: "Delete all unmanaged branches",
+        },
+        {
+          label: "Select individually",
+          description: "Choose which branches to delete",
+        },
+        { label: "No, keep all", description: "Don't delete any branches" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 4: Execute Deletion
+
+**Delete all unmanaged:**
+
+```bash
+git machete delete-unmanaged --yes
+```
+
+**Delete specific branches:**
+
+```bash
+# For each selected branch
+git branch -d <branch-name>
+
+# Force delete if not fully merged
+git branch -D <branch-name>
+```
+
+## Step 5: Clean Remote Tracking
+
+```bash
+# Prune remote tracking branches that no longer exist on remote
+git fetch --prune
+
+# Show any remaining stale remote refs
+git branch -vv | grep ': gone]'
+```
+
+## Step 6: Verify
+
+```bash
+echo "=== Remaining branches ==="
+git branch -a
+
+echo
+echo "=== Machete status ==="
+git machete status
+```
+
+</process>
+
+<protected_branches>
+
+The following branches are typically NOT deleted even if unmanaged:
+
+- `main` / `master`
+- `develop` / `development`
+- Current branch (can't delete checked-out branch)
+- Branches with worktrees
+
+**To delete anyway:**
+
+```bash
+git branch -D <branch-name>
+```
+
+</protected_branches>
+
+<related_cleanup>
+
+**Full cleanup workflow:**
+
+```bash
+# 1. Slide out merged branches from layout
+Skill({ skill: "crew:git:slide-out" })
+
+# 2. Delete unmanaged local branches
+Skill({ skill: "crew:git:cleanup-unmanaged" })
+
+# 3. Clean stale branches (deleted on remote)
+Skill({ skill: "crew:git:clean" })
+
+# 4. Prune remote tracking refs
+git fetch --prune
+```
+
+**Or use the combined clean command:**
+
+```javascript
+Skill({ skill: "crew:git:clean" });
+```
+
+</related_cleanup>
+
+<safe_deletion>
+
+**Safe deletion** (`git branch -d`):
+
+- Only deletes if branch is fully merged
+- Fails if branch has unmerged commits
+- Recommended for most cases
+
+**Force deletion** (`git branch -D`):
+
+- Deletes regardless of merge status
+- Use with caution
+- May lose unmerged work
+
+**Check before force deleting:**
+
+```bash
+# See what commits would be lost
+git log <branch> --not --remotes
+```
+
+</safe_deletion>
+
+<success_criteria>
+
+- [ ] Identified all unmanaged branches
+- [ ] Reviewed branches before deletion
+- [ ] Deleted appropriate branches
+- [ ] Pruned remote tracking refs
+- [ ] Verified remaining branches are correct
+
+</success_criteria>

--- a/crew/commands/git/discover.md
+++ b/crew/commands/git/discover.md
@@ -1,0 +1,171 @@
+---
+name: crew:git:discover
+description: Auto-detect branch layout from git reflog
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<constraints>
+
+**CRITICAL: NEVER output plain text questions. Use AskUserQuestion tool for all user choices.**
+
+</constraints>
+
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
+</stack_context>
+
+<objective>
+Auto-detect branch dependencies from git reflog and create a machete layout file.
+</objective>
+
+<process>
+
+## Step 1: Check for Existing Layout
+
+```bash
+git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+machete_file="${git_common_dir}/machete"
+if [[ -f "$machete_file" ]]; then
+    echo "Existing layout found at $machete_file"
+    cat "$machete_file"
+fi
+```
+
+If layout exists:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "A machete layout already exists. What to do?",
+      header: "Existing",
+      options: [
+        {
+          label: "Keep existing",
+          description: "Don't modify the current layout",
+        },
+        {
+          label: "Re-discover",
+          description: "Backup existing and create new layout",
+        },
+        { label: "Edit manually", description: "Open editor to modify layout" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 2: Run Discovery
+
+```bash
+# Backup existing layout if present
+if [[ -f "$machete_file" ]]; then
+    cp "$machete_file" "${machete_file}~"
+    echo "Backed up existing layout to ${machete_file}~"
+fi
+
+# Run discovery (suggests layout based on reflog)
+git machete discover --list-commits
+```
+
+## Step 3: Review and Confirm
+
+Discovery shows a preview. Ask user to confirm:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Accept the discovered layout?",
+      header: "Confirm",
+      options: [
+        {
+          label: "Yes (Recommended)",
+          description: "Accept the discovered layout",
+        },
+        {
+          label: "Edit first",
+          description: "Open editor to modify before saving",
+        },
+        { label: "Cancel", description: "Don't save, keep previous layout" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If "Yes":
+
+```bash
+git machete discover --yes
+```
+
+If "Edit first":
+
+```bash
+git machete discover --yes
+git machete edit
+```
+
+## Step 4: Annotate with PRs
+
+If GitHub PRs exist for branches:
+
+```bash
+# Annotate branches with PR numbers
+git machete github anno-prs
+```
+
+## Step 5: Show Final Status
+
+```bash
+echo "=== Discovered Layout ==="
+git machete status --list-commits
+```
+
+</process>
+
+<discovery_tips>
+
+**How discovery works:**
+
+1. Analyzes git reflog to find branch creation points
+2. Determines parent-child relationships from fork points
+3. Creates hierarchy based on commit ancestry
+
+**When discovery might be inaccurate:**
+
+- Old branches with expired reflogs
+- Branches created before git-machete was installed
+- Complex merge histories
+
+**Manual adjustment:**
+
+```bash
+# Edit layout file directly
+git machete edit
+
+# Add a branch to the layout
+git machete add <branch> --onto <parent>
+
+# Reorder branches
+# Just edit the .git/machete file (indentation = hierarchy)
+```
+
+</discovery_tips>
+
+<success_criteria>
+
+- [ ] Layout file created at `.git/machete`
+- [ ] All relevant branches included
+- [ ] Parent-child relationships correct
+- [ ] PR annotations added (if applicable)
+- [ ] `git machete status` shows correct tree
+
+</success_criteria>

--- a/crew/commands/git/go.md
+++ b/crew/commands/git/go.md
@@ -1,0 +1,230 @@
+---
+name: crew:git:go
+description: Navigate to branches in the machete stack
+argument-hint: "[up | down | next | prev | root | first | last]"
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<constraints>
+
+**CRITICAL: NEVER output plain text questions. Use AskUserQuestion tool for all user choices.**
+
+</constraints>
+
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
+</stack_context>
+
+<objective>
+Navigate between branches in the machete stack using directional commands.
+</objective>
+
+<directions>
+
+| Direction | Meaning                                      |
+| --------- | -------------------------------------------- |
+| `up`      | Parent branch                                |
+| `down`    | First child branch                           |
+| `next`    | Next sibling (same level, next in order)     |
+| `prev`    | Previous sibling (same level, prev in order) |
+| `root`    | Root of current branch's tree                |
+| `first`   | First branch in the entire layout            |
+| `last`    | Last branch in the entire layout             |
+
+</directions>
+
+<process>
+
+## Step 1: Determine Direction
+
+If no argument provided:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which direction to navigate?",
+      header: "Navigate",
+      options: [
+        { label: "Up", description: "Go to parent branch" },
+        { label: "Down", description: "Go to first child branch" },
+        { label: "Next", description: "Go to next sibling" },
+        { label: "Prev", description: "Go to previous sibling" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 2: Check Target Exists
+
+```bash
+direction="${1:-up}"  # default to up
+
+# Show what branch we'll navigate to
+target=$(git machete show "$direction" 2>/dev/null || echo "")
+
+if [[ -z "$target" ]]; then
+    echo "No branch in direction '$direction' from current branch"
+    git machete status
+    exit 1
+fi
+
+echo "Will checkout: $target"
+```
+
+## Step 3: Handle Worktree
+
+**If in a worktree:**
+
+⚠️ Cannot switch branches in a worktree. Each worktree is bound to its branch.
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question:
+        "You're in a worktree. Cannot switch branches here. What to do?",
+      header: "Worktree",
+      options: [
+        {
+          label: "Show worktree path",
+          description: "Show where the target branch's worktree is",
+        },
+        {
+          label: "Create worktree",
+          description: "Create a new worktree for the target branch",
+        },
+        { label: "Cancel", description: "Stay on current branch" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 4: Check for Uncommitted Changes
+
+```bash
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "You have uncommitted changes"
+    git status --short
+fi
+```
+
+If uncommitted changes:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "You have uncommitted changes. What to do?",
+      header: "Changes",
+      options: [
+        { label: "Stash", description: "Stash changes and switch" },
+        { label: "Commit", description: "Commit changes first" },
+        { label: "Discard", description: "Discard changes and switch" },
+        { label: "Cancel", description: "Stay on current branch" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If "Stash":
+
+```bash
+git stash push -m "Auto-stash before go $direction"
+```
+
+If "Commit":
+
+```javascript
+Skill({ skill: "crew:git:commit" });
+```
+
+## Step 5: Navigate
+
+```bash
+git machete go "$direction"
+```
+
+Or directly:
+
+```bash
+git checkout "$target"
+```
+
+## Step 6: Show New Context
+
+```bash
+echo "=== Now on: $(git branch --show-current) ==="
+git machete status
+```
+
+</process>
+
+<interactive_mode>
+
+On Unix terminals, `git machete go` supports interactive mode:
+
+```bash
+git machete go  # Without argument
+```
+
+**Controls:**
+
+- Arrow keys: Navigate
+- Shift+Arrow: Jump (e.g., Shift+Up = root)
+- Enter/Space: Select
+- q: Quit
+
+**Note:** Interactive mode not available on Windows.
+
+</interactive_mode>
+
+<navigation_examples>
+
+**Navigate through a stack:**
+
+```text
+main
+    feature-base      ← git machete go down (from main)
+        feature-1     ← git machete go down (from feature-base)
+        feature-2     ← git machete go next (from feature-1)
+    hotfix            ← git machete go next (from feature-base)
+```
+
+**Common patterns:**
+
+```bash
+# Go to parent to check its state
+git machete go up
+
+# Go to child to continue work
+git machete go down
+
+# Cycle through siblings
+git machete go next
+git machete go next
+
+# Jump to root of current tree
+git machete go root
+```
+
+</navigation_examples>
+
+<success_criteria>
+
+- [ ] Correctly identified target branch
+- [ ] Handled uncommitted changes appropriately
+- [ ] Successfully switched to target branch
+- [ ] Displayed new branch context
+
+</success_criteria>

--- a/crew/commands/git/pr.md
+++ b/crew/commands/git/pr.md
@@ -30,8 +30,74 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoW
 2. **Commit messages**: `git log origin/main..HEAD` - What was actually done
 3. **Diff analysis**: `git diff origin/main..HEAD --stat` - What files changed
 4. **Task/todo context**: Any active todos from the session
+5. **Repository PR template** (if exists): See `<pr_template_detection>`
 
 </context_sources>
+
+<pr_template_detection>
+
+**Check for existing PR templates in the repository:**
+
+```bash
+# GitHub PR template locations (check in order)
+templates=(
+    ".github/PULL_REQUEST_TEMPLATE.md"
+    ".github/pull_request_template.md"
+    "PULL_REQUEST_TEMPLATE.md"
+    "pull_request_template.md"
+    "docs/PULL_REQUEST_TEMPLATE.md"
+    ".github/PULL_REQUEST_TEMPLATE/default.md"
+)
+
+for template in "${templates[@]}"; do
+    if [[ -f "$template" ]]; then
+        echo "Found PR template: $template"
+        break
+    fi
+done
+```
+
+**If repository template exists:**
+
+1. Parse the template structure (headings, checkboxes, sections)
+2. Merge with crew templates, preserving repository-specific sections
+3. Fill in content from commits, plan file, and diff analysis
+
+**Template priority:**
+
+1. Repository template (if exists) — for repo-specific sections
+2. Crew templates — for content generation patterns
+3. Generated content — fills both
+
+**Example merge:**
+
+Repository template has:
+
+```markdown
+## Description
+
+<!-- Describe your changes -->
+
+## Checklist
+
+- [ ] Tests added
+- [ ] Documentation updated
+```
+
+Crew fills in:
+
+```markdown
+## Description
+
+This PR adds user authentication with JWT tokens...
+
+## Checklist
+
+- [x] Tests added
+- [x] Documentation updated
+```
+
+</pr_template_detection>
 
 <templates>
 
@@ -246,6 +312,9 @@ If PR is part of a stack (machete-managed):
 **After updating PR content:**
 
 ```bash
+# Ensure config is set for full PR description intro (required for --related)
+git config machete.github.prDescriptionIntroStyle full
+
 # Update machete sections in all related PRs (upstream and downstream)
 git machete github update-pr-descriptions --related
 ```

--- a/crew/commands/git/restack-pr.md
+++ b/crew/commands/git/restack-pr.md
@@ -1,0 +1,192 @@
+---
+name: crew:git:restack-pr
+description: Retarget PR, force push, and manage draft state atomically
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<constraints>
+
+**CRITICAL: NEVER output plain text questions. Use AskUserQuestion tool for all user choices.**
+
+</constraints>
+
+<pr_info>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-info.sh 2>&1`
+</pr_info>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
+</stack_context>
+
+<objective>
+Atomically retarget a PR, force push rebased changes, and optionally manage draft state.
+This prevents reviewers from seeing an inconsistent state during the update.
+</objective>
+
+<when_to_use>
+
+- After rebasing a branch that has an open PR
+- When you need to update both PR base and branch contents
+- To avoid CI running on an intermediate broken state
+- When the branch history has been rewritten
+
+</when_to_use>
+
+<process>
+
+## Step 1: Check Current State
+
+```bash
+branch=$(git branch --show-current)
+pr_number=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+pr_state=$(gh pr view --json state,isDraft -q '{state: .state, draft: .isDraft}' 2>/dev/null || echo "{}")
+current_base=$(gh pr view --json baseRefName -q '.baseRefName' 2>/dev/null || echo "")
+machete_parent=$(git machete show up 2>/dev/null || echo "main")
+
+echo "Branch: $branch"
+echo "PR #: $pr_number"
+echo "PR state: $pr_state"
+echo "Current base: $current_base"
+echo "Machete parent: $machete_parent"
+```
+
+## Step 2: Check for Unpushed Changes
+
+```bash
+# Check if local differs from remote
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/$branch 2>/dev/null || echo "none")
+
+if [[ "$local_sha" != "$remote_sha" ]]; then
+    echo "Local branch has unpushed changes"
+    git log --oneline origin/$branch..HEAD 2>/dev/null | head -5
+fi
+```
+
+## Step 3: Confirm Restack
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question:
+        "Restack will retarget PR and force push. This may trigger CI. Continue?",
+      header: "Restack",
+      options: [
+        {
+          label: "Yes with draft (Recommended)",
+          description: "Set to draft, restack, then ready for review",
+        },
+        {
+          label: "Yes without draft",
+          description:
+            "Restack immediately (CI will run on intermediate state)",
+        },
+        { label: "Cancel", description: "Don't restack" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 4: Execute Restack
+
+**With draft state management:**
+
+```bash
+# Convert to draft first (if not already)
+gh pr ready --undo $pr_number 2>/dev/null || true
+
+# Retarget PR to machete parent
+git machete github retarget-pr
+
+# Force push rebased branch
+git push --force-with-lease origin $branch
+
+# Convert back to ready for review
+gh pr ready $pr_number
+```
+
+**Without draft (using machete command):**
+
+```bash
+git machete github restack-pr
+```
+
+## Step 5: Update Related PRs
+
+```bash
+# Ensure config is set
+git config machete.github.prDescriptionIntroStyle full
+
+# Update PR descriptions for entire stack
+git machete github update-pr-descriptions --related
+```
+
+## Step 6: Verify
+
+```bash
+# Check PR status
+gh pr view --json state,mergeable,baseRefName -q '{state: .state, mergeable: .mergeable, base: .baseRefName}'
+
+# Check CI status
+gh pr checks
+```
+
+</process>
+
+<restack_vs_retarget>
+
+| Aspect          | `retarget-pr`           | `restack-pr`                      |
+| --------------- | ----------------------- | --------------------------------- |
+| Changes base    | Yes                     | Yes                               |
+| Force pushes    | No                      | Yes                               |
+| Draft handling  | No                      | Optional                          |
+| Use when        | Base changed, no rebase | After rebase with history rewrite |
+| CI implications | Minimal                 | Full CI re-run                    |
+
+</restack_vs_retarget>
+
+<common_scenarios>
+
+**Scenario: After syncing with main**
+
+```bash
+# You rebased onto latest main
+git fetch origin main
+git rebase origin/main
+
+# Now restack the PR
+Skill({ skill: "crew:git:restack-pr" })
+```
+
+**Scenario: After traverse updated the branch**
+
+```bash
+# Traverse rebased this branch
+git machete traverse -W -y
+
+# Restack PRs that were rebased
+Skill({ skill: "crew:git:restack-pr" })
+```
+
+**Scenario: Batch restack entire stack**
+
+```bash
+# Traverse with GitHub sync handles this automatically
+git machete traverse -W -y -H
+```
+
+</common_scenarios>
+
+<success_criteria>
+
+- [ ] PR base matches machete parent
+- [ ] Branch force pushed successfully
+- [ ] PR is not in draft state (if was ready before)
+- [ ] CI checks triggered on new state
+- [ ] Related PRs updated with chain info
+- [ ] PR shows as mergeable
+
+</success_criteria>

--- a/crew/commands/git/retarget-pr.md
+++ b/crew/commands/git/retarget-pr.md
@@ -1,0 +1,190 @@
+---
+name: crew:git:retarget-pr
+description: Change PR base branch to match machete parent
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<constraints>
+
+**CRITICAL: NEVER output plain text questions. Use AskUserQuestion tool for all user choices.**
+
+</constraints>
+
+<pr_info>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-info.sh 2>&1`
+</pr_info>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
+</stack_context>
+
+<objective>
+Change the base branch of a PR to match the machete parent branch.
+Used when the upstream PR is merged and you need to retarget to the new parent.
+</objective>
+
+<when_to_use>
+
+- Parent PR was merged, need to retarget to main/new parent
+- Rearranged stack order in machete layout
+- PR was created with wrong base branch
+- After `slide-out` of a parent branch
+
+</when_to_use>
+
+<process>
+
+## Step 1: Check Current State
+
+```bash
+branch=$(git branch --show-current)
+pr_number=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+current_base=$(gh pr view --json baseRefName -q '.baseRefName' 2>/dev/null || echo "")
+machete_parent=$(git machete show up 2>/dev/null || echo "main")
+
+echo "Branch: $branch"
+echo "PR #: $pr_number"
+echo "Current base: $current_base"
+echo "Machete parent: $machete_parent"
+```
+
+If no PR found:
+
+```
+No PR found for current branch. Create one first with:
+Skill({ skill: "crew:git:pr" })
+```
+
+## Step 2: Compare Base and Parent
+
+If `$current_base` equals `$machete_parent`:
+
+```
+PR base already matches machete parent ($machete_parent). No retargeting needed.
+```
+
+## Step 3: Confirm Retarget
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: `Retarget PR #${pr_number} from '${current_base}' to '${machete_parent}'?`,
+      header: "Retarget",
+      options: [
+        { label: "Yes (Recommended)", description: "Change PR base branch" },
+        { label: "No", description: "Keep current base" },
+        {
+          label: "Different target",
+          description: "Choose a different base branch",
+        },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If "Different target":
+
+```bash
+# List available branches
+git branch -r --list 'origin/*' | sed 's/origin\///' | head -20
+```
+
+Then ask for target branch selection.
+
+## Step 4: Execute Retarget
+
+```bash
+git machete github retarget-pr
+```
+
+Or manually:
+
+```bash
+gh pr edit $pr_number --base $machete_parent
+```
+
+## Step 5: Update PR Descriptions
+
+After retargeting, update PR chain descriptions:
+
+```bash
+# Ensure config is set
+git config machete.github.prDescriptionIntroStyle full
+
+# Update all related PRs
+git machete github update-pr-descriptions --related
+```
+
+## Step 6: Verify
+
+```bash
+# Check new base
+gh pr view --json baseRefName -q '.baseRefName'
+
+# Check PR status
+gh pr view --json state,mergeable -q '{state: .state, mergeable: .mergeable}'
+```
+
+</process>
+
+<batch_retarget>
+
+**Retarget all PRs in the stack:**
+
+During traverse with `-H` flag, machete automatically retargets PRs:
+
+```bash
+git machete traverse -W -y -H
+```
+
+Or use update-pr-descriptions to refresh all chain info:
+
+```bash
+git machete github update-pr-descriptions --related
+```
+
+</batch_retarget>
+
+<common_scenarios>
+
+**Scenario: Parent PR merged to main**
+
+```text
+Before:
+main
+    feature-base (merged)
+        feature-part-1 (PR base: feature-base)
+
+After slide-out and retarget:
+main
+    feature-part-1 (PR base: main)
+```
+
+```bash
+git machete slide-out feature-base --no-rebase
+git checkout feature-part-1
+git machete github retarget-pr
+```
+
+**Scenario: Reordered stack**
+
+If you edited `.git/machete` to change the order:
+
+```bash
+git machete github retarget-pr
+git machete github update-pr-descriptions --related
+```
+
+</common_scenarios>
+
+<success_criteria>
+
+- [ ] PR base branch matches machete parent
+- [ ] PR description updated with new chain info
+- [ ] Related PRs updated with `--related` flag
+- [ ] PR shows as mergeable (no conflicts)
+
+</success_criteria>

--- a/crew/commands/git/setup.md
+++ b/crew/commands/git/setup.md
@@ -1,0 +1,236 @@
+---
+name: crew:git:setup
+description: Configure optimal git-machete settings for stacked PRs
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
+---
+
+<objective>
+Set up git-machete with optimal configuration for stacked PR workflows.
+</objective>
+
+<process>
+
+## Step 1: Check Installation
+
+```bash
+if ! command -v git-machete &>/dev/null; then
+    echo "git-machete is not installed"
+    # Offer installation options
+fi
+git-machete version
+```
+
+If not installed, offer:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "git-machete is not installed. How to install?",
+      header: "Install",
+      options: [
+        {
+          label: "Homebrew (Recommended)",
+          description: "brew install git-machete",
+        },
+        { label: "pip", description: "pip install --user git-machete" },
+        { label: "Skip", description: "I'll install manually" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 2: Configure Machete Settings
+
+```bash
+# PR description intro style - required for update-pr-descriptions --related
+git config machete.github.prDescriptionIntroStyle full
+
+# Squash merge detection - detect GitHub squash merges as merged
+git config machete.squashMergeDetection simple
+
+# Include full PR URLs in annotations
+git config machete.github.annotateWithUrls true
+
+# Extra space before branch name for easier terminal selection
+git config machete.status.extraSpaceBeforeBranchName true
+```
+
+## Step 3: Configure Git Performance Settings
+
+**Recommended by Git core developers (zero downsides):**
+
+```bash
+# Better diff algorithm (histogram vs myers from 1986)
+git config --global diff.algorithm histogram
+
+# Highlight moved code in diffs
+git config --global diff.colorMoved plain
+
+# Auto-setup remote tracking branches
+git config --global push.autoSetupRemote true
+
+# Clean stale remote references on fetch
+git config --global fetch.prune true
+git config --global fetch.pruneTags true
+
+# Better branch/tag display
+git config --global column.ui auto
+git config --global branch.sort -committerdate
+git config --global tag.sort version:refname
+```
+
+**Performance settings for large repositories:**
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question:
+        "Enable filesystem monitoring for faster git status? (Recommended for large repos)",
+      header: "FSMonitor",
+      options: [
+        {
+          label: "Yes (Recommended for large repos)",
+          description: "Enable fsmonitor and untrackedCache",
+        },
+        {
+          label: "No",
+          description: "Skip filesystem monitoring",
+        },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If "Yes":
+
+```bash
+# Enable filesystem monitoring (runs a background process per repo)
+git config core.fsmonitor true
+
+# Cache untracked files for faster status
+git config core.untrackedCache true
+```
+
+**Additional performance for very large repos:**
+
+```bash
+# Enable multi-pack index for faster pack access
+git config --global core.multiPackIndex true
+
+# Enable commit graph for faster log/blame
+git config --global fetch.writeCommitGraph true
+
+# Enable sparse checkout readiness
+git config --global index.sparse true
+```
+
+## Step 4: Configure Shell Completions
+
+```bash
+SHELL_TYPE=$(basename "$SHELL")
+case "$SHELL_TYPE" in
+    bash)
+        echo 'eval "$(git machete completion bash)"' >> ~/.bashrc
+        ;;
+    zsh)
+        echo 'eval "$(git machete completion zsh)"' >> ~/.zshrc
+        ;;
+    fish)
+        echo 'git machete completion fish | source' >> ~/.config/fish/config.fish
+        ;;
+esac
+```
+
+## Step 5: Initialize Layout (if none exists)
+
+If no `.git/machete` file exists:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "No machete layout found. How to initialize?",
+      header: "Layout",
+      options: [
+        {
+          label: "Auto-discover (Recommended)",
+          description: "Detect branches from git reflog",
+        },
+        {
+          label: "Start fresh",
+          description: "Create empty layout, add branches manually",
+        },
+        { label: "Skip", description: "I'll set it up later" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If "Auto-discover":
+
+```javascript
+Skill({ skill: "crew:git:discover" });
+```
+
+## Step 6: Verify Setup
+
+```bash
+echo "=== Git Machete Configuration ==="
+git config --get-regexp machete 2>/dev/null || echo "(no machete config set)"
+echo
+echo "=== Layout File ==="
+cat .git/machete 2>/dev/null || echo "(no layout file)"
+echo
+echo "=== Current Status ==="
+git machete status 2>/dev/null || echo "(unable to get status)"
+```
+
+</process>
+
+<configuration_reference>
+
+**Machete Settings:**
+
+| Setting                                     | Value    | Purpose                               |
+| ------------------------------------------- | -------- | ------------------------------------- |
+| `machete.github.prDescriptionIntroStyle`    | `full`   | Full PR chain in descriptions         |
+| `machete.squashMergeDetection`              | `simple` | Detect squash-merged PRs              |
+| `machete.github.annotateWithUrls`           | `true`   | Include PR URLs in branch annotations |
+| `machete.status.extraSpaceBeforeBranchName` | `true`   | Easier terminal selection             |
+| `machete.traverse.push`                     | `true`   | Auto-push during traverse (optional)  |
+
+**Git Performance Settings (recommended by Git core developers):**
+
+| Setting                  | Value             | Purpose                         |
+| ------------------------ | ----------------- | ------------------------------- |
+| `diff.algorithm`         | `histogram`       | Better diff output than myers   |
+| `diff.colorMoved`        | `plain`           | Highlight moved code            |
+| `push.autoSetupRemote`   | `true`            | Auto-setup tracking branches    |
+| `fetch.prune`            | `true`            | Clean stale remote refs         |
+| `fetch.pruneTags`        | `true`            | Clean stale tag refs            |
+| `column.ui`              | `auto`            | Better branch/tag listing       |
+| `branch.sort`            | `-committerdate`  | Recent branches first           |
+| `tag.sort`               | `version:refname` | Semantic version sorting        |
+| `core.fsmonitor`         | `true`            | Faster git status (large repos) |
+| `core.untrackedCache`    | `true`            | Cache untracked files           |
+| `fetch.writeCommitGraph` | `true`            | Faster log/blame                |
+
+</configuration_reference>
+
+<success_criteria>
+
+- [ ] git-machete installed and accessible
+- [ ] Optimal configuration settings applied
+- [ ] Shell completions configured (optional)
+- [ ] Layout file exists or created
+- [ ] `git machete status` runs successfully
+
+</success_criteria>

--- a/crew/commands/git/stack-add.md
+++ b/crew/commands/git/stack-add.md
@@ -1,6 +1,7 @@
 ---
 name: crew:git:stack-add
 description: Add current or specified branch to the machete stack
+argument-hint: "[branch-name] [--onto parent]"
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
@@ -16,31 +17,197 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoW
 
 <process>
 
-1. `git branch --show-current`
-2. If no layout → `git machete discover`
-3. Add to layout:
+## Step 1: Determine Branch to Add
 
 ```bash
-git machete add --onto <parent-branch>
+branch="${1:-$(git branch --show-current)}"
+echo "Adding branch: $branch"
 ```
 
-4. `git machete status`
+## Step 2: Check if Already Managed
 
-If parent not specified:
+```bash
+if git machete is-managed "$branch" 2>/dev/null; then
+    echo "Branch '$branch' is already in the machete layout"
+    git machete status
+    exit 0
+fi
+```
+
+## Step 3: Initialize Layout if Needed
+
+If no layout exists:
 
 ```javascript
 AskUserQuestion({
   questions: [
     {
-      question: "Which parent branch?",
-      header: "Parent",
+      question: "No machete layout found. How to initialize?",
+      header: "Layout",
       options: [
-        { label: "main", description: "Base off main" },
-        { label: "Current parent", description: "Stack on current branch" },
+        {
+          label: "Discover (Recommended)",
+          description: "Auto-detect all branches from history",
+        },
+        {
+          label: "Start with this branch",
+          description: "Create layout with just this branch",
+        },
       ],
+      multiSelect: false,
     },
   ],
 });
 ```
 
+If "Discover":
+
+```javascript
+Skill({ skill: "crew:git:discover" });
+```
+
+If "Start with this branch":
+
+```bash
+echo "main" > .git/machete
+echo "    $branch" >> .git/machete
+```
+
+## Step 4: Select Parent Branch
+
+Get available parent options from machete context or open PRs:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: `Which branch should '${branch}' be stacked on?`,
+      header: "Parent",
+      options: [
+        { label: "main", description: "Stack directly on main branch" },
+        // Dynamic options from open PRs or existing layout branches
+        // { label: "feature-base", description: "PR #123: Auth improvements" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 5: Add to Stack
+
+```bash
+git machete add "$branch" --onto "$parent"
+```
+
+## Step 6: Add Qualifiers (Optional)
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Add any qualifiers to this branch?",
+      header: "Qualifiers",
+      options: [
+        { label: "None", description: "Standard behavior" },
+        {
+          label: "rebase=no push=no",
+          description: "Not my branch, skip rebase/push",
+        },
+        { label: "slide-out=no", description: "Never auto-slide-out" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If qualifiers selected:
+
+```bash
+git machete anno "$branch" "$qualifiers"
+```
+
+## Step 7: Verify and Show Status
+
+```bash
+echo "=== Branch added to stack ==="
+git machete status --list-commits
+```
+
 </process>
+
+<qualifiers_reference>
+
+| Qualifier      | Effect                           | When to Use                       |
+| -------------- | -------------------------------- | --------------------------------- |
+| `rebase=no`    | Skip rebase during traverse      | Branch you don't own              |
+| `push=no`      | Skip push during traverse        | Branch you don't own              |
+| `slide-out=no` | Don't auto-slide-out when merged | Branch that should stay in layout |
+
+**Combining qualifiers:**
+
+```bash
+git machete anno feature-x "PR #123 rebase=no push=no"
+```
+
+**Removing qualifiers:**
+
+```bash
+git machete anno feature-x ""
+# Or keep just PR annotation:
+git machete anno feature-x "PR #123"
+```
+
+</qualifiers_reference>
+
+<stacking_strategies>
+
+**Linear stack:**
+
+```
+main
+    feature-part-1
+        feature-part-2
+            feature-part-3
+```
+
+**Fan-out from main:**
+
+```
+main
+    feature-a
+    feature-b
+    feature-c
+```
+
+**Mixed:**
+
+```
+main
+    feature-base
+        feature-part-1
+        feature-part-2
+    hotfix
+```
+
+</stacking_strategies>
+
+<after_adding>
+
+After adding a branch to the stack:
+
+1. **Create PR:** `Skill({ skill: "crew:git:pr" })`
+2. **Sync stack:** `Skill({ skill: "crew:git:traverse" })`
+3. **View status:** `Skill({ skill: "crew:git:stack-status" })`
+
+</after_adding>
+
+<success_criteria>
+
+- [ ] Branch added to machete layout
+- [ ] Correct parent branch selected
+- [ ] Qualifiers applied (if needed)
+- [ ] Status shows correct tree structure
+
+</success_criteria>

--- a/crew/commands/git/stack-status.md
+++ b/crew/commands/git/stack-status.md
@@ -1,6 +1,6 @@
 ---
 name: crew:git:stack-status
-description: Show git-machete branch stack status
+description: Show git-machete branch stack status with visual indicators
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoWrite, WebFetch, WebSearch, MCPSearch, Skill
 ---
 
@@ -14,19 +14,22 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoW
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
 </stack_context>
 
-<indicators>
+<edge_colors>
 
-| Edge  | Meaning             |
-| ----- | ------------------- |
-| Green | In sync with parent |
-| Red   | Needs rebase        |
-| Gray  | Merged into parent  |
+| Color           | Meaning                         | Action                                       |
+| --------------- | ------------------------------- | -------------------------------------------- |
+| 🟢 **Green**    | In sync with parent             | No action needed                             |
+| 🟡 **Yellow**   | In sync, but fork point differs | Hidden commits exist, may need investigation |
+| 🔴 **Red**      | Out of sync with parent         | Run `Skill({ skill: "crew:git:sync" })`      |
+| ⚫ **Gray** (o) | Merged into parent              | Run `Skill({ skill: "crew:git:slide-out" })` |
 
-</indicators>
+</edge_colors>
 
 <process>
 
-1. If no layout:
+## Step 1: Check for Layout
+
+If no layout:
 
 ```javascript
 AskUserQuestion({
@@ -35,7 +38,10 @@ AskUserQuestion({
       question: "No git-machete layout found. What to do?",
       header: "Setup",
       options: [
-        { label: "Discover layout", description: "Auto-detect from history" },
+        {
+          label: "Discover layout (Recommended)",
+          description: "Auto-detect from history",
+        },
         { label: "Skip", description: "Continue without machete" },
       ],
       multiSelect: false,
@@ -44,13 +50,145 @@ AskUserQuestion({
 });
 ```
 
-2. Show status:
+If "Discover layout":
+
+```javascript
+Skill({ skill: "crew:git:discover" });
+```
+
+## Step 2: Update PR Annotations
 
 ```bash
-git machete github anno-prs  # Add PR numbers
+# Annotate branches with PR numbers and URLs
+git machete github anno-prs 2>/dev/null || true
+```
+
+## Step 3: Show Status
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What level of detail?",
+      header: "Detail",
+      options: [
+        { label: "Summary", description: "Branch tree only" },
+        {
+          label: "With commits (Recommended)",
+          description: "Show commits per branch",
+        },
+        { label: "Full", description: "Commits + fork points + remotes" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+**Summary:**
+
+```bash
+git machete status
+```
+
+**With commits:**
+
+```bash
 git machete status --list-commits
 ```
 
-3. Highlight: red edges (need rebase), gray edges (can slide out)
+**Full:**
+
+```bash
+git machete status --list-commits --list-commits-with-hashes
+echo
+echo "=== Fork Points ==="
+for branch in $(git machete list managed); do
+    fp=$(git machete fork-point "$branch" 2>/dev/null || echo "unknown")
+    echo "$branch: $fp"
+done
+```
+
+## Step 4: Analyze Issues
+
+```bash
+status_output=$(git machete status 2>/dev/null)
+
+# Count issues
+red_count=$(echo "$status_output" | grep -c "^[^o].*[│├└]" 2>/dev/null || echo "0")
+merged_count=$(echo "$status_output" | grep -cE "^\s*o\s" 2>/dev/null || echo "0")
+```
+
+## Step 5: Suggest Actions
+
+If issues detected, suggest next steps:
+
+**If red edges (out of sync):**
+
+```
+⚠️ $red_count branch(es) out of sync with parent.
+
+Recommended: Run `Skill({ skill: "crew:git:traverse" })` to sync all branches.
+```
+
+**If gray edges (merged):**
+
+```
+🔀 $merged_count merged branch(es) detected.
+
+Recommended: Run `Skill({ skill: "crew:git:slide-out" })` to clean up.
+```
+
+**If all green:**
+
+```
+✅ All branches are in sync!
+```
 
 </process>
+
+<annotations>
+
+Branches may have annotations showing:
+
+- **PR #123** — GitHub PR number
+- **rebase=no** — Skip rebase during traverse (not your branch)
+- **push=no** — Skip push during traverse (not your branch)
+- **slide-out=no** — Don't auto-slide-out when merged
+
+**Example status output:**
+
+```
+  main
+  │
+  ├─ feature-auth  PR #45
+  │  │
+  │  └─ feature-auth-tests  PR #46 rebase=no push=no
+  │
+  └─o feature-old  PR #30  (merged)
+```
+
+</annotations>
+
+<quick_actions>
+
+After viewing status, common next steps:
+
+| Situation                  | Command                                  |
+| -------------------------- | ---------------------------------------- |
+| Branches out of sync       | `Skill({ skill: "crew:git:traverse" })`  |
+| Merged branches to clean   | `Skill({ skill: "crew:git:slide-out" })` |
+| Need to add current branch | `Skill({ skill: "crew:git:stack-add" })` |
+| Navigate to another branch | `Skill({ skill: "crew:git:go" })`        |
+| Create PR for branch       | `Skill({ skill: "crew:git:pr" })`        |
+
+</quick_actions>
+
+<success_criteria>
+
+- [ ] Status displayed with proper edge coloring
+- [ ] PR annotations shown (if GitHub PRs exist)
+- [ ] Issues identified (red/gray edges)
+- [ ] Next action suggestions provided
+
+</success_criteria>

--- a/crew/commands/git/traverse.md
+++ b/crew/commands/git/traverse.md
@@ -29,13 +29,23 @@ AskUserQuestion({
       question: "No git-machete layout. What to do?",
       header: "Setup",
       options: [
-        { label: "Discover layout", description: "Auto-detect from history" },
+        {
+          label: "Discover layout (Recommended)",
+          description: "Auto-detect from history",
+        },
         { label: "Create manually", description: "Open editor" },
         { label: "Skip", description: "Continue without machete" },
       ],
+      multiSelect: false,
     },
   ],
 });
+```
+
+If "Discover layout":
+
+```javascript
+Skill({ skill: "crew:git:discover" });
 ```
 
 **If in a WORKTREE:**
@@ -92,11 +102,90 @@ To sync your stack across worktrees:
 
 **If in MAIN checkout (not a worktree):**
 
-Full traverse is safe:
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "How should traverse handle GitHub PRs?",
+      header: "PR Sync",
+      options: [
+        { label: "Local only", description: "Just rebase branches locally" },
+        {
+          label: "Retarget PRs (Recommended)",
+          description: "Update PR base branches on GitHub",
+        },
+        {
+          label: "Full sync",
+          description: "Retarget + update PR descriptions",
+        },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+**Local only:**
 
 ```bash
-git machete traverse -W -y      # Basic sync
-git machete traverse -W -y -H   # With PR retargeting
+git machete traverse -W -y
+```
+
+**Retarget PRs:**
+
+```bash
+git machete traverse -W -y -H
+```
+
+**Full sync:**
+
+```bash
+git machete traverse -W -y -H
+
+# Ensure config is set for update-pr-descriptions
+git config machete.github.prDescriptionIntroStyle full
+
+# Update all related PR descriptions with stack chain
+git machete github update-pr-descriptions --related
+```
+
+## Post-Traverse Actions
+
+After traverse completes, check for merged branches:
+
+```bash
+# Check for merged branches (gray edges)
+merged=$(git machete status 2>/dev/null | grep -cE "^\s*o\s" || echo "0")
+if [[ "$merged" -gt 0 ]]; then
+    echo "🔀 $merged merged branch(es) detected"
+fi
+```
+
+If merged branches found:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Merged branches detected. Clean them up?",
+      header: "Cleanup",
+      options: [
+        {
+          label: "Yes (Recommended)",
+          description: "Slide out merged branches",
+        },
+        { label: "No", description: "Keep them in the layout" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+If yes:
+
+```javascript
+Skill({ skill: "crew:git:slide-out" });
 ```
 
 Report: branches rebased, pushed, needing manual intervention.
@@ -105,10 +194,46 @@ Report: branches rebased, pushed, needing manual intervention.
 
 <flags>
 
-| Flag | Effect                        |
-| ---- | ----------------------------- |
-| `-W` | Fetch + traverse entire tree  |
-| `-y` | Auto-confirm                  |
-| `-H` | Include GitHub PR retargeting |
+| Flag                    | Effect                                       |
+| ----------------------- | -------------------------------------------- |
+| `-W`                    | Fetch + traverse entire tree (whole)         |
+| `-y`                    | Auto-confirm all prompts (yes)               |
+| `-H`                    | Include GitHub PR retargeting (github-sync)  |
+| `-n`                    | No push (rebase only, don't push)            |
+| `-M`                    | Detect merged branches and suggest slide-out |
+| `--start-from=<branch>` | Start traverse from specific branch          |
+| `--return-to=<branch>`  | Return to branch after traverse              |
 
 </flags>
+
+<common_patterns>
+
+**Daily sync workflow:**
+
+```bash
+# Full sync with PR updates
+git machete traverse -W -y -H
+```
+
+**Quick local rebase:**
+
+```bash
+# No push, no GitHub sync
+git machete traverse -W -y -n
+```
+
+**After parent PR merged:**
+
+```bash
+# Slide out merged, then traverse
+Skill({ skill: "crew:git:slide-out" })
+git machete traverse -W -y -H
+```
+
+**Sync and cleanup:**
+
+```bash
+git machete traverse -W -y -H -M
+```
+
+</common_patterns>

--- a/crew/commands/git/update-pr.md
+++ b/crew/commands/git/update-pr.md
@@ -140,6 +140,9 @@ EOF
 **If machete-managed:**
 
 ```bash
+# Ensure config is set for full PR description intro (required for --related)
+git config machete.github.prDescriptionIntroStyle full
+
 git machete github anno-prs
 git machete github update-pr-descriptions --related
 ```

--- a/crew/scripts/git/machete-context.sh
+++ b/crew/scripts/git/machete-context.sh
@@ -9,16 +9,34 @@ set -euo pipefail
 
 # Check if git-machete is installed
 if ! command -v git-machete &>/dev/null; then
-	echo "## Git Machete"
-	echo "⚠️ git-machete is not installed."
-	echo "Install with: \`brew install git-machete\` or \`pip install git-machete\`"
-	echo
-	exit 0
+  echo "## Git Machete"
+  echo "⚠️ git-machete is not installed."
+  echo "Install with: \`brew install git-machete\` or \`pip install git-machete\`"
+  echo
+  exit 0
 fi
+
+# Ensure optimal machete configuration
+# prDescriptionIntroStyle=full: Required for update-pr-descriptions --related
+# squashMergeDetection=simple: Detect squash-merged PRs as merged
+# annotateWithUrls=true: Include full PR URLs in annotations
+configure_machete_setting() {
+  local key="$1"
+  local value="$2"
+  local current
+  current=$(git config --get "$key" 2>/dev/null || echo "")
+  if [[ "$current" != "$value" ]]; then
+    git config "$key" "$value"
+  fi
+}
+
+configure_machete_setting "machete.github.prDescriptionIntroStyle" "full"
+configure_machete_setting "machete.squashMergeDetection" "simple"
+configure_machete_setting "machete.github.annotateWithUrls" "true"
 
 # Check if in a git repo
 if ! git rev-parse --git-dir &>/dev/null; then
-	exit 0
+  exit 0
 fi
 
 branch=$(git branch --show-current 2>/dev/null || echo "")
@@ -33,87 +51,103 @@ echo
 
 # Check if machete file exists
 if [[ -f "$machete_file" ]]; then
-	echo "**Layout file:** \`${machete_file}\`"
-	echo
+  echo "**Layout file:** \`${machete_file}\`"
+  echo
 
-	# Check if current branch is in machete layout
-	if git machete is-managed "$branch" 2>/dev/null; then
-		echo "**Current branch:** \`$branch\` is in machete layout"
+  # Check if current branch is in machete layout
+  if git machete is-managed "$branch" 2>/dev/null; then
+    echo "**Current branch:** \`$branch\` is in machete layout"
 
-		# Get parent branch
-		parent=$(git machete show up 2>/dev/null || echo "")
-		if [[ -n "$parent" ]]; then
-			echo "**Parent branch:** \`$parent\`"
-		else
-			echo "**Parent branch:** (root branch)"
-		fi
+    # Get parent branch
+    parent=$(git machete show up 2>/dev/null || echo "")
+    if [[ -n "$parent" ]]; then
+      echo "**Parent branch:** \`$parent\`"
+    else
+      echo "**Parent branch:** (root branch)"
+    fi
 
-		# Get child branches
-		children=$(git machete show down 2>/dev/null || echo "")
-		if [[ -n "$children" ]]; then
-			echo "**Child branches:** \`$children\`"
-		fi
+    # Get child branches
+    children=$(git machete show down 2>/dev/null || echo "")
+    if [[ -n "$children" ]]; then
+      echo "**Child branches:** \`$children\`"
+    fi
 
-		# Check sync status
-		echo
-		echo "### Sync Status"
-		echo '```'
-		git machete status 2>/dev/null | head -20 || echo "(unable to get status)"
-		echo '```'
+    # Check sync status
+    echo
+    echo "### Sync Status"
+    echo '```'
+    status_output=$(git machete status 2>/dev/null | head -25 || echo "(unable to get status)")
+    echo "$status_output"
+    echo '```'
 
-		# Check if out of sync with parent
-		if [[ -n "$parent" ]]; then
-			if ! git machete is-ancestor "$parent" "$branch" 2>/dev/null; then
-				echo
-				echo "⚠️ **Out of sync with parent** - consider running \`git machete update\`"
-			fi
-		fi
-	else
-		echo "**Current branch:** \`$branch\` is NOT in machete layout"
-		echo
-		echo "To add to stack: \`git machete add --onto <parent-branch>\`"
-		echo
-		echo "### Current Layout"
-		echo '```'
-		cat "$machete_file" 2>/dev/null | head -20 || echo "(unable to read)"
-		echo '```'
-		echo
-		echo "### Available Parent Branches"
-		echo "Use these to populate stacking question options:"
-		echo '```json'
-		echo "["
-		echo '  { "branch": "main", "description": "Main branch" }'
+    # Detect merged branches (gray edges indicated by 'o' prefix in status)
+    merged_count=$(echo "$status_output" | grep -cE "^\s*o\s" 2>/dev/null || echo "0")
+    if [[ "$merged_count" -gt 0 ]]; then
+      echo
+      echo "🔀 **$merged_count merged branch(es) detected** — run \`Skill({ skill: \"crew:git:slide-out\" })\` to clean up"
+    fi
 
-		# Get open PRs that could be parent branches
-		if command -v gh &>/dev/null; then
-			gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
-		fi
+    # Check if out of sync with parent
+    if [[ -n "$parent" ]]; then
+      if ! git machete is-ancestor "$parent" "$branch" 2>/dev/null; then
+        echo
+        echo "⚠️ **Out of sync with parent** — run \`Skill({ skill: \"crew:git:sync\" })\` or \`git machete update\`"
+      fi
+    fi
 
-		echo "]"
-		echo '```'
-	fi
+    # Edge coloring legend
+    echo
+    echo "### Edge Colors"
+    echo "- 🟢 **Green**: In sync with parent"
+    echo "- 🟡 **Yellow**: In sync but fork point differs (hidden commits)"
+    echo "- 🔴 **Red**: Out of sync, needs rebase"
+    echo "- ⚫ **Gray (o)**: Merged into parent, can be slid out"
+  else
+    echo "**Current branch:** \`$branch\` is NOT in machete layout"
+    echo
+    echo "To add to stack: \`git machete add --onto <parent-branch>\`"
+    echo
+    echo "### Current Layout"
+    echo '```'
+    cat "$machete_file" 2>/dev/null | head -20 || echo "(unable to read)"
+    echo '```'
+    echo
+    echo "### Available Parent Branches"
+    echo "Use these to populate stacking question options:"
+    echo '```json'
+    echo "["
+    echo '  { "branch": "main", "description": "Main branch" }'
+
+    # Get open PRs that could be parent branches
+    if command -v gh &>/dev/null; then
+      gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
+    fi
+
+    echo "]"
+    echo '```'
+  fi
 else
-	echo "**No machete layout** - \`${machete_file}\` does not exist"
-	echo
-	echo "To set up stacked branches:"
-	echo "1. \`git machete discover\` - auto-detect layout"
-	echo "2. \`git machete edit\` - manually define layout"
-	echo
-	echo "**Note:** In worktrees, the machete file is shared with the main repo."
-	echo
-	echo "### Available Parent Branches"
-	echo "Use these to populate stacking question options:"
-	echo '```json'
-	echo "["
-	echo '  { "branch": "main", "description": "Main branch" }'
+  echo "**No machete layout** - \`${machete_file}\` does not exist"
+  echo
+  echo "To set up stacked branches, run \`Skill({ skill: \"crew:git:discover\" })\` or:"
+  echo "1. \`git machete discover\` - auto-detect layout from reflog"
+  echo "2. \`git machete edit\` - manually define layout"
+  echo
+  echo "**Note:** In worktrees, the machete file is shared with the main repo."
+  echo
+  echo "### Available Parent Branches"
+  echo "Use these to populate stacking question options:"
+  echo '```json'
+  echo "["
+  echo '  { "branch": "main", "description": "Main branch" }'
 
-	# Get open PRs that could be parent branches
-	if command -v gh &>/dev/null; then
-		gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
-	fi
+  # Get open PRs that could be parent branches
+  if command -v gh &>/dev/null; then
+    gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
+  fi
 
-	echo "]"
-	echo '```'
+  echo "]"
+  echo '```'
 fi
 
 echo

--- a/crew/skills/git/SKILL.md
+++ b/crew/skills/git/SKILL.md
@@ -17,17 +17,44 @@ Git workflow guidance: conventional commits, branch naming, PR workflows.
 
 <routing>
 
-| Task          | Resource                    |
-| ------------- | --------------------------- |
-| Commit format | `references/conventions.md` |
-| Branch naming | `references/conventions.md` |
-| PR workflow   | `references/conventions.md` |
-| Feature PR    | `templates/pr-feature.md`   |
-| Bug fix PR    | `templates/pr-fix.md`       |
-| Refactor PR   | `templates/pr-refactor.md`  |
-| Quick PR      | `templates/pr-default.md`   |
+| Task          | Resource                      |
+| ------------- | ----------------------------- |
+| Commit format | `references/conventions.md`   |
+| Branch naming | `references/conventions.md`   |
+| PR workflow   | `references/conventions.md`   |
+| Machete hooks | `references/machete-hooks.md` |
+| Feature PR    | `templates/pr-feature.md`     |
+| Bug fix PR    | `templates/pr-fix.md`         |
+| Refactor PR   | `templates/pr-refactor.md`    |
+| Quick PR      | `templates/pr-default.md`     |
 
 </routing>
+
+<commands>
+
+| Command                                          | Purpose                               |
+| ------------------------------------------------ | ------------------------------------- |
+| `Skill({ skill: "crew:git:setup" })`             | Configure git + machete optimally     |
+| `Skill({ skill: "crew:git:discover" })`          | Auto-detect branch layout             |
+| `Skill({ skill: "crew:git:pr" })`                | Create PR with template               |
+| `Skill({ skill: "crew:git:update-pr" })`         | Update PR title/body                  |
+| `Skill({ skill: "crew:git:stack-status" })`      | View branch stack status              |
+| `Skill({ skill: "crew:git:stack-add" })`         | Add branch to stack                   |
+| `Skill({ skill: "crew:git:traverse" })`          | Sync all stacked branches             |
+| `Skill({ skill: "crew:git:sync" })`              | Sync current branch with parent       |
+| `Skill({ skill: "crew:git:slide-out" })`         | Remove merged branch from stack       |
+| `Skill({ skill: "crew:git:advance" })`           | Fast-forward merge child into current |
+| `Skill({ skill: "crew:git:go" })`                | Navigate stack (up/down/next/prev)    |
+| `Skill({ skill: "crew:git:checkout-prs" })`      | Checkout PRs from GitHub              |
+| `Skill({ skill: "crew:git:retarget-pr" })`       | Change PR base branch                 |
+| `Skill({ skill: "crew:git:restack-pr" })`        | Retarget + force push atomically      |
+| `Skill({ skill: "crew:git:cleanup-unmanaged" })` | Delete branches not in layout         |
+| `Skill({ skill: "crew:git:commit" })`            | Create conventional commit            |
+| `Skill({ skill: "crew:git:branch" })`            | Create feature branch                 |
+| `Skill({ skill: "crew:git:push" })`              | Push current branch                   |
+| `Skill({ skill: "crew:git:clean" })`             | Clean stale branches                  |
+
+</commands>
 
 <scripts>
 

--- a/crew/skills/git/references/machete-hooks.md
+++ b/crew/skills/git/references/machete-hooks.md
@@ -1,0 +1,238 @@
+# Git Machete Hooks Integration
+
+<objective>
+Document and provide templates for git-machete custom hooks that integrate with crew workflows.
+</objective>
+
+## Available Hooks
+
+Git-machete supports custom hooks executed from the repository root:
+
+| Hook                     | Trigger                           | Arguments                                                 |
+| ------------------------ | --------------------------------- | --------------------------------------------------------- |
+| `machete-post-slide-out` | After branch removal              | `<new-upstream> <lowest-slid-out> [<new-downstreams>...]` |
+| `machete-pre-rebase`     | Before rebase operations          | `<new-base> <fork-point> <branch>`                        |
+| `machete-status-branch`  | Per-branch during status/traverse | `<branch-name>`                                           |
+
+## Hook Location
+
+Hooks are placed in `.git/hooks/` with the name matching the hook type.
+
+```bash
+.git/hooks/
+├── machete-post-slide-out   # Executable script
+├── machete-pre-rebase       # Executable script
+└── machete-status-branch    # Executable script
+```
+
+## Hook Templates
+
+### machete-post-slide-out
+
+Called after a branch is slid out. Use to update PR descriptions or notify team.
+
+```bash
+#!/usr/bin/env bash
+# .git/hooks/machete-post-slide-out
+#
+# Arguments:
+#   $1 - new upstream branch
+#   $2 - lowest slid-out branch
+#   $3+ - new downstream branches (children of slid-out)
+#
+set -euo pipefail
+
+new_upstream="$1"
+slid_out="$2"
+shift 2
+downstreams=("$@")
+
+echo "Branch '$slid_out' was slid out"
+echo "New upstream: $new_upstream"
+echo "New downstreams: ${downstreams[*]:-none}"
+
+# Update PR descriptions for all related PRs
+git config machete.github.prDescriptionIntroStyle full
+git machete github update-pr-descriptions --related 2>/dev/null || true
+
+# Optional: Delete the remote branch
+# git push origin --delete "$slid_out" 2>/dev/null || true
+
+# Optional: Notify via webhook
+# curl -X POST "$SLACK_WEBHOOK" -d "{\"text\": \"Branch $slid_out merged and cleaned up\"}"
+```
+
+### machete-pre-rebase
+
+Called before rebase. Use to run checks or prevent rebases on certain branches.
+
+```bash
+#!/usr/bin/env bash
+# .git/hooks/machete-pre-rebase
+#
+# Arguments:
+#   $1 - new base commit
+#   $2 - fork point commit
+#   $3 - branch being rebased
+#
+# Exit non-zero to abort the rebase
+#
+set -euo pipefail
+
+new_base="$1"
+fork_point="$2"
+branch="$3"
+
+# Prevent rebase on protected branches
+protected_branches=("main" "master" "develop" "release")
+for protected in "${protected_branches[@]}"; do
+    if [[ "$branch" == "$protected" ]]; then
+        echo "ERROR: Cannot rebase protected branch '$branch'"
+        exit 1
+    fi
+done
+
+# Optional: Run linting before rebase
+# if ! npm run lint --if-present 2>/dev/null; then
+#     echo "WARNING: Lint issues found, but continuing with rebase"
+# fi
+
+# Optional: Check for work in progress
+if git log --oneline "$fork_point..$branch" | grep -qi "wip\|fixup\|squash"; then
+    echo "WARNING: Found WIP/fixup commits that should be cleaned up"
+fi
+
+exit 0
+```
+
+### machete-status-branch
+
+Called per-branch during `status`, `discover`, and `traverse`. Output is appended to the branch line.
+
+```bash
+#!/usr/bin/env bash
+# .git/hooks/machete-status-branch
+#
+# Arguments:
+#   $1 - branch name
+#
+# Output is appended to the status line for this branch
+#
+set -euo pipefail
+
+branch="$1"
+
+# Show CI status for branches with PRs
+pr_number=$(gh pr view "$branch" --json number -q '.number' 2>/dev/null || echo "")
+if [[ -n "$pr_number" ]]; then
+    # Get CI check status
+    checks=$(gh pr checks "$pr_number" 2>/dev/null || echo "")
+
+    if echo "$checks" | grep -q "fail"; then
+        echo " ❌"
+    elif echo "$checks" | grep -q "pending"; then
+        echo " ⏳"
+    elif echo "$checks" | grep -q "pass"; then
+        echo " ✅"
+    fi
+fi
+
+# Optional: Show last commit date
+# last_commit=$(git log -1 --format="%cr" "$branch" 2>/dev/null || echo "")
+# if [[ -n "$last_commit" ]]; then
+#     echo " ($last_commit)"
+# fi
+```
+
+## Installing Hooks
+
+### Manual Installation
+
+```bash
+# Create hooks directory if needed
+mkdir -p .git/hooks
+
+# Create hook file
+cat > .git/hooks/machete-status-branch << 'EOF'
+#!/usr/bin/env bash
+branch="$1"
+pr_number=$(gh pr view "$branch" --json number -q '.number' 2>/dev/null || echo "")
+if [[ -n "$pr_number" ]]; then
+    checks=$(gh pr checks "$pr_number" 2>/dev/null || echo "")
+    if echo "$checks" | grep -q "fail"; then echo " ❌"
+    elif echo "$checks" | grep -q "pending"; then echo " ⏳"
+    elif echo "$checks" | grep -q "pass"; then echo " ✅"
+    fi
+fi
+EOF
+
+# Make executable
+chmod +x .git/hooks/machete-status-branch
+```
+
+### Via crew:git:setup
+
+The `Skill({ skill: "crew:git:setup" })` command can optionally install these hooks during setup.
+
+## Hook Behavior
+
+- **Non-zero exit** from `machete-pre-rebase` aborts the rebase
+- **Non-zero exit** from `machete-post-slide-out` aborts subsequent operations
+- **Output** from `machete-status-branch` is appended to the status line
+- Hooks run from the **repository root directory**
+
+## Integration with Crew Workflows
+
+### After slide-out, update PRs
+
+The `machete-post-slide-out` hook can automatically trigger:
+
+```bash
+# In the hook:
+git machete github update-pr-descriptions --related
+```
+
+This keeps all PR descriptions updated with the correct stack chain.
+
+### CI status in stack-status
+
+The `machete-status-branch` hook can show CI status:
+
+```
+  main
+  │
+  ├─ feature-auth  PR #45 ✅
+  │  │
+  │  └─ feature-auth-tests  PR #46 ⏳
+  │
+  └─ feature-api  PR #47 ❌
+```
+
+### Pre-rebase validation
+
+Use `machete-pre-rebase` to:
+
+- Prevent rebasing protected branches
+- Run pre-commit checks
+- Warn about WIP commits
+
+## Troubleshooting
+
+**Hook not running:**
+
+```bash
+# Check hook is executable
+ls -la .git/hooks/machete-*
+
+# Check hook syntax
+bash -n .git/hooks/machete-status-branch
+```
+
+**Hook slowing down status:**
+
+```bash
+# Profile the hook
+time .git/hooks/machete-status-branch main
+```
+
+Consider caching results or making GitHub API calls asynchronous.

--- a/devtools/skills/git-machete/workflows/cleanup.md
+++ b/devtools/skills/git-machete/workflows/cleanup.md
@@ -153,6 +153,13 @@ git machete slide-out --no-rebase feature-x
 git machete traverse -W -y
 ```
 
+Or using crew commands:
+
+```javascript
+Skill({ skill: "crew:git:slide-out" });
+Skill({ skill: "crew:git:traverse" });
+```
+
 **Scenario: Multiple branches merged:**
 
 ```bash
@@ -166,7 +173,26 @@ git machete traverse -W -y
 git machete slide-out --delete feature-x
 ```
 
+**Scenario: Delete all unmanaged branches:**
+
+```javascript
+Skill({ skill: "crew:git:cleanup-unmanaged" });
+```
+
 </common_scenarios>
+
+<related_commands>
+
+| Task                      | Crew Command                                     |
+| ------------------------- | ------------------------------------------------ |
+| View stack status         | `Skill({ skill: "crew:git:stack-status" })`      |
+| Slide out merged branches | `Skill({ skill: "crew:git:slide-out" })`         |
+| Sync all branches         | `Skill({ skill: "crew:git:traverse" })`          |
+| Delete unmanaged branches | `Skill({ skill: "crew:git:cleanup-unmanaged" })` |
+| Clean stale remote refs   | `Skill({ skill: "crew:git:clean" })`             |
+| Fast-forward merge child  | `Skill({ skill: "crew:git:advance" })`           |
+
+</related_commands>
 
 <success_criteria>
 


### PR DESCRIPTION
## Summary

This PR significantly enhances the crew plugin's git workflow capabilities by adding 8 new commands for git-machete integration, enhancing existing commands, and adding comprehensive documentation.

## New commands

| Command | Purpose |
|---------|---------|
| `crew:git:setup` | Configure git + machete with optimal settings (including Git core dev recommendations) |
| `crew:git:discover` | Auto-detect branch layout from git reflog |
| `crew:git:advance` | Fast-forward merge child into current, then slide out |
| `crew:git:checkout-prs` | Checkout PRs from GitHub (`--mine`, `--all`, `--by=<user>`) |
| `crew:git:retarget-pr` | Change PR base to match machete parent |
| `crew:git:restack-pr` | Retarget + force push atomically with draft state management |
| `crew:git:go` | Navigate stack (up/down/next/prev/root) |
| `crew:git:cleanup-unmanaged` | Delete local branches not in machete layout |

## Enhanced commands

- **machete-context.sh**: Auto-configures `squashMergeDetection`, `prDescriptionIntroStyle`, `annotateWithUrls`; adds merge detection with `Skill()` suggestions
- **traverse**: Adds PR sync options (local only / retarget / full sync), post-traverse cleanup suggestions
- **stack-status**: Adds edge color legend, quick action suggestions, detail level options
- **stack-add**: Adds qualifiers support (`rebase=no`, `push=no`, `slide-out=no`)
- **pr**: Adds PR template detection for repository templates
- **update-pr**: Ensures config is set before `update-pr-descriptions --related`

## Git performance settings

The `crew:git:setup` command now includes Git performance settings recommended by Git core developers:
- `diff.algorithm histogram` (better than myers from 1986)
- `diff.colorMoved plain` (highlight moved code)
- `push.autoSetupRemote true`
- `fetch.prune true` / `fetch.pruneTags true`
- Optional: `core.fsmonitor` and `core.untrackedCache` for large repos

## New documentation

- `crew/skills/git/references/machete-hooks.md`: Templates for `machete-post-slide-out`, `machete-pre-rebase`, `machete-status-branch` hooks
- Updated `crew/skills/git/SKILL.md` with complete command reference table

## Test plan

- [ ] Run `Skill({ skill: "crew:git:setup" })` and verify config is applied
- [ ] Run `Skill({ skill: "crew:git:stack-status" })` and verify edge colors display
- [ ] Run `Skill({ skill: "crew:git:traverse" })` and verify PR sync options appear
- [ ] Verify `machete-context.sh` auto-configures settings on execution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive git-machete integration with 8 new commands for setup, discovery, navigation, PR sync, and cleanup. Improves stack visibility and PR automation, and applies Git performance defaults.

- **New Features**
  - 8 new commands: crew:git:setup, discover, go, advance, checkout-prs, retarget-pr, restack-pr, cleanup-unmanaged.
  - crew:git:setup applies optimal machete config and Git performance defaults (histogram diffs, colorMoved, push.autoSetupRemote, fetch.prune/pruneTags; optional fsmonitor/untrackedCache).

- **Improvements**
  - traverse: PR sync modes (local only / retarget / full), plus post-traverse cleanup suggestions.
  - stack-status: edge color legend, detail levels, and quick action hints.
  - stack-add: supports qualifiers (rebase=no, push=no, slide-out=no).
  - pr/update-pr: detects repository PR templates; ensures prDescriptionIntroStyle=full before update-pr-descriptions --related.
  - machete-context.sh: auto-configures machete settings and surfaces sync/cleanup suggestions.
  - Docs: new machete hooks reference, expanded SKILL command table, and command guides.

<sup>Written for commit 13ba396ce2bf2c21c5ab397a12934c4ed4658dbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

