### PR TITLE
fix(crew): resolve PostToolUse hook arithmetic error in check-comments

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/scripts/hooks/post-tool/check-comments.sh
+++ b/crew/scripts/hooks/post-tool/check-comments.sh
@@ -71,7 +71,7 @@ fi
 [[ -z "$CONTENT" ]] && exit 0
 
 # Count lines
-total_lines=$(echo "$CONTENT" | grep -cv '^[[:space:]]*$' || echo 0)
+total_lines=$(echo "$CONTENT" | grep -cv '^[[:space:]]*$' || true)
 [[ "$total_lines" -eq 0 ]] && exit 0
 
 # Count comment lines based on language
@@ -82,13 +82,13 @@ count_comment_lines() {
 
   case "$ext" in
     py)
-      count=$(echo "$content" | grep -c '^[[:space:]]*#' || echo 0)
+      count=$(echo "$content" | grep -c '^[[:space:]]*#' || true)
       ;;
     ts | tsx | js | jsx | java | go | rs | cpp | c | sol)
       # Count // and /* style comments
-      count=$(echo "$content" | grep -c '^\s*//' || echo 0)
-      count=$((count + $(echo "$content" | grep -c '^\s*/\*' || echo 0)))
-      count=$((count + $(echo "$content" | grep -c '^\s*\*' || echo 0)))
+      count=$(echo "$content" | grep -c '^[[:space:]]*//' || true)
+      count=$((count + $(echo "$content" | grep -c '^[[:space:]]*/\*' || true)))
+      count=$((count + $(echo "$content" | grep -c '^[[:space:]]*\*' || true)))
       ;;
   esac
 


### PR DESCRIPTION
## Summary

Fixed an arithmetic error in the PostToolUse:Edit hook that was causing hook failures when running post-tool checks on code files.

## Root Cause

The `grep -c` command returns exit code 1 when it finds zero matches, but still outputs "0". Using `|| echo 0` as a fallback caused duplicate output ("0\n0"), which broke the `$((...))` arithmetic expansion.

## Changes

- Replaced `|| echo 0` with `|| true` in grep command substitutions to prevent duplicate output
- Replaced non-portable `\s` escape sequence with POSIX `[[:space:]]` in grep patterns for better portability
- Bumped version to 1.56.1 per release guidelines

## Testing

- Verified hook now exits cleanly on code files with and without comments
- Confirmed arithmetic calculations work correctly with grep counts of 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PostToolUse check-comments hook so arithmetic works when grep returns zero matches. Makes the grep patterns portable across environments.

- **Bug Fixes**
  - Use "|| true" with grep -c to prevent duplicate "0" output that broke arithmetic.
  - Replace "\s" with POSIX "[[:space:]]" in patterns.
  - Bump plugin version to 1.56.1.

<sup>Written for commit 6919611ebe3b005d9f4031d5e153faccd406a928. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

