### PR TITLE
fix(crew): use $$ instead of mktemp XXXXXX for temp file names

### DIFF
--- a/crew/commands/build.md
+++ b/crew/commands/build.md
@@ -147,8 +147,8 @@ Use `<pattern name="large-output"/>` to capture full results:
 
 ```bash
 cd $(git rev-parse --show-toplevel)
-LOG_CI=$(mktemp /tmp/ci-final-XXXXXX.log)
-LOG_INT=$(mktemp /tmp/integration-XXXXXX.log)
+LOG_CI=/tmp/ci-final-$$.log
+LOG_INT=/tmp/integration-$$.log
 
 bun run ci 2>&1 | tee $LOG_CI
 bun run test:integration 2>&1 | tee $LOG_INT

--- a/crew/commands/ci.md
+++ b/crew/commands/ci.md
@@ -45,7 +45,7 @@ Task({
   prompt: `Run CI check with output logged to temp file:
 
 1. Create log file:
-   LOG=$(mktemp /tmp/ci-${checkType}-XXXXXX.log)
+   LOG=/tmp/ci-${checkType}-$$.log
    echo "Log file: $LOG"
 
 2. Run command with full output captured:

--- a/crew/skills/crew-patterns/references/patterns.md
+++ b/crew/skills/crew-patterns/references/patterns.md
@@ -65,7 +65,7 @@ Task({
   prompt: `Run tests with output captured to temp file (see large-output pattern):
 
 1. Create log file:
-   LOG=$(mktemp /tmp/test-run-XXXXXX.log)
+   LOG=/tmp/test-run-$$.log
    echo "Log file: $LOG"
 
 2. Run tests with full output:


### PR DESCRIPTION
## Summary

Sub-agents were interpreting the `mktemp /tmp/test-run-XXXXXX.log` template syntax literally, creating files named `/tmp/test-run-XXXXXX.log` instead of running `mktemp` to generate unique filenames.

## Changes

- Replace `mktemp /tmp/...-XXXXXX.log` with `/tmp/...-$$.log` in instruction templates
- Affected files:
  - `crew/commands/build.md`
  - `crew/commands/ci.md`
  - `crew/skills/crew-patterns/references/patterns.md`

## Why

Using `$$` (shell process ID) is simpler and always expands correctly without needing sub-agents to understand mktemp's template syntax. The `XXXXXX` pattern requires actually running `mktemp`, but sub-agents were treating it as a literal string.

## Test plan

- [ ] Verify sub-agents create temp files with actual PID in filename
- [ ] Confirm no more literal `XXXXXX` in created filenames

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced mktemp XXXXXX templates with $$ (PID) for temp log filenames so sub-agents stop creating literal XXXXXX files and produce unique logs reliably. This removes the need to run mktemp and always expands correctly.

- **Bug Fixes**
  - Updated: crew/commands/build.md, crew/commands/ci.md, crew/skills/crew-patterns/references/patterns.md

<sup>Written for commit 5ab60936cec359ae4a24193cb88d4fcd3386d841. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

