### PR TITLE
feat(crew): migrate to Bash subagent for large output commands

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/agents/workflow/work-orchestrator.md
+++ b/crew/agents/workflow/work-orchestrator.md
@@ -86,14 +86,33 @@ TaskOutput({task_id: "agent-id", block: false})
 - No `find`, `grep`, `cat`, `sed`, `echo >`
 - Use native tools instead
 
-## Shell Commands (Appropriate Uses)
+## Shell Commands
+
+### Bash Subagent (for large output commands)
+
+Use `subagent_type: "Bash"` for commands with large output - runs in separate context:
 
 ```javascript
-// Tests and CI
-Bash({command: "bun run test", description: "Run tests"})
-Bash({command: "bun run ci", description: "Run CI checks"})
+// Tests, CI, builds - use Bash subagent
+Task({
+  subagent_type: "Bash",
+  prompt: "Run bun run test and report pass/fail with error details",
+  description: "test-runner",
+  run_in_background: false,
+});
 
-// Git operations
+Task({
+  subagent_type: "Bash",
+  prompt: "Run bun run ci and report results",
+  description: "ci-check",
+  run_in_background: true,
+});
+```
+
+### Direct Bash (for quick commands)
+
+```javascript
+// Quick git operations - direct Bash is fine
 Bash({command: "git status", description: "Check status"})
 Bash({command: "git add . && git commit -m 'feat: ...'", description: "Commit"})
 Bash({command: "git push -u origin branch", description: "Push branch"})

--- a/crew/commands/build.md
+++ b/crew/commands/build.md
@@ -143,21 +143,26 @@ Launch quality agents using `<pattern name="quality-agents"/>`.
 <phase name="final-validation">
 **MANDATORY: Fix ALL issues, even unrelated ones.**
 
-Use `<pattern name="large-output"/>` to capture full results:
+Use the Bash subagent for final validation (runs in separate context, no output pollution):
 
-```bash
-cd $(git rev-parse --show-toplevel)
-LOG_CI=/tmp/ci-final-$$.log
-LOG_INT=/tmp/integration-$$.log
+```javascript
+Task({
+  subagent_type: "Bash",
+  prompt: `Run final validation and report results:
 
-bun run ci 2>&1 | tee $LOG_CI
-bun run test:integration 2>&1 | tee $LOG_INT
+1. Run CI: bun run ci
+2. Run integration tests: bun run test:integration
+3. Report:
+   - If both pass: "VALIDATION PASSED"
+   - If failures: List each error with file:line
 
-echo "CI log: $LOG_CI"
-echo "Integration log: $LOG_INT"
+The Bash subagent handles large output in its own context.`,
+  description: "final-validation",
+  run_in_background: false,
+});
 ```
 
-Loop until BOTH pass with zero errors. Log files allow re-reading errors without re-running.
+Loop until BOTH pass with zero errors.
 </phase>
 
 <phase name="completion">

--- a/crew/commands/ci.md
+++ b/crew/commands/ci.md
@@ -23,7 +23,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task, AskUserQuestion, TodoW
 
 <process>
 
-Use `<pattern name="large-output"/>` to capture full output for later analysis.
+Use the Bash subagent for CI checks. It runs in a separate context window, preventing output pollution in the main thread.
 
 ```javascript
 const pm = Bash({
@@ -40,23 +40,15 @@ const commands = {
 };
 
 Task({
-  subagent_type: "general-purpose",
-  model: "haiku",
-  prompt: `Run CI check with output logged to temp file:
+  subagent_type: "Bash",
+  prompt: `Run CI check: ${checkType}
 
-1. Create log file:
-   LOG=/tmp/ci-${checkType}-$$.log
-   echo "Log file: $LOG"
-
-2. Run command with full output captured:
-   (${commands[checkType]}) 2>&1 | tee $LOG
-
-3. Report results:
+1. Run: ${commands[checkType]}
+2. Report results:
    - Pass: "ALL CHECKS PASSING"
    - Fail: "[ERROR|WARN] type: file:line - message" (1 line per issue)
-   - Always include: "Full output: $LOG"
 
-The log file preserves full stack traces and allows re-reading without re-running.`,
+The Bash subagent handles large output in its own context - no temp files needed.`,
   description: `ci-${checkType}`,
   run_in_background: true,
 });

--- a/crew/skills/crew-patterns/SKILL.md
+++ b/crew/skills/crew-patterns/SKILL.md
@@ -28,17 +28,17 @@ Use <pattern name="test-runner"/> after each batch.
 
 <routing>
 
-| Pattern                     | Purpose                                    |
-| --------------------------- | ------------------------------------------ |
-| `user-questions-constraint` | **MANDATORY** - Use AskUserQuestion always |
-| `spawn-batch`               | Launch parallel agents (max 6)             |
-| `test-runner`               | Haiku agent for test execution             |
-| `large-output`              | Capture large output to temp file          |
-| `todo-progress`             | TodoWrite status tracking                  |
-| `ask-user`                  | AskUserQuestion templates                  |
-| `task-file`                 | Task file frontmatter format               |
-| `collect-results`           | TaskOutput collection pattern              |
-| `always-works`              | Verification sanity checks for builds      |
+| Pattern                     | Purpose                                       |
+| --------------------------- | --------------------------------------------- |
+| `user-questions-constraint` | **MANDATORY** - Use AskUserQuestion always    |
+| `spawn-batch`               | Launch parallel agents (max 6)                |
+| `test-runner`               | Bash subagent for test execution              |
+| `large-output`              | Bash subagent for commands with large output  |
+| `todo-progress`             | TodoWrite status tracking                     |
+| `ask-user`                  | AskUserQuestion templates                     |
+| `task-file`                 | Task file frontmatter format                  |
+| `collect-results`           | TaskOutput collection pattern                 |
+| `always-works`              | Verification sanity checks for builds         |
 
 </routing>
 

--- a/crew/skills/native-tools/SKILL.md
+++ b/crew/skills/native-tools/SKILL.md
@@ -40,6 +40,40 @@ Related: `ast-grep` skill for structural code patterns.
 
 </routing>
 
+<bash_subagent>
+
+## Bash Subagent for Large Output Commands
+
+For commands with large output (tests, builds, CI), use the **Bash subagent** instead of direct Bash:
+
+```javascript
+// DON'T: Direct Bash pollutes main context
+Bash({ command: "bun run test" });
+
+// DO: Bash subagent runs in separate context
+Task({
+  subagent_type: "Bash",
+  prompt: "Run bun run test and report pass/fail with error details",
+  description: "test-runner",
+});
+```
+
+**When to use Bash subagent:**
+
+- Test suites (`bun run test`, `vitest`, `jest`)
+- CI checks (`bun run ci`, `eslint`, `tsc`)
+- Builds (`bun run build`, `turbo build`)
+- Package installs (`bun install`, `npm i`)
+- Any command with verbose output
+
+**When to use direct Bash:**
+
+- Quick commands: `git status`, `ls`, `pwd`
+- Single-line output commands
+- Commands where you need immediate inline result
+
+</bash_subagent>
+
 <quick_reference>
 
 | Tool            | Permission | Purpose                |


### PR DESCRIPTION
## Summary

This PR migrates the crew plugin to use the new Bash subagent (`subagent_type: "Bash"`) for commands with large output, replacing the previous temp file piping patterns.

## Changes

- **crew-patterns**: Updated `test-runner` and `large-output` patterns to use Bash subagent
- **ci.md**: Changed from `general-purpose` with haiku + temp files to `Bash` subagent
- **build.md**: Updated `final-validation` phase to use Bash subagent
- **native-tools**: Added `<bash_subagent>` section documenting when to use it
- **work-orchestrator**: Updated shell commands section with Bash subagent examples
- **wrap-long-output.sh**: Kept as fallback safety net for direct Bash calls

## Why Bash subagent?

The Bash subagent (introduced in Claude Code v2.0.77) runs in a separate context window, which:

- Prevents output pollution in the main thread
- Eliminates need for temp file piping (`tee /tmp/...`)
- Provides a focused agent with only Bash tool access
- Can run in background for parallel work

## Before vs After

**Before (temp file approach):**
```javascript
Task({
  subagent_type: "general-purpose",
  model: "haiku",
  prompt: `Run tests with temp file:
    LOG=/tmp/test-run-$$.log
    bun run test 2>&1 | tee $LOG`,
});
```

**After (Bash subagent):**
```javascript
Task({
  subagent_type: "Bash",
  prompt: "Run bun run test and report pass/fail with error details",
  description: "test-runner",
});
```

## Test plan

- [ ] Run `/crew:ci test` and verify it uses Bash subagent
- [ ] Run `/crew:build` and verify final-validation uses Bash subagent
- [ ] Check that direct Bash calls still get wrapped by hook (fallback works)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates crew to the Bash subagent for commands with large output (tests, CI, builds), replacing temp file piping. This isolates noisy output from the main thread and enables clean background runs.

- **Refactors**
  - Updated test-runner and large-output patterns to use subagent_type: "Bash".
  - Switched CI and build final-validation to Bash subagent; removed temp file piping.
  - Added Bash subagent guidance to native-tools; expanded work-orchestrator examples.
  - Kept wrap-long-output.sh as fallback for direct Bash calls.
  - Bumped plugin version to 1.29.0.

- **Migration**
  - Use subagent_type: "Bash" for tests, CI, builds, and other verbose commands.
  - Stop using tee and temp files; the subagent handles large output in its own context.
  - Keep direct Bash for quick, single-line commands (e.g., git status).

<sup>Written for commit d576eefcffee09d370ed82b0196ef88aba3f2dc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

