### PR TITLE
refactor(crew): improve machete stack detection in git commands

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.49.1",
+  "version": "1.50.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/git/commit-and-push.md
+++ b/crew/commands/git/commit-and-push.md
@@ -36,11 +36,14 @@ Commit format per @rules/git-safety.md
 <process>
 
 <phase name="sync-stack">
-**If machete-managed, sync with parent FIRST:**
+**Check `<stack_context>` above. If it shows "is in machete layout", sync with parent FIRST:**
 
 ```bash
-git fetch origin
-git machete update    # Rebase onto parent (safe in worktrees)
+# Only run if machete-managed (check stack_context output)
+if git machete is-managed "$(git branch --show-current)" 2>/dev/null; then
+  git fetch origin
+  git machete update    # Rebase onto parent (safe in worktrees)
+fi
 ```
 
 </phase>

--- a/crew/commands/git/pr.md
+++ b/crew/commands/git/pr.md
@@ -268,13 +268,12 @@ Match the primary commit type:
 
 <machete_integration>
 
-If machete-managed, machete markers are auto-added per @rules/machete-workflow.md.
+**Machete markers are auto-added when using machete commands.**
 
-After updating PR:
+The `update-pr` skill called in step 10 handles all machete annotation updates, including:
+- `git machete github anno-prs` - Annotate PRs with stack info
+- `git machete github update-pr-descriptions --related` - Update all related PRs
 
-```bash
-git config machete.github.prDescriptionIntroStyle full
-git machete github update-pr-descriptions --related
-```
+See @rules/machete-workflow.md for marker format.
 
 </machete_integration>

--- a/crew/commands/git/push.md
+++ b/crew/commands/git/push.md
@@ -32,11 +32,14 @@ allowed-tools:
 <process>
 
 <phase name="sync-stack">
-**If machete-managed, sync with parent FIRST:**
+**Check `<stack_context>` above. If it shows "is in machete layout", sync with parent FIRST:**
 
 ```bash
-git fetch origin
-git machete update    # Rebase onto parent (safe in worktrees)
+# Only run if machete-managed (check stack_context output)
+if git machete is-managed "$(git branch --show-current)" 2>/dev/null; then
+  git fetch origin
+  git machete update    # Rebase onto parent (safe in worktrees)
+fi
 ```
 
 </phase>

--- a/crew/commands/git/sync.md
+++ b/crew/commands/git/sync.md
@@ -31,36 +31,37 @@ allowed-tools:
 
 <process>
 
-**If machete-managed branch:**
+**Check `<stack_context>` above to determine which sync method to use.**
+
+## If "is in machete layout" (machete-managed branch)
 
 ⚠️ This branch is part of a stack. Sync with PARENT, not main:
 
 ```bash
-git fetch origin
-git machete update           # Rebase onto parent branch
-git push --force-with-lease  # Push rebased branch
+# Verify machete-managed first
+if git machete is-managed "$(git branch --show-current)" 2>/dev/null; then
+  git fetch origin
+  git machete update           # Rebase onto parent branch
+  git push --force-with-lease  # Push rebased branch
+fi
 ```
 
 Do NOT use `git rebase origin/main` - that would flatten the stack!
 
-**If in a WORKTREE with stacked branches:**
+**If also in a WORKTREE:** This is the correct workflow - each worktree syncs its own branch. After syncing, move to child worktrees and repeat.
 
-This is the correct workflow - each worktree syncs its own branch:
+## If "is NOT in machete layout" (regular branch)
 
 ```bash
-git fetch origin
-git machete update           # Rebase onto parent
-git push --force-with-lease
+# Stash uncommitted changes if any
+git stash push -m "sync-stash" 2>/dev/null || true
+
+git fetch origin main
+git rebase origin/main
+
+# Pop stash if we stashed
+git stash pop 2>/dev/null || true
 ```
-
-Then move to child worktrees and repeat.
-
-**If regular branch (not machete-managed):**
-
-1. If uncommitted → `git stash push -m "sync-stash"`
-2. `git fetch origin main`
-3. `git rebase origin/main`
-4. If stashed → `git stash pop`
 
 </process>
 

--- a/crew/commands/git/update-pr.md
+++ b/crew/commands/git/update-pr.md
@@ -145,15 +145,25 @@ EOF
 </phase>
 
 <phase name="update-machete">
-**If machete-managed:**
+**ALWAYS run if `<stack_context>` shows branch is in machete layout:**
+
+Check the `<stack_context>` output above. If it shows "is in machete layout", run these commands:
 
 ```bash
-# Ensure config is set for full PR description intro (required for --related)
-git config machete.github.prDescriptionIntroStyle full
+# Check if machete-managed (skip if not)
+if git machete is-managed "$(git branch --show-current)" 2>/dev/null; then
+  # Ensure config is set for full PR description intro (required for --related)
+  git config machete.github.prDescriptionIntroStyle full
 
-git machete github anno-prs
-git machete github update-pr-descriptions --related
+  # Update PR annotations with stack info
+  git machete github anno-prs
+
+  # Update all related PRs in the stack (parents and children)
+  git machete github update-pr-descriptions --related
+fi
 ```
+
+**This step is CRITICAL** - it ensures all stacked PRs show the correct dependency chain.
 
 </phase>
 

--- a/crew/hooks/hooks.json
+++ b/crew/hooks/hooks.json
@@ -65,6 +65,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/post-tool/check-comments.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/post-tool/sync-machete-stack.sh"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [


### PR DESCRIPTION
## Summary

- Replace ambiguous "if machete-managed" instructions with explicit `git machete is-managed` guards
- Update fix-reviews.md to use TodoWrite for tracking PR comment resolutions
- Add PostToolUse hook for sync-machete-stack.sh on Bash commands
- Clarify sync.md with separate sections for machete vs regular branches

## Why

Git commands were relying on implicit machete detection that could fail silently or run machete commands on non-managed branches. The `<stack_context>` injection provides explicit state, but commands weren't checking it properly.

## What changed

| File | Change |
|------|--------|
| `fix-reviews.md` | Added TodoWrite tracking pattern, simplified machete sync guard |
| `sync.md` | Split into explicit machete vs non-machete sections |
| `update-pr.md` | Added `is-managed` guard, marked machete step as critical |
| `push.md`, `commit-and-push.md` | Added `is-managed` conditional guards |
| `pr.md` | Clarified that update-pr handles machete annotations |
| `hooks.json` | Added PostToolUse hook for Bash → sync-machete-stack.sh |

## Test plan

- [ ] Run `/crew:git:sync` on a machete-managed branch → should sync with parent
- [ ] Run `/crew:git:sync` on a non-machete branch → should rebase on main
- [ ] Run `/crew:git:fix-reviews` → should create TodoWrite list for tracking
- [ ] Run `/crew:git:pr` → machete annotations should be updated via update-pr

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes machete stack handling explicit in git commands using <stack_context> and git machete is-managed, so machete ops only run on managed branches. Adds TodoWrite tracking for PR reviews and a Bash post-tool hook to auto-sync stacks.

- **Refactors**
  - Add is-managed guards to commit-and-push, push, sync, update-pr.
  - Split sync.md into machete vs regular branch flows; clarify pr.md.
  - Document update-pr machete step as critical and gated by stack context.

- **New Features**
  - Use TodoWrite in fix-reviews to track comment resolution with THREAD_IDs.
  - Add PostToolUse hook for Bash to run sync-machete-stack.sh.

<sup>Written for commit f510f9314a3f8161b0792d5600ac01a47d7f5b82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

