### PR TITLE
feat(crew): add ast-grep skill triggers and expand plugin setup

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.55.2",
+  "version": "1.56.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/scripts/hooks/pre-tool/suggest-skill.sh
+++ b/crew/scripts/hooks/pre-tool/suggest-skill.sh
@@ -34,6 +34,16 @@ if [[ $CMD_LINE =~ ^git\ push ]]; then
   SUGGESTION="⚠️ **BEFORE PUSHING:** Use Skill(skill: \"crew:ci\") to catch issues early."
 fi
 
+# Sed/grep patterns that look like code refactoring - suggest ast-grep
+# Patterns: sed with s/ replacement, for loops with sed/grep, grep -l piped to xargs
+if [[ $CMD_LINE =~ sed[[:space:]]+-i?[[:space:]]*[\'\"]?s/ ]] ||
+  [[ $CMD_LINE =~ for[[:space:]]+.*in.*\$\(.*grep ]] ||
+  [[ $CMD_LINE =~ grep[[:space:]]+-[lr].*\|.*sed ]] ||
+  [[ $CMD_LINE =~ grep[[:space:]]+-[lr].*\|.*xargs ]] ||
+  [[ $COMMAND =~ import.*from ]] && [[ $CMD_LINE =~ sed ]]; then
+  SUGGESTION="⚠️ **USE SKILL:** Consider Skill(skill: \"crew:ast-grep\") for syntax-aware code refactoring. ast-grep understands code structure, ignores strings/comments, and is safer for mass changes."
+fi
+
 # Output suggestion if we have one
 if [[ -n $SUGGESTION ]]; then
   # Use jq to properly escape the suggestion for JSON

--- a/crew/scripts/hooks/session-start/inject-skills.sh
+++ b/crew/scripts/hooks/session-start/inject-skills.sh
@@ -19,17 +19,46 @@ cat <<'EOF'
 | `/crew:git:branch` | Create feature branch |
 | `/crew:git:sync` | Sync branch with main |
 
-### Skills (auto-loaded by triggers)
+### Skills - Crew Plugin (auto-loaded by triggers)
 | Skill | Triggers | Purpose |
 |-------|----------|---------|
+| ast-grep | rename, replace, refactor, imports | AST-aware code search & refactor |
 | git | commit, branch, pr | Git conventions and workflows |
 | agent-architecture | agent, orchestration | Agent patterns and loops |
 | skill-builder | skill, create skill | Skill creation framework |
 | todo-tracking | todo, task | File-based task management |
 
+### Skills - Devtools Plugin (auto-loaded by triggers)
+| Skill | Triggers | Purpose |
+|-------|----------|---------|
+| react | .tsx, component, tailwind, tanstack | React 19 + Tailwind CSS v4 + shadcn |
+| shadcn | shadcn, components/ui, cn() | shadcn/ui components via MCP |
+| drizzle | drizzle, pgTable, db.select | Drizzle ORM for PostgreSQL |
+| vitest | vitest, describe, it, expect | Unit testing patterns |
+| playwright | playwright, e2e, getByRole | E2E testing with Page Objects |
+| tdd-typescript | implement, add feature | RED-GREEN-REFACTOR workflow |
+| solidity | .sol, contract, forge | Smart contracts with Foundry |
+| viem | viem, publicClient, walletClient | Ethereum client interactions |
+| tanstack-start | createFileRoute, loader | Full-stack React framework |
+| git-machete | stacked, machete, branch stack | Stacked PR workflows |
+| troubleshooting | help debug, troubleshoot | Structured debugging workflow |
+
+### LSP Features (typescript-lsp plugin)
+When working with TypeScript/JavaScript files, you have LSP capabilities:
+- **Go to definition**: Find where symbols are defined
+- **Find references**: Find all usages of a symbol
+- **Error checking**: Real-time type errors and diagnostics
+
+### Code Simplifier Agent (code-simplifier plugin)
+Use Task tool with subagent_type="code-simplifier" to refine recently modified code:
+- Simplifies code for clarity, consistency, and maintainability
+- Preserves all functionality while improving structure
+- Applies project-specific standards from CLAUDE.md
+
 ### Best Practices
 - **Git commits**: Use conventional format `type(scope): description`
 - **CI checks**: Use Skill(skill: "crew:ci") to run in background (keeps main thread free)
+- **Code refactoring**: Use Skill(skill: "crew:ast-grep") for mass rename/replace (NOT grep+sed)
 - **Planning**: Use Skill(skill: "crew:design") before implementing complex features
 - **Progress**: Use TodoWrite to track multi-step tasks
 EOF

--- a/crew/scripts/hooks/session-start/setup-plugins.sh
+++ b/crew/scripts/hooks/session-start/setup-plugins.sh
@@ -160,6 +160,12 @@ force_update_plugin() {
 
 echo "Step 1: Adding Marketplaces"
 echo "----------------------------"
+# Claude Official marketplace is often preinstalled - silently skip errors
+if ! claude plugin marketplace add "anthropics/claude-plugins-official" &>/dev/null; then
+  success "Claude Official marketplace already configured"
+else
+  success "Claude Official marketplace added"
+fi
 add_marketplace "settlemint/agent-marketplace" "SettleMint"
 add_marketplace "sawyerhood/dev-browser" "Dev Browser"
 add_marketplace "thedotmack/claude-mem" "Claude Mem"
@@ -167,6 +173,7 @@ echo ""
 
 echo "Step 2: Updating Marketplaces"
 echo "-----------------------------"
+update_marketplace "claude-plugins-official"
 update_marketplace "settlemint"
 update_marketplace "dev-browser-marketplace"
 update_marketplace "thedotmack"
@@ -174,6 +181,13 @@ echo ""
 
 echo "Step 3: Updating Plugins"
 echo "------------------------"
+echo ""
+
+echo "Official plugins (Anthropic):"
+force_update_plugin "ralph-loop@claude-plugins-official" "ralph-loop (autonomous loops)"
+force_update_plugin "frontend-design@claude-plugins-official" "frontend-design (UI generation)"
+force_update_plugin "typescript-lsp@claude-plugins-official" "typescript-lsp (TS/JS language server)"
+force_update_plugin "code-simplifier@claude-plugins-official" "code-simplifier (code refinement)"
 echo ""
 
 echo "Core plugins (SettleMint):"
@@ -192,6 +206,10 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
   echo -e "${GREEN}Setup complete!${NC}"
   echo ""
   echo "Installed plugins:"
+  echo "  • ralph-loop@claude-plugins-official - Autonomous agent loops"
+  echo "  • frontend-design@claude-plugins-official - High-quality UI generation"
+  echo "  • typescript-lsp@claude-plugins-official - TypeScript/JavaScript LSP"
+  echo "  • code-simplifier@claude-plugins-official - Code refinement agent"
   echo "  • crew@settlemint - Work orchestration (/design, /build, /check)"
   echo "  • devtools@settlemint - Development skills (React, API, etc.)"
   echo "  • dev-browser - Browser automation"

--- a/crew/skills/ast-grep/SKILL.md
+++ b/crew/skills/ast-grep/SKILL.md
@@ -2,6 +2,7 @@
 name: ast-grep
 description: Mass rename/replace across codebase. Use when user asks to rename functions, replace patterns, or refactor code across files. Better than grep for code changes.
 triggers:
+  # Explicit requests
   - "rename all"
   - "replace all.*with"
   - "refactor.*across"
@@ -9,6 +10,21 @@ triggers:
   - "find and replace"
   - "ast-grep"
   - "sg "
+  # Import modifications
+  - "fix.*import"
+  - "remove.*import"
+  - "unused import"
+  - "clean.*import"
+  - "update.*import.*across"
+  # Lint/code fixes at scale
+  - "fix.*across.*files"
+  - "fix all.*lint"
+  - "remove.*from.*files"
+  # Pattern-based changes
+  - "replace.*pattern"
+  - "change.*syntax"
+  - "migrate.*to"
+  - "convert all"
 ---
 
 <objective>


### PR DESCRIPTION
## Summary

- Add PreToolUse hook that suggests `ast-grep` skill when detecting sed/grep refactoring patterns
- Expand ast-grep skill triggers to cover more refactoring scenarios
- Add Claude Official marketplace and Anthropic plugins to session-start setup
- Improve skill documentation in session inject table

## Changes

### PreToolUse hook suggestion
Detects bash commands using `sed -i`, `grep -l | xargs`, or similar patterns that indicate code refactoring. Suggests using `Skill(skill: "crew:ast-grep")` as a safer, syntax-aware alternative.

### ast-grep skill triggers
Added triggers for:
- Import modifications (`fix imports`, `remove imports`, `unused imports`)
- Lint fixes at scale (`fix all lint`, `fix across files`)
- Pattern-based changes (`replace pattern`, `migrate to`, `convert all`)

### Plugin setup expansion
Added Claude Official marketplace with Anthropic plugins:
- `ralph-loop` - Autonomous agent loops
- `frontend-design` - High-quality UI generation  
- `typescript-lsp` - TypeScript/JavaScript language server
- `code-simplifier` - Code refinement agent

### Inject skills documentation
Expanded the session-start skill table to include:
- All devtools plugin skills (react, shadcn, drizzle, vitest, etc.)
- LSP features from typescript-lsp plugin
- Code simplifier agent usage

## Test plan

- [ ] Start new Claude Code session, verify expanded skill table appears
- [ ] Run `sed -i 's/foo/bar/' file.ts`, verify ast-grep suggestion appears
- [ ] Run `/crew:ast-grep` or trigger with "rename all", verify skill loads
- [ ] Run session-start hooks, verify Official marketplace plugins install

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ast-grep suggestion for risky grep/sed refactor commands and broadens ast-grep triggers for common code changes. Also expands session setup to include Anthropic official plugins and updates the injected skills docs.

- **New Features**
  - PreToolUse hook suggests Skill(skill: "crew:ast-grep") for sed -i, grep -l | xargs, and similar refactor patterns.
  - Expanded ast-grep triggers for import fixes, lint-at-scale, and pattern/migration changes (rename, replace, convert).
  - Updated session-start docs to list devtools skills, TypeScript LSP features, and the code-simplifier agent.

- **Dependencies**
  - Added Claude Official marketplace and installed official plugins: ralph-loop, frontend-design, typescript-lsp, code-simplifier.

<sup>Written for commit 1f93078a6c10e76de67757cb5427032ed00a92a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

