### PR TITLE
feat(hooks): auto-wrap long-running commands with temp file logging

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/hooks/hooks.json
+++ b/crew/hooks/hooks.json
@@ -49,6 +49,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/wrap-long-output.sh"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/suggest-skill.sh"
           }
         ]

--- a/crew/scripts/hooks/pre-tool/wrap-long-output.sh
+++ b/crew/scripts/hooks/pre-tool/wrap-long-output.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Automatically wrap long-running commands to capture output in temp file
+# This prevents context window pollution from verbose command output
+
+set +e
+
+INPUT=$(cat)
+
+# Extract tool name and command
+read -r TOOL_NAME COMMAND < <(echo "$INPUT" | jq -r '[.tool_name // "", .tool_input.command // ""] | @tsv' 2>/dev/null)
+
+# Only process Bash tool
+[[ $TOOL_NAME != "Bash" ]] && exit 0
+
+# Skip if command is empty
+[[ -z $COMMAND ]] && exit 0
+
+# Skip if command already has output redirection (user knows what they're doing)
+# Patterns: |, >, >>, 2>, 2>&1, &>, tee
+if [[ $COMMAND =~ \|[[:space:]] ]] ||
+	[[ $COMMAND =~ \>[[:space:]] ]] ||
+	[[ $COMMAND =~ \>\> ]] ||
+	[[ $COMMAND =~ 2\> ]] ||
+	[[ $COMMAND =~ \&\> ]] ||
+	[[ $COMMAND =~ tee[[:space:]] ]]; then
+	exit 0
+fi
+
+# Skip simple/quick commands that don't need wrapping
+# These are fast and produce minimal output
+SKIP_PATTERNS=(
+	"^ls[[:space:]]"
+	"^cd[[:space:]]"
+	"^pwd$"
+	"^echo[[:space:]]"
+	"^cat[[:space:]]"
+	"^head[[:space:]]"
+	"^tail[[:space:]]"
+	"^grep[[:space:]]"
+	"^find[[:space:]]"
+	"^which[[:space:]]"
+	"^whoami$"
+	"^git[[:space:]]+(status|log|diff|branch|show|rev-parse)"
+	"^git[[:space:]]+add"
+	"^git[[:space:]]+checkout"
+	"^git[[:space:]]+stash"
+	"^git[[:space:]]+fetch"
+	"^mkdir[[:space:]]"
+	"^rm[[:space:]]"
+	"^mv[[:space:]]"
+	"^cp[[:space:]]"
+	"^touch[[:space:]]"
+	"^chmod[[:space:]]"
+	"^export[[:space:]]"
+	"^source[[:space:]]"
+	"^\.[[:space:]]"
+	"^read[[:space:]]"
+	"^sleep[[:space:]]"
+	"^kill[[:space:]]"
+	"^pkill[[:space:]]"
+	"^curl[[:space:]].*-s"
+	"^wget[[:space:]].*-q"
+	"^jq[[:space:]]"
+	"^sed[[:space:]]"
+	"^awk[[:space:]]"
+	"^sort[[:space:]]"
+	"^uniq[[:space:]]"
+	"^wc[[:space:]]"
+	"^date$"
+	"^hostname$"
+	"^uname"
+	"^env$"
+	"^printenv"
+	"^shfmt[[:space:]]"
+	"^shellcheck[[:space:]]"
+)
+
+for pattern in "${SKIP_PATTERNS[@]}"; do
+	if [[ $COMMAND =~ $pattern ]]; then
+		exit 0
+	fi
+done
+
+# Patterns that indicate long-running or verbose commands
+WRAP_PATTERNS=(
+	# Dev servers (run indefinitely)
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?dev([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?start([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?serve([[:space:]]|$)"
+	# Integration/E2E tests (slow, verbose)
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?test:(integration|e2e|smoke)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?test[[:space:]].*--run"
+	"playwright[[:space:]]+test"
+	"cypress[[:space:]]+run"
+	# Build commands (can be verbose)
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?build([[:space:]]|$)"
+	"turbo[[:space:]]+(run[[:space:]]+)?build"
+	"turbo[[:space:]]+(run[[:space:]]+)?test"
+	# Watch modes (run indefinitely)
+	"--watch"
+	"-w[[:space:]]"
+	# Docker builds (verbose)
+	"docker[[:space:]]+build"
+	"docker[[:space:]]+compose[[:space:]]+up"
+	"docker-compose[[:space:]]+up"
+	# Package installs (can be verbose)
+	"(npm|bun|pnpm|yarn)[[:space:]]+install([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+i([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+add[[:space:]]"
+	# Turbo commands (generally verbose)
+	"^turbo[[:space:]]"
+	# Database operations
+	"prisma[[:space:]]+(migrate|db[[:space:]]+push|generate)"
+	"drizzle-kit[[:space:]]+(push|generate|migrate)"
+	# Full test suites
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?test([[:space:]]|$)"
+	"^vitest([[:space:]]|$)"
+	"^jest([[:space:]]|$)"
+	# Linting full projects
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(lint|format|typecheck)([[:space:]]|$)"
+	"^biome[[:space:]]+(check|lint|format)"
+	"^eslint[[:space:]]"
+	"^tsc([[:space:]]|$)"
+	# CI/all commands
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?ci([[:space:]]|$)"
+	# Reset/setup scripts
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(reset|setup|dev:reset)"
+)
+
+SHOULD_WRAP=false
+for pattern in "${WRAP_PATTERNS[@]}"; do
+	if [[ $COMMAND =~ $pattern ]]; then
+		SHOULD_WRAP=true
+		break
+	fi
+done
+
+# Exit if command doesn't match any wrap patterns
+[[ $SHOULD_WRAP != true ]] && exit 0
+
+# Generate descriptive temp file name
+# Extract a meaningful slug from the command
+SLUG=$(echo "$COMMAND" | head -c 50 | tr -cs '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]' | sed 's/^-//;s/-$//')
+[[ -z $SLUG ]] && SLUG="cmd"
+TIMESTAMP=$(date +%H%M%S)
+LOGFILE="/tmp/claude-${SLUG}-${TIMESTAMP}.log"
+
+# Build the wrapped command
+# Use script for better terminal handling, or simple tee if script unavailable
+WRAPPED_CMD="{ ${COMMAND}; } 2>&1 | tee \"${LOGFILE}\"; echo \"\n📄 Full output saved: ${LOGFILE}\""
+
+# Return modified tool input
+jq -n \
+	--arg cmd "$WRAPPED_CMD" \
+	--arg msg "📝 Output will be saved to: ${LOGFILE}" \
+	'{
+    "hookResponse": {
+      "decision": "ALLOW",
+      "modifiedToolInput": {
+        "command": $cmd
+      }
+    },
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "message": $msg
+    }
+  }'
+
+exit 0

--- a/devtools/.claude-plugin/plugin.json
+++ b/devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devtools",
   "description": "Modern development tools for React, APIs, blockchain, databases, and testing. MCP-first skills with Context7 integration for up-to-date documentation.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "SettleMint",
     "email": "support@settlemint.com"

--- a/devtools/hooks/hooks.json
+++ b/devtools/hooks/hooks.json
@@ -17,6 +17,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/wrap-long-output.sh"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/suggest-skill.sh"
           }
         ]

--- a/devtools/scripts/hooks/pre-tool/wrap-long-output.sh
+++ b/devtools/scripts/hooks/pre-tool/wrap-long-output.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Automatically wrap long-running commands to capture output in temp file
+# This prevents context window pollution from verbose command output
+
+set +e
+
+INPUT=$(cat)
+
+# Extract tool name and command
+read -r TOOL_NAME COMMAND < <(echo "$INPUT" | jq -r '[.tool_name // "", .tool_input.command // ""] | @tsv' 2>/dev/null)
+
+# Only process Bash tool
+[[ $TOOL_NAME != "Bash" ]] && exit 0
+
+# Skip if command is empty
+[[ -z $COMMAND ]] && exit 0
+
+# Skip if command already has output redirection (user knows what they're doing)
+# Patterns: |, >, >>, 2>, 2>&1, &>, tee
+if [[ $COMMAND =~ \|[[:space:]] ]] ||
+	[[ $COMMAND =~ \>[[:space:]] ]] ||
+	[[ $COMMAND =~ \>\> ]] ||
+	[[ $COMMAND =~ 2\> ]] ||
+	[[ $COMMAND =~ \&\> ]] ||
+	[[ $COMMAND =~ tee[[:space:]] ]]; then
+	exit 0
+fi
+
+# Skip simple/quick commands that don't need wrapping
+# These are fast and produce minimal output
+SKIP_PATTERNS=(
+	"^ls[[:space:]]"
+	"^cd[[:space:]]"
+	"^pwd$"
+	"^echo[[:space:]]"
+	"^cat[[:space:]]"
+	"^head[[:space:]]"
+	"^tail[[:space:]]"
+	"^grep[[:space:]]"
+	"^find[[:space:]]"
+	"^which[[:space:]]"
+	"^whoami$"
+	"^git[[:space:]]+(status|log|diff|branch|show|rev-parse)"
+	"^git[[:space:]]+add"
+	"^git[[:space:]]+checkout"
+	"^git[[:space:]]+stash"
+	"^git[[:space:]]+fetch"
+	"^mkdir[[:space:]]"
+	"^rm[[:space:]]"
+	"^mv[[:space:]]"
+	"^cp[[:space:]]"
+	"^touch[[:space:]]"
+	"^chmod[[:space:]]"
+	"^export[[:space:]]"
+	"^source[[:space:]]"
+	"^\.[[:space:]]"
+	"^read[[:space:]]"
+	"^sleep[[:space:]]"
+	"^kill[[:space:]]"
+	"^pkill[[:space:]]"
+	"^curl[[:space:]].*-s"
+	"^wget[[:space:]].*-q"
+	"^jq[[:space:]]"
+	"^sed[[:space:]]"
+	"^awk[[:space:]]"
+	"^sort[[:space:]]"
+	"^uniq[[:space:]]"
+	"^wc[[:space:]]"
+	"^date$"
+	"^hostname$"
+	"^uname"
+	"^env$"
+	"^printenv"
+	"^shfmt[[:space:]]"
+	"^shellcheck[[:space:]]"
+)
+
+for pattern in "${SKIP_PATTERNS[@]}"; do
+	if [[ $COMMAND =~ $pattern ]]; then
+		exit 0
+	fi
+done
+
+# Patterns that indicate long-running or verbose commands
+WRAP_PATTERNS=(
+	# Dev servers (run indefinitely)
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?dev([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?start([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?serve([[:space:]]|$)"
+	# Integration/E2E tests (slow, verbose)
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?test:(integration|e2e|smoke)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?test[[:space:]].*--run"
+	"playwright[[:space:]]+test"
+	"cypress[[:space:]]+run"
+	# Build commands (can be verbose)
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?build([[:space:]]|$)"
+	"turbo[[:space:]]+(run[[:space:]]+)?build"
+	"turbo[[:space:]]+(run[[:space:]]+)?test"
+	# Watch modes (run indefinitely)
+	"--watch"
+	"-w[[:space:]]"
+	# Docker builds (verbose)
+	"docker[[:space:]]+build"
+	"docker[[:space:]]+compose[[:space:]]+up"
+	"docker-compose[[:space:]]+up"
+	# Package installs (can be verbose)
+	"(npm|bun|pnpm|yarn)[[:space:]]+install([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+i([[:space:]]|$)"
+	"(npm|bun|pnpm|yarn)[[:space:]]+add[[:space:]]"
+	# Turbo commands (generally verbose)
+	"^turbo[[:space:]]"
+	# Database operations
+	"prisma[[:space:]]+(migrate|db[[:space:]]+push|generate)"
+	"drizzle-kit[[:space:]]+(push|generate|migrate)"
+	# Full test suites
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?test([[:space:]]|$)"
+	"^vitest([[:space:]]|$)"
+	"^jest([[:space:]]|$)"
+	# Linting full projects
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(lint|format|typecheck)([[:space:]]|$)"
+	"^biome[[:space:]]+(check|lint|format)"
+	"^eslint[[:space:]]"
+	"^tsc([[:space:]]|$)"
+	# CI/all commands
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?ci([[:space:]]|$)"
+	# Reset/setup scripts
+	"(npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(reset|setup|dev:reset)"
+)
+
+SHOULD_WRAP=false
+for pattern in "${WRAP_PATTERNS[@]}"; do
+	if [[ $COMMAND =~ $pattern ]]; then
+		SHOULD_WRAP=true
+		break
+	fi
+done
+
+# Exit if command doesn't match any wrap patterns
+[[ $SHOULD_WRAP != true ]] && exit 0
+
+# Generate descriptive temp file name
+# Extract a meaningful slug from the command
+SLUG=$(echo "$COMMAND" | head -c 50 | tr -cs '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]' | sed 's/^-//;s/-$//')
+[[ -z $SLUG ]] && SLUG="cmd"
+TIMESTAMP=$(date +%H%M%S)
+LOGFILE="/tmp/claude-${SLUG}-${TIMESTAMP}.log"
+
+# Build the wrapped command
+# Use script for better terminal handling, or simple tee if script unavailable
+WRAPPED_CMD="{ ${COMMAND}; } 2>&1 | tee \"${LOGFILE}\"; echo \"\n📄 Full output saved: ${LOGFILE}\""
+
+# Return modified tool input
+jq -n \
+	--arg cmd "$WRAPPED_CMD" \
+	--arg msg "📝 Output will be saved to: ${LOGFILE}" \
+	'{
+    "hookResponse": {
+      "decision": "ALLOW",
+      "modifiedToolInput": {
+        "command": $cmd
+      }
+    },
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "message": $msg
+    }
+  }'
+
+exit 0


### PR DESCRIPTION
## Summary

- Add `wrap-long-output.sh` PreToolUse hook to both crew and devtools plugins
- Automatically wraps verbose commands with `tee` to capture full output in temp files
- Updates `<pattern name="large-output"/>` documentation to reflect automation

## Why

Long-running commands like `bun run test:integration`, `turbo build`, and `bun run dev` produce verbose output that pollutes the context window. Previously, users had to manually pipe to temp files or remember to use the `/crew:ci` skill.

## What changed

| File | Change |
|------|--------|
| `crew/scripts/hooks/pre-tool/wrap-long-output.sh` | New hook script |
| `devtools/scripts/hooks/pre-tool/wrap-long-output.sh` | Copy for independence |
| `*/hooks/hooks.json` | Added hook to PreToolUse chain |
| `crew/skills/crew-patterns/references/patterns.md` | Updated docs |
| `*/.claude-plugin/plugin.json` | Version bumps |

## How it works

**Wrapped patterns:**
- Dev servers: `bun run dev`, `npm run start`, `--watch`
- Tests: `test:integration`, `vitest`, `jest`, `playwright`
- Builds: `bun run build`, `turbo build`
- Lint: `eslint`, `biome`, `tsc`
- Install: `bun install`, `npm add`
- Docker: `docker build`, `docker compose up`

**Smart skips:**
- Commands with existing pipes (`|`, `>`, `tee`)
- Quick commands (`git status`, `ls`, `cat`, etc.)

**Output:**
```
📝 Output will be saved to: /tmp/claude-bun-run-test-integration-150826.log
[command runs with tee]
📄 Full output saved: /tmp/claude-bun-run-test-integration-150826.log
```

## Test plan

- [x] Verified hook detects and wraps `bun run test:integration`
- [x] Verified hook skips already-piped commands
- [x] Verified hook skips quick commands like `git status`
- [x] shellcheck passes on script

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PreToolUse hook that auto-wraps long-running Bash commands with tee to save full logs to /tmp, reducing noisy context and preserving output for debugging. Applied to both crew and devtools, and docs updated to mark this as automated.

- New Features
  - Added wrap-long-output.sh to crew and devtools; enabled in Bash PreToolUse.
  - Wraps verbose commands (dev servers, tests, builds, lint, installs, Docker, DB ops) and logs to /tmp/claude-{slug}-{time}.log.
  - Skips commands already using pipes/redirects and fast commands (e.g., git status, ls).
  - Updated large-output pattern docs; bumped plugin versions.

<sup>Written for commit 23e9f865cba29ac0f456863522c8473c9ab0624f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

