### PR TITLE
feat(crew): add review-pr command for PR code review with GitHub posting

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.50.0",
+  "version": "1.54.2",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/review-pr.md
+++ b/crew/commands/review-pr.md
@@ -1,0 +1,345 @@
+---
+name: crew:review-pr
+description: Review a PR with multi-agent analysis and optional GitHub review posting
+argument-hint: "[PR number]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - Task
+  - AskUserQuestion
+  - TodoWrite
+  - WebFetch
+  - WebSearch
+  - MCPSearch
+  - Skill
+context: fork
+skills:
+  - crew:crew-patterns
+hooks:
+  PostToolUse: false
+---
+
+<worktree_status>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh`
+</worktree_status>
+
+<stack_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
+</stack_context>
+
+<prerequisite>
+
+**Load patterns skill first:**
+
+```javascript
+Skill({ skill: "crew:crew-patterns" });
+```
+
+This provides: `<pattern name="quality-agents"/>`, `<pattern name="task-file"/>`.
+
+</prerequisite>
+
+<input>
+<pr_number>$ARGUMENTS</pr_number>
+</input>
+
+<seven_leg_system>
+
+| Leg             | Focus            | Key Checks                             |
+| --------------- | ---------------- | -------------------------------------- |
+| **Correctness** | Logic accuracy   | Edge cases, null handling, type safety |
+| **Performance** | Speed/efficiency | Complexity, caching, N+1 queries       |
+| **Security**    | Vulnerabilities  | OWASP, injection, auth, secrets        |
+| **Elegance**    | Design quality   | SOLID, clean architecture, cohesion    |
+| **Resilience**  | Failure handling | Error recovery, cleanup, degradation   |
+| **Style**       | Conventions      | Naming, formatting, idioms             |
+| **Smells**      | Debt indicators  | Anti-patterns, duplication, complexity |
+
+**Severity levels:**
+
+- **P0**: Critical - Must fix, blocks deployment
+- **P1**: High - Should fix, significant impact
+- **P2**: Medium - Address soon
+- **Observation**: Note for consideration
+
+**Output format:** `[Severity] file:line - Description`
+
+</seven_leg_system>
+
+<scripts>
+
+```bash
+# List open PRs for selection
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-list-open.sh [--json]
+
+# Get PR info
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-info.sh <PR_NUMBER>
+
+# Get PR diff
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-diff.sh <PR_NUMBER> [--files-only]
+
+# Post review with file comments
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-post-review.sh <PR_NUMBER> <EVENT> <BODY_FILE> [COMMENTS_JSON]
+# EVENT: APPROVE | REQUEST_CHANGES | COMMENT
+# COMMENTS_JSON format: [{"path": "src/file.ts", "line": 42, "body": "Comment text"}]
+```
+
+</scripts>
+
+<process>
+
+<phase name="determine-pr">
+
+If `<pr_number>` is empty or unclear:
+
+```bash
+# Get list of open PRs
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-list-open.sh --json
+```
+
+Then present selection:
+
+```javascript
+// Parse PR list into options
+// AskUserQuestion allows max 4 options, so show 3 recent + hint about "Other"
+const prs = JSON.parse(prListOutput);
+const totalPRs = prs.length;
+const options = prs.slice(0, 3).map((pr) => ({
+  label: `#${pr.number}: ${pr.title.substring(0, 25)}`,
+  description: `${pr.headRefName} by @${pr.author.login} (+${pr.additions}/-${pr.deletions})`,
+}));
+
+// Add a 4th option showing there are more PRs available
+if (totalPRs > 3) {
+  options.push({
+    label: `${totalPRs - 3} more PRs...`,
+    description: "Select 'Other' below to enter a PR number directly",
+  });
+}
+
+AskUserQuestion({
+  questions: [
+    {
+      question: `Found ${totalPRs} open PRs. Which one to review?`,
+      header: "PR",
+      options: options,
+      multiSelect: false,
+    },
+  ],
+});
+// Note: User can always select "Other" to type a specific PR number
+```
+
+If user selects "X more PRs..." or "Other", show full list:
+
+```bash
+# Display all open PRs for reference
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-list-open.sh
+```
+
+Then ask for the PR number directly.
+
+</phase>
+
+<phase name="fetch-pr-context">
+
+```bash
+# Get PR info
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-info.sh ${PR_NUMBER}
+
+# Get changed files
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-diff.sh ${PR_NUMBER} --files-only
+
+# Get full diff
+${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-diff.sh ${PR_NUMBER}
+```
+
+</phase>
+
+<phase name="launch-reviewers">
+
+Launch ALL 7 using `<pattern name="quality-agents"/>` in SINGLE message:
+
+```javascript
+const legs = [
+  "correctness",
+  "performance",
+  "security",
+  "elegance",
+  "resilience",
+  "style",
+  "smells",
+];
+for (const leg of legs) {
+  Task({
+    subagent_type: `crew:review:seven-legs:${leg}-reviewer`,
+    prompt: `CONTEXT: Review PR #${prNumber}
+TITLE: ${prTitle}
+FILES: ${files.join(", ")}
+DIFF:
+${diff}
+
+FOCUS: ${legFocus[leg]}
+OUTPUT FORMAT: [P0|P1|P2|Obs] file:line - description
+
+Use Glob, Grep, Read to examine the actual code. Do NOT run bash commands.
+Return findings in the specified format, one per line.`,
+    description: `${leg} review`,
+    run_in_background: true,
+  });
+}
+```
+
+</phase>
+
+<phase name="collect-synthesize">
+
+```javascript
+const findings = [];
+for (const leg of legs) {
+  const result = TaskOutput({ task_id: leg.id, block: true });
+  findings.push(...parseFindings(result, leg));
+}
+// Deduplicate and sort by severity: P0 → P1 → P2 → Obs
+// Group by file for review comments
+```
+
+</phase>
+
+<phase name="meta-analysis">
+
+Optional for complex reviews with many findings:
+
+```javascript
+Task({
+  subagent_type: "crew:review:seven-legs:meta-reviewer",
+  prompt: `Synthesize findings from all 7 legs. Find: cross-leg patterns, priority escalations, systemic issues.\nMCP: Use Codex for deep reasoning.`,
+  run_in_background: false,
+});
+```
+
+</phase>
+
+<phase name="create-task-files">
+
+Add findings as task files using `<pattern name="task-file"/>`:
+
+```javascript
+const slugBranch = prBranch.replace(/\//g, "-");
+// Findings start at order 050
+// Naming: {order}-pending-{severity}-found-{slug}.md
+// Example: 050-pending-p0-found-fix-null-deref.md
+```
+
+Each finding task includes:
+
+- Leg dimension (correctness, security, etc.)
+- Severity (P0/P1/P2/Obs)
+- File:line location
+- Recommended fix
+
+</phase>
+
+<phase name="ask-post-review">
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: `Found ${p0} P0, ${p1} P1, ${p2} P2, ${obs} observations. Post as GitHub review?`,
+      header: "Post review",
+      options: [
+        {
+          label: "Yes, as COMMENT (Recommended)",
+          description: "Add review comments without approval/request changes",
+        },
+        {
+          label: "Yes, REQUEST_CHANGES",
+          description: "Request changes on the PR",
+        },
+        { label: "No", description: "Keep findings local only" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+</phase>
+
+<phase name="post-github-review">
+
+If user chose to post:
+
+```javascript
+// 1. Create review body file
+Write({
+  file_path: "/tmp/review-body.md",
+  content: `## Code Review Summary
+
+**Findings:** ${p0} Critical, ${p1} High, ${p2} Medium, ${obs} Observations
+
+### Critical Issues (P0)
+${p0Findings.map((f) => `- ${f.file}:${f.line} - ${f.description}`).join("\n")}
+
+### High Priority (P1)
+${p1Findings.map((f) => `- ${f.file}:${f.line} - ${f.description}`).join("\n")}
+
+### Medium Priority (P2)
+${p2Findings.map((f) => `- ${f.file}:${f.line} - ${f.description}`).join("\n")}
+
+---
+*Review generated by crew:review-pr*`,
+});
+
+// 2. Create comments JSON for file-level comments
+// Only include findings that have valid line numbers in the diff
+Write({
+  file_path: "/tmp/review-comments.json",
+  content: JSON.stringify(
+    findings
+      .filter((f) => f.line && f.path)
+      .map((f) => ({
+        path: f.path,
+        line: f.line,
+        body: `**[${f.severity}] ${f.leg}**\n\n${f.description}\n\n${f.fix ? `**Suggested fix:** ${f.fix}` : ""}`,
+      })),
+  ),
+});
+
+// 3. Post review
+Bash({
+  command: `${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-post-review.sh ${prNumber} ${reviewEvent} /tmp/review-body.md /tmp/review-comments.json`,
+});
+```
+
+</phase>
+
+<phase name="report-result">
+
+Output summary:
+
+- Number of findings by severity
+- Task files created
+- GitHub review URL (if posted)
+- Suggest next steps: `/crew:build` to fix, or manual review
+
+</phase>
+
+</process>
+
+<success_criteria>
+
+- [ ] PR selected via argument or AskUserQuestion
+- [ ] All 7 canonical reviewers launched in single message
+- [ ] Findings deduplicated and prioritized
+- [ ] Task files created with naming convention
+- [ ] User asked about posting GitHub review
+- [ ] If posting: review submitted with file-level comments
+- [ ] Summary provided with next steps
+
+</success_criteria>

--- a/crew/scripts/git/gh-pr-diff.sh
+++ b/crew/scripts/git/gh-pr-diff.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Get the diff for a PR
+# Usage: ./gh-pr-diff.sh [PR_NUMBER] [--files-only]
+# If PR_NUMBER is omitted, uses current branch's PR
+
+set -uo pipefail
+
+PR_NUMBER=""
+FILES_ONLY=""
+
+# Parse arguments
+for arg in "$@"; do
+  case $arg in
+    --files-only)
+      FILES_ONLY="true"
+      ;;
+    *)
+      if [[ "$arg" =~ ^[0-9]+$ ]]; then
+        PR_NUMBER="$arg"
+      fi
+      ;;
+  esac
+done
+
+# Build gh pr diff command
+if [ -n "$PR_NUMBER" ]; then
+  PR_CMD="gh pr diff $PR_NUMBER"
+else
+  PR_CMD="gh pr diff"
+fi
+
+if [ "$FILES_ONLY" = "true" ]; then
+  # Get just the files changed
+  if [ -n "$PR_NUMBER" ]; then
+    gh pr view "$PR_NUMBER" --json files -q '.files[].path'
+  else
+    gh pr view --json files -q '.files[].path'
+  fi
+else
+  # Get full diff
+  $PR_CMD 2>/dev/null || {
+    echo "No PR found or error fetching diff"
+    exit 0
+  }
+fi

--- a/crew/scripts/git/gh-pr-list-open.sh
+++ b/crew/scripts/git/gh-pr-list-open.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# List open PRs for a repository (excludes your own PRs by default)
+# Usage: ./gh-pr-list-open.sh [--json] [--include-mine]
+# Output: Human-readable list or JSON for programmatic use
+
+set -uo pipefail
+
+JSON_MODE=""
+INCLUDE_MINE=""
+
+# Parse arguments
+for arg in "$@"; do
+	case $arg in
+	--json)
+		JSON_MODE="true"
+		;;
+	--include-mine)
+		INCLUDE_MINE="true"
+		;;
+	esac
+done
+
+# Get current GitHub user
+CURRENT_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+
+# Fetch open PRs
+PRS=$(gh pr list --state open --json number,title,headRefName,author,createdAt,additions,deletions,changedFiles --limit 50 2>/dev/null)
+if [ -z "$PRS" ] || [ "$PRS" = "[]" ]; then
+	echo "No open PRs found"
+	exit 0
+fi
+
+# Filter out current user's PRs unless --include-mine is set
+if [ -n "$CURRENT_USER" ] && [ "$INCLUDE_MINE" != "true" ]; then
+	PRS=$(echo "$PRS" | jq --arg user "$CURRENT_USER" '[.[] | select(.author.login != $user)]')
+	if [ "$PRS" = "[]" ]; then
+		echo "No open PRs from other authors found"
+		exit 0
+	fi
+fi
+
+if [ "$JSON_MODE" = "true" ]; then
+	echo "$PRS"
+else
+	echo "## Open Pull Requests (excluding yours)"
+	echo ""
+	echo "$PRS" | jq -r '.[] | "- #\(.number): \(.title) [\(.headRefName)] by @\(.author.login) (+\(.additions)/-\(.deletions), \(.changedFiles) files)"'
+fi

--- a/crew/scripts/git/gh-pr-post-review.sh
+++ b/crew/scripts/git/gh-pr-post-review.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Post a review with file-level comments to a GitHub PR
+# Usage: ./gh-pr-post-review.sh <PR_NUMBER> <REVIEW_EVENT> <BODY_FILE> [COMMENTS_JSON_FILE]
+# REVIEW_EVENT: APPROVE, REQUEST_CHANGES, COMMENT
+# BODY_FILE: File containing the overall review body
+# COMMENTS_JSON_FILE: Optional JSON file with array of {path, line, body} comments
+
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+REVIEW_EVENT="${2:-COMMENT}"
+BODY_FILE="${3:-}"
+COMMENTS_FILE="${4:-}"
+
+if [ -z "$PR_NUMBER" ] || [ -z "$BODY_FILE" ]; then
+  echo "ERROR: PR_NUMBER and BODY_FILE are required" >&2
+  echo "Usage: $0 <PR_NUMBER> <REVIEW_EVENT> <BODY_FILE> [COMMENTS_JSON_FILE]" >&2
+  exit 1
+fi
+
+if [ ! -f "$BODY_FILE" ]; then
+  echo "ERROR: Body file not found: $BODY_FILE" >&2
+  exit 1
+fi
+
+# Validate REVIEW_EVENT
+case "$REVIEW_EVENT" in
+  APPROVE | REQUEST_CHANGES | COMMENT) ;;
+  *)
+    echo "ERROR: Invalid REVIEW_EVENT. Use APPROVE, REQUEST_CHANGES, or COMMENT" >&2
+    exit 1
+    ;;
+esac
+
+# Get repo info
+OWNER=$(gh repo view --json owner -q '.owner.login')
+REPO=$(gh repo view --json name -q '.name')
+
+# Get PR head SHA (required for review comments)
+HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q '.headRefOid')
+if [ -z "$HEAD_SHA" ]; then
+  echo "ERROR: Could not get head SHA for PR #$PR_NUMBER" >&2
+  exit 1
+fi
+
+# Read body
+BODY=$(cat "$BODY_FILE")
+
+# Build comments array
+if [ -n "$COMMENTS_FILE" ] && [ -f "$COMMENTS_FILE" ]; then
+  COMMENTS=$(cat "$COMMENTS_FILE")
+else
+  COMMENTS="[]"
+fi
+
+# GraphQL mutation for creating a review with comments
+# shellcheck disable=SC2016 # Single quotes intentional - GraphQL variables
+MUTATION='
+mutation($input: AddPullRequestReviewInput!) {
+  addPullRequestReview(input: $input) {
+    pullRequestReview {
+      id
+      state
+      url
+    }
+  }
+}
+'
+
+# Get PR node ID
+PR_NODE_ID=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER" --jq '.node_id')
+if [ -z "$PR_NODE_ID" ]; then
+  echo "ERROR: Could not get PR node ID" >&2
+  exit 1
+fi
+
+# Build input JSON
+INPUT=$(jq -n \
+  --arg prId "$PR_NODE_ID" \
+  --arg body "$BODY" \
+  --arg event "$REVIEW_EVENT" \
+  --arg sha "$HEAD_SHA" \
+  --argjson comments "$COMMENTS" \
+  '{
+    pullRequestId: $prId,
+    body: $body,
+    event: $event,
+    commitOID: $sha,
+    comments: ($comments | map({
+      path: .path,
+      body: .body,
+      line: .line
+    }) | if length == 0 then null else . end)
+  } | with_entries(select(.value != null))')
+
+# Submit review
+RESULT=$(
+  gh api graphql \
+    -f query="$MUTATION" \
+    --input - <<EOF
+{"input": $INPUT}
+EOF
+) || {
+  echo "ERROR: Failed to submit review" >&2
+  exit 1
+}
+
+# Output result
+REVIEW_URL=$(echo "$RESULT" | jq -r '.data.addPullRequestReview.pullRequestReview.url')
+REVIEW_STATE=$(echo "$RESULT" | jq -r '.data.addPullRequestReview.pullRequestReview.state')
+
+echo "REVIEW_SUBMITTED=true"
+echo "REVIEW_STATE=$REVIEW_STATE"
+echo "REVIEW_URL=$REVIEW_URL"


### PR DESCRIPTION
## Summary

Add new `/crew:review-pr` command that enables multi-agent code review of pull requests with optional posting of findings as native GitHub review comments.

## Changes

### New Command: `/crew:review-pr [PR number]`
- Lists open PRs (excluding your own by default) for selection via `AskUserQuestion`
- Runs all 7 review legs in parallel (correctness, performance, security, elegance, resilience, style, smells)
- Creates task files for findings in `.claude/branches/{branch}/tasks/`
- Asks if user wants to post findings as GitHub PR review with file-level comments
- Supports COMMENT or REQUEST_CHANGES review types

### New Scripts
| Script | Purpose |
|--------|---------|
| `gh-pr-list-open.sh` | List open PRs, excludes your own by default (`--include-mine` to override) |
| `gh-pr-diff.sh` | Get PR diff and changed files (`--files-only` flag) |
| `gh-pr-post-review.sh` | Post reviews with file-level comments via GraphQL API |

### Version
1.53.0 → 1.54.2

## Test Plan

- [ ] Run `/crew:review-pr` without arguments - should show PR selection
- [ ] Run `/crew:review-pr 123` with specific PR number
- [ ] Verify own PRs are filtered out by default
- [ ] Test posting review comments to GitHub

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new /crew:review-pr command for multi-agent PR code review. It runs seven checks in parallel and can post file-level comments to GitHub as a review.

- **New Features**
  - Command /crew:review-pr: lists open PRs (excludes yours by default), runs 7-leg review, writes findings to task files, and can post a GitHub review as COMMENT or REQUEST_CHANGES.
  - Scripts added: gh-pr-list-open.sh (list PRs), gh-pr-diff.sh (diff or files-only), gh-pr-post-review.sh (submit reviews via GraphQL).

<sup>Written for commit 9975ea2906903b594a4b58ea3b4cd362120447cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

