### PR TITLE
feat(crew): improve worktree + machete integration

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.54.2",
+  "version": "1.55.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/README.md
+++ b/crew/README.md
@@ -6,36 +6,44 @@ Unified orchestration for work execution, skill creation, git conventions, and s
 
 ### Core Workflow
 
-| Command | Purpose |
-|---------|---------|
+| Command        | Purpose                                                 |
+| -------------- | ------------------------------------------------------- |
 | `/crew:design` | Create validated implementation plan from feature/issue |
-| `/crew:build` | Execute plan with TodoWrite progress tracking |
-| `/crew:check` | Multi-agent 7-leg code review with triage |
-| `/crew:fix` | Repair skills, resolve blockers |
+| `/crew:build`  | Execute plan with TodoWrite progress tracking           |
+| `/crew:check`  | Multi-agent 7-leg code review with triage               |
+| `/crew:fix`    | Repair skills, resolve blockers                         |
 
 ### Git Operations
 
-| Command | Purpose |
-|---------|---------|
-| `/crew:git:sync` | Rebase on main/parent + push + update PR |
-| `/crew:git:commit` | Create conventional commit |
-| `/crew:git:commit-and-push` | Commit + push + update PR |
-| `/crew:git:push` | Push to origin + update PR |
-| `/crew:git:pr` | Create pull request |
-| `/crew:git:fix-reviews` | Resolve PR comments and CI failures |
+| Command                     | Purpose                                  |
+| --------------------------- | ---------------------------------------- |
+| `/crew:git:sync`            | Rebase on main/parent + push + update PR |
+| `/crew:git:commit`          | Create conventional commit               |
+| `/crew:git:commit-and-push` | Commit + push + update PR                |
+| `/crew:git:push`            | Push to origin + update PR               |
+| `/crew:git:pr`              | Create pull request                      |
+| `/crew:git:fix-reviews`     | Resolve PR comments and CI failures      |
 
 ### Stacked PRs (git-machete)
 
-| Command | Purpose |
-|---------|---------|
-| `/crew:git:branch` | Create feature branch from main |
-| `/crew:git:stack-add` | Add branch to machete stack |
+| Command                  | Purpose                                  |
+| ------------------------ | ---------------------------------------- |
+| `/crew:git:branch`       | Create feature branch from main          |
+| `/crew:git:stack-add`    | Add branch to machete stack              |
 | `/crew:git:stack-status` | Show branch stack with visual indicators |
-| `/crew:git:traverse` | Sync entire stack with parents/remotes |
-| `/crew:git:slide-out` | Remove merged branches, update child PRs |
-| `/crew:git:retarget-pr` | Change PR base to match machete parent |
-| `/crew:git:restack-pr` | Retarget + force push after rebase |
-| `/crew:git:advance` | Fast-forward merge child into current |
+| `/crew:git:go`           | Navigate between branches in stack       |
+| `/crew:git:traverse`     | Sync entire stack with parents/remotes   |
+| `/crew:git:slide-out`    | Remove merged branches, update child PRs |
+| `/crew:git:retarget-pr`  | Change PR base to match machete parent   |
+| `/crew:git:restack-pr`   | Retarget + force push after rebase       |
+| `/crew:git:advance`      | Fast-forward merge child into current    |
+
+### Code Review
+
+| Command           | Purpose                                        |
+| ----------------- | ---------------------------------------------- |
+| `/crew:check`     | Multi-agent 7-leg code review                  |
+| `/crew:review-pr` | Review external PR with GitHub comment posting |
 
 ## Installation
 
@@ -108,7 +116,43 @@ For stacked branches (git-machete):
 /crew:git:pr             # Create PR with stack annotations
 /crew:git:retarget-pr    # Change PR base to match machete parent
 /crew:git:restack-pr     # Retarget + force push after rebase
+/crew:git:go down        # Navigate to child branch in stack
 ```
+
+### Worktrees + Stacked PRs
+
+**Recommended pattern: One worktree per stack**
+
+```
+main-checkout/          # Stack A: feat/auth → feat/auth-ui → feat/auth-tests
+worktree-payments/      # Stack B: feat/payments (independent feature)
+worktree-hotfix/        # Stack C: fix/critical (independent bugfix)
+```
+
+**Why this works:**
+
+- Stacked PRs are sequential (depend on each other) → work naturally with machete
+- Worktrees isolate independent work → no context switching between unrelated features
+- Each worktree can use full machete commands (`traverse`, `go`) within its stack
+
+**Navigation within a stack:**
+
+```
+/crew:git:go up          # Go to parent branch
+/crew:git:go down        # Go to child branch
+/crew:git:go next        # Go to sibling branch
+```
+
+The machete context automatically suggests next steps:
+
+- ✅ **PR approved** → suggests moving to child branch
+- ⏳ **PR open** → can continue on child while awaiting review
+- 🔀 **PR merged** → suggests slide-out then move to child
+
+**Safety detection:**
+
+- Single stack in worktree → all machete commands work normally
+- Multi-stack layout shared → warns about cross-stack navigation
 
 ### Code Review
 
@@ -120,22 +164,26 @@ For stacked branches (git-machete):
 ## Features
 
 ### Work Orchestration
+
 - Plan-driven development with `/crew:design`
 - Progress tracking with TodoWrite integration
 - Handoffs for context preservation across sessions
 - Iteration loops for autonomous completion
 
 ### Skill Management
+
 - Create new skills with guided workflows
 - Audit and improve existing skills
 - Templates for common skill patterns
 
 ### Git Conventions
+
 - Conventional commit format enforcement
 - Branch naming standards
 - PR workflow automation
 
 ### Hooks
+
 - Session state recovery on startup/resume
 - Auto-lint on file modifications
 - Git commit validation (requires CI pass)

--- a/crew/commands/git/go.md
+++ b/crew/commands/git/go.md
@@ -87,21 +87,26 @@ echo "Will checkout: $target"
 
 ## Step 3: Handle Worktree
 
-**If in a worktree:**
+Check `<worktree_status>` for `WORKTREE_MACHETE_SAFE` status:
 
-⚠️ Cannot switch branches in a worktree. Each worktree is bound to its branch.
+**If safe pattern (single stack):** Proceed normally - navigation within the stack is fine.
+
+**If unsafe pattern (multi-stack layout):**
 
 ```javascript
 AskUserQuestion({
   questions: [
     {
-      question:
-        "You're in a worktree. Cannot switch branches here. What to do?",
+      question: `Target branch "${target}" may be outside this worktree's stack. Continue?`,
       header: "Worktree",
       options: [
         {
-          label: "Show worktree path",
-          description: "Show where the target branch's worktree is",
+          label: "Continue anyway",
+          description: "Switch branches (know what you're doing)",
+        },
+        {
+          label: "Show main checkout path",
+          description: "Navigate in main checkout instead",
         },
         {
           label: "Create worktree",
@@ -113,6 +118,15 @@ AskUserQuestion({
     },
   ],
 });
+```
+
+**If "Create worktree":**
+
+```bash
+# Create worktree for target branch
+git worktree add "../$(basename $(pwd))-${target}" "$target"
+echo "Created worktree at: ../$(basename $(pwd))-${target}"
+echo "cd there to continue work on $target"
 ```
 
 ## Step 4: Check for Uncommitted Changes

--- a/crew/scripts/git/machete-context.sh
+++ b/crew/scripts/git/machete-context.sh
@@ -9,11 +9,11 @@ set -euo pipefail
 
 # Check if git-machete is installed
 if ! command -v git-machete &>/dev/null; then
-  echo "## Git Machete"
-  echo "⚠️ git-machete is not installed."
-  echo "Install with: \`brew install git-machete\` or \`pip install git-machete\`"
-  echo
-  exit 0
+	echo "## Git Machete"
+	echo "⚠️ git-machete is not installed."
+	echo "Install with: \`brew install git-machete\` or \`pip install git-machete\`"
+	echo
+	exit 0
 fi
 
 # Ensure optimal machete configuration
@@ -21,13 +21,13 @@ fi
 # squashMergeDetection=simple: Detect squash-merged PRs as merged
 # annotateWithUrls=true: Include full PR URLs in annotations
 configure_machete_setting() {
-  local key="$1"
-  local value="$2"
-  local current
-  current=$(git config --get "$key" 2>/dev/null || echo "")
-  if [[ "$current" != "$value" ]]; then
-    git config "$key" "$value"
-  fi
+	local key="$1"
+	local value="$2"
+	local current
+	current=$(git config --get "$key" 2>/dev/null || echo "")
+	if [[ "$current" != "$value" ]]; then
+		git config "$key" "$value"
+	fi
 }
 
 configure_machete_setting "machete.github.prDescriptionIntroStyle" "full"
@@ -36,7 +36,7 @@ configure_machete_setting "machete.github.annotateWithUrls" "true"
 
 # Check if in a git repo
 if ! git rev-parse --git-dir &>/dev/null; then
-  exit 0
+	exit 0
 fi
 
 branch=$(git branch --show-current 2>/dev/null || echo "")
@@ -51,103 +51,134 @@ echo
 
 # Check if machete file exists
 if [[ -f "$machete_file" ]]; then
-  echo "**Layout file:** \`${machete_file}\`"
-  echo
+	echo "**Layout file:** \`${machete_file}\`"
+	echo
 
-  # Check if current branch is in machete layout
-  if git machete is-managed "$branch" 2>/dev/null; then
-    echo "**Current branch:** \`$branch\` is in machete layout"
+	# Check if current branch is in machete layout
+	if git machete is-managed "$branch" 2>/dev/null; then
+		echo "**Current branch:** \`$branch\` is in machete layout"
 
-    # Get parent branch
-    parent=$(git machete show up 2>/dev/null || echo "")
-    if [[ -n "$parent" ]]; then
-      echo "**Parent branch:** \`$parent\`"
-    else
-      echo "**Parent branch:** (root branch)"
-    fi
+		# Get parent branch
+		parent=$(git machete show up 2>/dev/null || echo "")
+		if [[ -n "$parent" ]]; then
+			echo "**Parent branch:** \`$parent\`"
+		else
+			echo "**Parent branch:** (root branch)"
+		fi
 
-    # Get child branches
-    children=$(git machete show down 2>/dev/null || echo "")
-    if [[ -n "$children" ]]; then
-      echo "**Child branches:** \`$children\`"
-    fi
+		# Get child branches
+		children=$(git machete show down 2>/dev/null || echo "")
+		if [[ -n "$children" ]]; then
+			echo "**Child branches:** \`$children\`"
+		fi
 
-    # Check sync status
-    echo
-    echo "### Sync Status"
-    echo '```'
-    status_output=$(git machete status 2>/dev/null | head -25 || echo "(unable to get status)")
-    echo "$status_output"
-    echo '```'
+		# Check sync status
+		echo
+		echo "### Sync Status"
+		echo '```'
+		status_output=$(git machete status 2>/dev/null | head -25 || echo "(unable to get status)")
+		echo "$status_output"
+		echo '```'
 
-    # Detect merged branches (gray edges indicated by 'o' prefix in status)
-    merged_count=$(echo "$status_output" | grep -cE "^\s*o\s" 2>/dev/null || echo "0")
-    if [[ "$merged_count" -gt 0 ]]; then
-      echo
-      echo "🔀 **$merged_count merged branch(es) detected** — run \`Skill({ skill: \"crew:git:slide-out\" })\` to clean up"
-    fi
+		# Detect merged branches (gray edges indicated by 'o' prefix in status)
+		merged_count=$(echo "$status_output" | grep -cE "^\s*o\s" 2>/dev/null || echo "0")
+		if [[ "$merged_count" -gt 0 ]]; then
+			echo
+			echo "🔀 **$merged_count merged branch(es) detected** — run \`Skill({ skill: \"crew:git:slide-out\" })\` to clean up"
+		fi
 
-    # Check if out of sync with parent
-    if [[ -n "$parent" ]]; then
-      if ! git machete is-ancestor "$parent" "$branch" 2>/dev/null; then
-        echo
-        echo "⚠️ **Out of sync with parent** — run \`Skill({ skill: \"crew:git:sync\" })\` or \`git machete update\`"
-      fi
-    fi
+		# Check if out of sync with parent
+		if [[ -n "$parent" ]]; then
+			if ! git machete is-ancestor "$parent" "$branch" 2>/dev/null; then
+				echo
+				echo "⚠️ **Out of sync with parent** — run \`Skill({ skill: \"crew:git:sync\" })\` or \`git machete update\`"
+			fi
+		fi
 
-    # Edge coloring legend
-    echo
-    echo "### Edge Colors"
-    echo "- 🟢 **Green**: In sync with parent"
-    echo "- 🟡 **Yellow**: In sync but fork point differs (hidden commits)"
-    echo "- 🔴 **Red**: Out of sync, needs rebase"
-    echo "- ⚫ **Gray (o)**: Merged into parent, can be slid out"
-  else
-    echo "**Current branch:** \`$branch\` is NOT in machete layout"
-    echo
-    echo "To add to stack: \`git machete add --onto <parent-branch>\`"
-    echo
-    echo "### Current Layout"
-    echo '```'
-    cat "$machete_file" 2>/dev/null | head -20 || echo "(unable to read)"
-    echo '```'
-    echo
-    echo "### Available Parent Branches"
-    echo "Use these to populate stacking question options:"
-    echo '```json'
-    echo "["
-    echo '  { "branch": "main", "description": "Main branch" }'
+		# Edge coloring legend
+		echo
+		echo "### Edge Colors"
+		echo "- 🟢 **Green**: In sync with parent"
+		echo "- 🟡 **Yellow**: In sync but fork point differs (hidden commits)"
+		echo "- 🔴 **Red**: Out of sync, needs rebase"
+		echo "- ⚫ **Gray (o)**: Merged into parent, can be slid out"
 
-    # Get open PRs that could be parent branches
-    if command -v gh &>/dev/null; then
-      gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
-    fi
+		# Suggest next steps based on state
+		echo
+		echo "### Suggested Next Steps"
 
-    echo "]"
-    echo '```'
-  fi
+		# Check if current branch has children
+		if [[ -n "$children" ]]; then
+			# Check if current branch's PR is merged or approved
+			pr_state=$(gh pr view --json state,reviewDecision -q '.state + ":" + (.reviewDecision // "NONE")' 2>/dev/null || echo "")
+			if [[ "$pr_state" == "MERGED:"* ]]; then
+				echo "✅ **PR merged** — run \`Skill({ skill: \"crew:git:slide-out\" })\` then work on child"
+			elif [[ "$pr_state" == *":APPROVED" ]]; then
+				echo "✅ **PR approved** — consider moving to child: \`Skill({ skill: \"crew:git:go\", args: \"down\" })\`"
+			elif [[ "$pr_state" == "OPEN:"* ]]; then
+				echo "⏳ **PR open** — awaiting review. Can work on child: \`Skill({ skill: \"crew:git:go\", args: \"down\" })\`"
+			fi
+		fi
+
+		# Check if there's a sibling to work on
+		next_sibling=$(git machete show next 2>/dev/null || echo "")
+		if [[ -n "$next_sibling" ]]; then
+			echo "➡️ **Sibling branch available:** \`$next_sibling\` — \`Skill({ skill: \"crew:git:go\", args: \"next\" })\`"
+		fi
+
+		# Check if we're on a leaf (no children) and PR is open
+		if [[ -z "$children" ]]; then
+			pr_url=$(gh pr view --json url -q '.url' 2>/dev/null || echo "")
+			if [[ -n "$pr_url" ]]; then
+				echo "🍃 **Leaf branch with PR** — waiting for review or ready to extend stack"
+			fi
+		fi
+	else
+		echo "**Current branch:** \`$branch\` is NOT in machete layout"
+		echo
+		echo "To add to stack: \`git machete add --onto <parent-branch>\`"
+		echo
+		echo "### Current Layout"
+		echo '```'
+		cat "$machete_file" 2>/dev/null | head -20 || echo "(unable to read)"
+		echo '```'
+		echo
+		echo "### Available Parent Branches"
+		echo "Use these to populate stacking question options:"
+		echo '```json'
+		echo "["
+		echo '  { "branch": "main", "description": "Main branch" }'
+
+		# Get open PRs that could be parent branches
+		if command -v gh &>/dev/null; then
+			gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
+		fi
+
+		echo "]"
+		echo '```'
+	fi
 else
-  echo "**No machete layout** - \`${machete_file}\` does not exist"
-  echo
-  echo "To set up stacked branches, run \`Skill({ skill: \"crew:git:discover\" })\` or:"
-  echo "1. \`git machete discover\` - auto-detect layout from reflog"
-  echo "2. \`git machete edit\` - manually define layout"
-  echo
-  echo "**Note:** In worktrees, the machete file is shared with the main repo."
-  echo
-  echo "### Available Parent Branches"
-  echo "Use these to populate stacking question options:"
-  echo '```json'
-  echo "["
-  echo '  { "branch": "main", "description": "Main branch" }'
+	echo "**No machete layout** - \`${machete_file}\` does not exist"
+	echo
+	echo "To set up stacked branches, run \`Skill({ skill: \"crew:git:discover\" })\` or:"
+	echo "1. \`git machete discover\` - auto-detect layout from reflog"
+	echo "2. \`git machete edit\` - manually define layout"
+	echo
+	echo "**Note:** In worktrees, the machete file is shared with the main repo."
+	echo
+	echo "### Available Parent Branches"
+	echo "Use these to populate stacking question options:"
+	echo '```json'
+	echo "["
+	echo '  { "branch": "main", "description": "Main branch" }'
 
-  # Get open PRs that could be parent branches
-  if command -v gh &>/dev/null; then
-    gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
-  fi
+	# Get open PRs that could be parent branches
+	if command -v gh &>/dev/null; then
+		gh pr list --state open --json number,headRefName,title --limit 10 2>/dev/null | jq -r '.[] | ",  { \"branch\": \"\(.headRefName)\", \"description\": \"PR #\(.number): \(.title | .[0:50])\" }"' 2>/dev/null || true
+	fi
 
-  echo "]"
-  echo '```'
+	echo "]"
+	echo '```'
 fi
 
 echo

--- a/crew/scripts/git/worktree-context.sh
+++ b/crew/scripts/git/worktree-context.sh
@@ -1,50 +1,93 @@
 #!/usr/bin/env bash
 #
 # Provides git worktree context for commands
-# Detects if current directory is a worktree and shows related info
+# Detects if current directory is a worktree and analyzes machete safety
 #
 set -euo pipefail
 
 # Check if in a git repo
 if ! git rev-parse --git-dir &>/dev/null; then
-  echo "## Worktree Status"
-  echo "Not in a git repository"
-  # Use return when sourced, exit when executed directly
-  # shellcheck disable=SC2317
-  return 0 2>/dev/null || exit 0
+	echo "## Worktree Status"
+	echo "Not in a git repository"
+	# Use return when sourced, exit when executed directly
+	# shellcheck disable=SC2317
+	return 0 2>/dev/null || exit 0
 fi
 
 branch=$(git branch --show-current 2>/dev/null || echo "(detached)")
 git_dir=$(git rev-parse --git-dir)
 git_common_dir=$(git rev-parse --git-common-dir)
+machete_file="${git_common_dir}/machete"
 
 echo "## Worktree Status"
 echo
 
 # Determine if this is a worktree
 if [[ "$git_dir" != "$git_common_dir" ]]; then
-  echo "**Type:** Worktree (not main checkout)"
-  echo "**Current branch:** \`$branch\`"
-  echo "**Git dir:** \`$git_dir\`"
-  echo "**Common dir:** \`$git_common_dir\`"
-  echo
-  echo "### Worktree Safety"
-  echo "⚠️ **Branch-switching commands are dangerous in worktrees!**"
-  echo
-  echo "**Safe commands:**"
-  echo "- \`git machete update\` - rebase current branch onto parent"
-  echo "- \`git machete status\` - view stack status"
-  echo "- \`git machete show up/down\` - view parent/child"
-  echo
-  echo "**Dangerous commands (will break worktree):**"
-  echo "- \`git machete traverse\` - switches between branches"
-  echo "- \`git machete go up/down\` - switches to parent/child"
-  echo "- \`git checkout <other-branch>\` - defeats worktree purpose"
-  IS_WORKTREE="true"
+	echo "**Type:** Worktree (not main checkout)"
+	echo "**Current branch:** \`$branch\`"
+	echo "**Git dir:** \`$git_dir\`"
+	echo "**Common dir:** \`$git_common_dir\`"
+	IS_WORKTREE="true"
+
+	# Analyze machete layout to determine safety
+	echo
+	if [[ -f "$machete_file" ]]; then
+		# Count root branches (lines without leading whitespace, excluding main/master)
+		root_branches=$(grep -cE "^[a-zA-Z]" "$machete_file" 2>/dev/null || echo "0")
+		# Get all branches in layout
+		all_branches=$(grep -oE "[a-zA-Z][a-zA-Z0-9/_-]*" "$machete_file" 2>/dev/null | sort -u)
+		branch_count=$(echo "$all_branches" | wc -l | tr -d ' ')
+
+		# Check if current branch is in the layout
+		if echo "$all_branches" | grep -qxF "$branch"; then
+			in_layout="true"
+		else
+			in_layout="false"
+		fi
+
+		echo "### Machete Analysis"
+
+		if [[ "$root_branches" -le 2 && "$in_layout" == "true" ]]; then
+			# Single stack pattern: main + one feature branch tree
+			echo "✅ **Safe pattern detected:** Single stack in this worktree"
+			echo
+			echo "All machete commands work normally:"
+			echo "- \`git machete traverse -W -y\` — sync entire stack"
+			echo "- \`git machete go up/down\` — navigate stack"
+			echo "- \`git machete update\` — rebase current branch"
+			WORKTREE_MACHETE_SAFE="true"
+		elif [[ "$branch_count" -gt 5 || "$root_branches" -gt 2 ]]; then
+			# Multi-stack pattern: multiple independent feature branches
+			echo "⚠️ **Shared layout detected:** Machete file has multiple stacks"
+			echo
+			echo "**Recommendation:** Use main checkout for \`traverse\`/\`go\`, or:"
+			echo "1. Create separate worktrees per independent stack"
+			echo "2. Edit machete layout to only include this worktree's branches"
+			echo
+			echo "**Safe in this worktree:**"
+			echo "- \`git machete update\` — rebase current branch only"
+			echo "- \`git machete status\` — view (read-only)"
+			echo
+			echo "**Potentially unsafe (may switch to wrong branch):**"
+			echo "- \`git machete traverse\` — walks ALL branches in layout"
+			echo "- \`git machete go up/down\` — may switch to unrelated branch"
+			WORKTREE_MACHETE_SAFE="false"
+		else
+			echo "ℹ️ **Small layout:** Machete commands likely safe"
+			WORKTREE_MACHETE_SAFE="true"
+		fi
+	else
+		echo "ℹ️ No machete layout — worktree is independent"
+		WORKTREE_MACHETE_SAFE="true"
+	fi
 else
-  echo "**Type:** Main checkout (not a worktree)"
-  echo "**Current branch:** \`$branch\`"
-  IS_WORKTREE="false"
+	echo "**Type:** Main checkout (not a worktree)"
+	echo "**Current branch:** \`$branch\`"
+	echo
+	echo "✅ All machete commands work normally in main checkout."
+	IS_WORKTREE="false"
+	WORKTREE_MACHETE_SAFE="true"
 fi
 
 echo
@@ -55,5 +98,16 @@ echo '```'
 git worktree list 2>/dev/null || echo "(unable to list worktrees)"
 echo '```'
 
+# Best practice hint
+worktree_count=$(git worktree list 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$worktree_count" -gt 1 ]]; then
+	echo
+	echo "### Best Practice"
+	echo "- **Main checkout**: Primary stack, full \`traverse\` support"
+	echo "- **Worktrees**: Independent features/hotfixes, isolated context"
+	echo "- **One stack per worktree**: Keeps machete commands safe"
+fi
+
 # Export for use in conditionals (when sourced)
 export IS_WORKTREE
+export WORKTREE_MACHETE_SAFE


### PR DESCRIPTION
## Summary

Improve the integration between git worktrees and git-machete for stacked PR workflows.

## Changes

### Worktree Detection (`worktree-context.sh`)
- **Smart safety analysis**: Detects single-stack vs multi-stack machete layouts
- **Safe pattern**: When worktree is dedicated to one stack, all machete commands work normally
- **Multi-stack warning**: Only warns when navigation might cross stack boundaries
- **Best practices hint**: Shows recommended worktree patterns

### Machete Context (`machete-context.sh`)
- **Suggested Next Steps**: Automatically suggests navigation based on PR state:
  - ✅ PR approved → suggests `/crew:git:go down`
  - ⏳ PR open → can work on child while awaiting review
  - 🔀 PR merged → suggests slide-out then move to child
- **Sibling detection**: Shows available sibling branches

### Go Command (`go.md`)
- Uses `WORKTREE_MACHETE_SAFE` for context-aware behavior
- Allows navigation within stack even in worktrees (safe pattern)
- Offers worktree creation for cross-stack navigation

### Documentation
- New "Worktrees + Stacked PRs" section in README
- Documents one-worktree-per-stack pattern
- Added `/crew:git:go` and `/crew:review-pr` to command tables

## Version
crew: 1.54.2 → 1.55.0

## Test Plan
- [ ] Run worktree-context.sh in main checkout (should show "all commands safe")
- [ ] Run in worktree with single stack (should show "safe pattern")
- [ ] Run `/crew:git:go down` in worktree with dedicated stack
- [ ] Verify machete context shows "Suggested Next Steps"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds smart worktree safety detection and context-aware navigation for git-machete stacks. The go command now safely navigates within a worktree stack and offers worktree creation for cross-stack moves, while machete context suggests next steps based on PR state.

- **New Features**
  - Worktree analysis: detects single vs multi-stack and exports WORKTREE_MACHETE_SAFE.
  - Safe pattern: allow traverse/go within dedicated worktree; warn on shared multi-stack.
  - go command respects WORKTREE_MACHETE_SAFE; prompt to continue, open main checkout, or create a new worktree.
  - Machete context adds Suggested Next Steps (approved/open/merged), plus sibling detection.
  - Version bump to 1.55.0.

- **Documentation**
  - New “Worktrees + Stacked PRs” section with one-worktree-per-stack guidance and navigation examples.
  - Added /crew:git:go and /crew:review-pr to command tables.

<sup>Written for commit 0619905ed57d650ff17ab2e290e4652dfea56cdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

