### PR TITLE
fix(crew): correct claude-mem marketplace reference

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/scripts/hooks/session-start/setup-plugins.sh
+++ b/crew/scripts/hooks/session-start/setup-plugins.sh
@@ -31,29 +31,29 @@ info() { echo -e "${ARROW} $1"; }
 success() { echo -e "${CHECK} $1"; }
 warn() { echo -e "${WARN} $1"; }
 error() {
-	echo -e "${CROSS} $1" >&2
-	ERRORS+=("$1")
+  echo -e "${CROSS} $1" >&2
+  ERRORS+=("$1")
 }
 
 # Check if running as hook - skip on compact/resume events
 # Only attempt to read stdin if CLAUDE_HOOK environment variable is set
 # This avoids consuming stdin when run via "curl ... | bash"
 if [[ -n "${CLAUDE_HOOK:-}" ]] && [[ ! -t 0 ]]; then
-	# Running as Claude hook with piped input
-	INPUT=$(cat)
-	EVENT_TYPE=$(echo "$INPUT" | jq -r '.type // "unknown"' 2>/dev/null || echo "direct")
+  # Running as Claude hook with piped input
+  INPUT=$(cat)
+  EVENT_TYPE=$(echo "$INPUT" | jq -r '.type // "unknown"' 2>/dev/null || echo "direct")
 
-	if [[ $EVENT_TYPE == "compact" || $EVENT_TYPE == "resume" ]]; then
-		# Skip on compact/resume - only run on fresh startup or direct execution
-		exit 0
-	fi
+  if [[ $EVENT_TYPE == "compact" || $EVENT_TYPE == "resume" ]]; then
+    # Skip on compact/resume - only run on fresh startup or direct execution
+    exit 0
+  fi
 fi
 
 # Check if claude CLI is available
 if ! command -v claude &>/dev/null; then
-	error "Claude CLI not found. Please install Claude Code first."
-	echo "  Visit: https://claude.ai/code"
-	exit 1
+  error "Claude CLI not found. Please install Claude Code first."
+  echo "  Visit: https://claude.ai/code"
+  exit 1
 fi
 
 echo ""
@@ -64,98 +64,98 @@ echo ""
 
 # Function to add marketplace
 add_marketplace() {
-	local repo="$1"
-	local name="$2"
+  local repo="$1"
+  local name="$2"
 
-	info "Adding marketplace: $name"
+  info "Adding marketplace: $name"
 
-	output=$(claude plugin marketplace add "$repo" 2>&1) || true
+  output=$(claude plugin marketplace add "$repo" 2>&1) || true
 
-	if echo "$output" | grep -qi "already added\|already exists\|already registered\|already installed"; then
-		success "$name marketplace already configured"
-		return 0
-	elif echo "$output" | grep -qi "added\|success"; then
-		success "$name marketplace added"
-		return 0
-	elif [[ -z "$output" ]]; then
-		success "$name marketplace configured"
-		return 0
-	else
-		# Check if it's a real error
-		if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
-			error "Failed to add $name marketplace: $output"
-			return 1
-		else
-			# Unknown output, assume success
-			success "$name marketplace configured"
-			return 0
-		fi
-	fi
+  if echo "$output" | grep -qi "already added\|already exists\|already registered\|already installed"; then
+    success "$name marketplace already configured"
+    return 0
+  elif echo "$output" | grep -qi "added\|success"; then
+    success "$name marketplace added"
+    return 0
+  elif [[ -z "$output" ]]; then
+    success "$name marketplace configured"
+    return 0
+  else
+    # Check if it's a real error
+    if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
+      error "Failed to add $name marketplace: $output"
+      return 1
+    else
+      # Unknown output, assume success
+      success "$name marketplace configured"
+      return 0
+    fi
+  fi
 }
 
 # Function to update marketplace
 update_marketplace() {
-	local name="$1"
+  local name="$1"
 
-	info "Updating marketplace: $name"
+  info "Updating marketplace: $name"
 
-	output=$(claude plugin marketplace update "$name" 2>&1) || true
+  output=$(claude plugin marketplace update "$name" 2>&1) || true
 
-	if echo "$output" | grep -qi "up to date\|already up\|no updates"; then
-		success "$name is up to date"
-		return 0
-	elif echo "$output" | grep -qi "updated\|success"; then
-		success "$name updated"
-		return 0
-	elif [[ -z "$output" ]]; then
-		success "$name checked"
-		return 0
-	else
-		if echo "$output" | grep -qi "error\|fail\|not found"; then
-			warn "Could not update $name: $output"
-			return 0 # Non-fatal
-		else
-			success "$name checked"
-			return 0
-		fi
-	fi
+  if echo "$output" | grep -qi "up to date\|already up\|no updates"; then
+    success "$name is up to date"
+    return 0
+  elif echo "$output" | grep -qi "updated\|success"; then
+    success "$name updated"
+    return 0
+  elif [[ -z "$output" ]]; then
+    success "$name checked"
+    return 0
+  else
+    if echo "$output" | grep -qi "error\|fail\|not found"; then
+      warn "Could not update $name: $output"
+      return 0 # Non-fatal
+    else
+      success "$name checked"
+      return 0
+    fi
+  fi
 }
 
 # Function to force update plugin (uninstall + reinstall)
 # Use this for plugins that need to be at the latest version
 force_update_plugin() {
-	local plugin="$1"
-	local display_name="${2:-$plugin}"
+  local plugin="$1"
+  local display_name="${2:-$plugin}"
 
-	info "Updating plugin: $display_name"
+  info "Updating plugin: $display_name"
 
-	# Uninstall first (ignore errors if not installed)
-	claude plugin uninstall "$plugin" &>/dev/null || true
+  # Uninstall first (ignore errors if not installed)
+  claude plugin uninstall "$plugin" &>/dev/null || true
 
-	# Clear plugin cache for this marketplace
-	local marketplace="${plugin#*@}"
-	if [[ -d "$HOME/.claude/plugins/cache/$marketplace" ]]; then
-		rm -rf "$HOME/.claude/plugins/cache/$marketplace"
-	fi
+  # Clear plugin cache for this marketplace
+  local marketplace="${plugin#*@}"
+  if [[ -d "$HOME/.claude/plugins/cache/$marketplace" ]]; then
+    rm -rf "$HOME/.claude/plugins/cache/$marketplace"
+  fi
 
-	# Install fresh
-	output=$(claude plugin install "$plugin" 2>&1) || true
+  # Install fresh
+  output=$(claude plugin install "$plugin" 2>&1) || true
 
-	if echo "$output" | grep -qi "installed\|enabled\|success"; then
-		success "$display_name updated"
-		return 0
-	elif [[ -z "$output" ]]; then
-		success "$display_name updated"
-		return 0
-	else
-		if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
-			error "Failed to update $display_name: $output"
-			return 1
-		else
-			success "$display_name updated"
-			return 0
-		fi
-	fi
+  if echo "$output" | grep -qi "installed\|enabled\|success"; then
+    success "$display_name updated"
+    return 0
+  elif [[ -z "$output" ]]; then
+    success "$display_name updated"
+    return 0
+  else
+    if echo "$output" | grep -qi "error\|fail\|not found\|invalid"; then
+      error "Failed to update $display_name: $output"
+      return 1
+    else
+      success "$display_name updated"
+      return 0
+    fi
+  fi
 }
 
 echo "Step 1: Adding Marketplaces"
@@ -169,7 +169,7 @@ echo "Step 2: Updating Marketplaces"
 echo "-----------------------------"
 update_marketplace "settlemint"
 update_marketplace "dev-browser-marketplace"
-update_marketplace "claude-mem"
+update_marketplace "thedotmack"
 echo ""
 
 echo "Step 3: Updating Plugins"
@@ -183,31 +183,31 @@ echo ""
 
 echo "Additional plugins:"
 force_update_plugin "dev-browser@dev-browser-marketplace" "dev-browser"
-force_update_plugin "claude-mem@claude-mem" "claude-mem (memory)"
+force_update_plugin "claude-mem@thedotmack" "claude-mem (memory)"
 echo ""
 
 # Summary
 echo "================================"
 if [[ ${#ERRORS[@]} -eq 0 ]]; then
-	echo -e "${GREEN}Setup complete!${NC}"
-	echo ""
-	echo "Installed plugins:"
-	echo "  • crew@settlemint - Work orchestration (/design, /build, /check)"
-	echo "  • devtools@settlemint - Development skills (React, API, etc.)"
-	echo "  • dev-browser - Browser automation"
-	echo "  • claude-mem - Memory persistence"
-	echo ""
-	echo "Get started:"
-	echo "  /crew:design <feature>  - Plan a feature"
-	echo "  /crew:build             - Execute the plan"
-	echo "  /crew:check             - Review code quality"
-	echo "================================"
-	exit 0
+  echo -e "${GREEN}Setup complete!${NC}"
+  echo ""
+  echo "Installed plugins:"
+  echo "  • crew@settlemint - Work orchestration (/design, /build, /check)"
+  echo "  • devtools@settlemint - Development skills (React, API, etc.)"
+  echo "  • dev-browser - Browser automation"
+  echo "  • claude-mem - Memory persistence"
+  echo ""
+  echo "Get started:"
+  echo "  /crew:design <feature>  - Plan a feature"
+  echo "  /crew:build             - Execute the plan"
+  echo "  /crew:check             - Review code quality"
+  echo "================================"
+  exit 0
 else
-	echo -e "${RED}Setup completed with ${#ERRORS[@]} error(s):${NC}"
-	for err in "${ERRORS[@]}"; do
-		echo -e "  ${CROSS} $err"
-	done
-	echo "================================"
-	exit 1
+  echo -e "${RED}Setup completed with ${#ERRORS[@]} error(s):${NC}"
+  for err in "${ERRORS[@]}"; do
+    echo -e "  ${CROSS} $err"
+  done
+  echo "================================"
+  exit 1
 fi


### PR DESCRIPTION
## Summary

Fixes the claude-mem plugin installation by using the correct marketplace name (`thedotmack` instead of `claude-mem`).

## Problem

The session-start hook was failing to install the claude-mem plugin because it referenced the wrong marketplace. The plugin is published under `thedotmack`, not `claude-mem`.

## Changes

- Updated marketplace name from `claude-mem` to `thedotmack` in `setup-plugins.sh`
- Updated plugin reference from `claude-mem@claude-mem` to `claude-mem@thedotmack`
- Version bump: 1.49.0 → 1.49.1

## Test Plan

- [ ] Run `/crew:restart` to verify the setup-plugins hook completes without errors
- [ ] Verify claude-mem plugin is installed correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes claude-mem installation by using the correct marketplace name (thedotmack). This removes session-start setup errors and ensures the memory plugin installs and updates correctly.

- **Bug Fixes**
  - Update marketplace target from claude-mem to thedotmack in setup-plugins.sh
  - Change install reference to claude-mem@thedotmack

- **Dependencies**
  - Bump version: 1.49.0 → 1.49.1

<sup>Written for commit c005e340508993956beea9c5ff208de7ed4fb487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

