### PR TITLE
refactor(crew): remove Anthropic marketplace installation

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -1460,8 +1460,8 @@ bash setup-plugins.sh
 
 This script automatically:
 
-- Adds the SettleMint, Anthropic Official, and Dev Browser marketplaces
-- Installs and updates all plugins (crew, devtools, typescript-lsp, frontend-design, dev-browser)
+- Adds the SettleMint and Dev Browser marketplaces
+- Installs and updates all plugins (crew, devtools, dev-browser)
 - Clears plugin caches to ensure the latest versions
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ curl -fsSL https://raw.githubusercontent.com/settlemint/agent-marketplace/main/c
 This installs all recommended plugins with status notifications:
 
 - SettleMint crew & devtools
-- Anthropic typescript-lsp & frontend-design
 - Dev Browser automation
 
 **Core plugin only:**
@@ -51,12 +50,11 @@ claude plugin install crew@settlemint
 
 ## Recommended Additional Plugins
 
-For the best experience, add these complementary plugins:
+For the best experience, add the dev-browser plugin for browser automation:
 
 ```bash
-claude plugin marketplace add anthropics/claude-plugins-official
 claude plugin marketplace add sawyerhood/dev-browser
-claude plugin install typescript-lsp@claude-plugins-official frontend-design@claude-plugins-official dev-browser@dev-browser-marketplace
+claude plugin install dev-browser@dev-browser-marketplace
 ```
 
 Or add to your `.claude/settings.json`:
@@ -64,12 +62,6 @@ Or add to your `.claude/settings.json`:
 ```json
 {
   "extraKnownMarketplaces": {
-    "claude-plugins-official": {
-      "source": {
-        "source": "github",
-        "repo": "anthropics/claude-plugins-official"
-      }
-    },
     "dev-browser-marketplace": {
       "source": {
         "source": "github",
@@ -78,18 +70,14 @@ Or add to your `.claude/settings.json`:
     }
   },
   "enabledPlugins": {
-    "typescript-lsp@claude-plugins-official": true,
-    "dev-browser@dev-browser-marketplace": true,
-    "frontend-design@claude-plugins-official": true
+    "dev-browser@dev-browser-marketplace": true
   }
 }
 ```
 
-| Plugin            | Source                  | Purpose                                |
-| ----------------- | ----------------------- | -------------------------------------- |
-| `typescript-lsp`  | claude-plugins-official | TypeScript language server integration |
-| `frontend-design` | claude-plugins-official | Frontend design assistance             |
-| `dev-browser`     | dev-browser-marketplace | Browser automation for development     |
+| Plugin        | Source                  | Purpose                            |
+| ------------- | ----------------------- | ---------------------------------- |
+| `dev-browser` | dev-browser-marketplace | Browser automation for development |
 
 ## Plugins
 

--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/scripts/hooks/session-start/setup-plugins.sh
+++ b/crew/scripts/hooks/session-start/setup-plugins.sh
@@ -161,14 +161,12 @@ force_update_plugin() {
 echo "Step 1: Adding Marketplaces"
 echo "----------------------------"
 add_marketplace "settlemint/agent-marketplace" "SettleMint"
-add_marketplace "anthropics/claude-plugins-official" "Anthropic Official"
 add_marketplace "sawyerhood/dev-browser" "Dev Browser"
 echo ""
 
 echo "Step 2: Updating Marketplaces"
 echo "-----------------------------"
 update_marketplace "settlemint"
-update_marketplace "claude-plugins-official"
 update_marketplace "dev-browser-marketplace"
 echo ""
 
@@ -182,8 +180,6 @@ force_update_plugin "devtools@settlemint" "devtools (development skills)"
 echo ""
 
 echo "Additional plugins:"
-force_update_plugin "typescript-lsp@claude-plugins-official" "typescript-lsp"
-force_update_plugin "frontend-design@claude-plugins-official" "frontend-design"
 force_update_plugin "dev-browser@dev-browser-marketplace" "dev-browser"
 echo ""
 
@@ -195,8 +191,6 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
 	echo "Installed plugins:"
 	echo "  • crew@settlemint - Work orchestration (/design, /build, /check)"
 	echo "  • devtools@settlemint - Development skills (React, API, etc.)"
-	echo "  • typescript-lsp - TypeScript language server"
-	echo "  • frontend-design - UI/UX assistance"
 	echo "  • dev-browser - Browser automation"
 	echo ""
 	echo "Get started:"


### PR DESCRIPTION
Removes the install and update of the anthropics/claude-plugins-official marketplace and associated plugins (typescript-lsp, frontend-design) from the automated setup script. These are now optional plugins that users can install separately if desired.

Updates setup-plugins.sh, README.md, and MANIFESTO.md accordingly. Bumps crew plugin version to 1.44.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops auto-installing the Anthropic official marketplace and its TypeScript LSP and frontend-design plugins; these are now optional. Updates the setup script and docs, and bumps crew to 1.44.0.

- **Refactors**
  - Removed Anthropic marketplace add/update from setup-plugins.sh
  - Removed auto-install of typescript-lsp and frontend-design
  - Kept SettleMint and Dev Browser marketplaces and dev-browser installation
  - Updated README and MANIFESTO to reflect optional Anthropic plugins
  - Bumped crew plugin version to 1.44.0

- **Migration**
  - No action needed unless you want Anthropic plugins
  - To add them: run “claude plugin marketplace add anthropics/claude-plugins-official” then “claude plugin install typescript-lsp@claude-plugins-official frontend-design@claude-plugins-official”

<sup>Written for commit 40188756c356239d6a4cf72994d3b172fec4d855. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

