### PR TITLE
feat(crew): add Phantom CLI skill and worktree commands

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.56.1",
+  "version": "1.58.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/.mcp.json
+++ b/crew/.mcp.json
@@ -23,6 +23,11 @@
     "restate-docs": {
       "type": "http",
       "url": "https://docs.restate.dev/mcp"
+    },
+    "phantom": {
+      "type": "stdio",
+      "command": "phantom",
+      "args": ["mcp", "serve"]
     }
   }
 }

--- a/crew/README.md
+++ b/crew/README.md
@@ -21,8 +21,19 @@ Unified orchestration for work execution, skill creation, git conventions, and s
 | `/crew:git:commit`          | Create conventional commit               |
 | `/crew:git:commit-and-push` | Commit + push + update PR                |
 | `/crew:git:push`            | Push to origin + update PR               |
+| `/crew:git:branch-new`      | Create branch with username prefix       |
 | `/crew:git:pr`              | Create pull request                      |
 | `/crew:git:fix-reviews`     | Resolve PR comments and CI failures      |
+
+### Worktrees (phantom)
+
+| Command                          | Purpose                         |
+| -------------------------------- | ------------------------------- |
+| `/crew:git:worktree`             | Create worktree and auto-switch |
+| `/crew:git:worktree-switch`      | Switch to existing worktree     |
+| `/crew:git:worktree-list`        | List all worktrees              |
+| `/crew:git:worktree-delete`      | Delete a worktree               |
+| `/crew:git:worktree-checkout-pr` | Checkout PR into new worktree   |
 
 ### Stacked PRs (git-machete)
 
@@ -70,6 +81,16 @@ Or use a local plugin directory:
 ```bash
 claude --plugin-dir ~/Development/agent-marketplace/crew
 ```
+
+### Prerequisites
+
+**Phantom CLI** (for worktree commands):
+
+```bash
+brew install phantom
+```
+
+Phantom is auto-detected on session start. If not installed, worktree commands will suggest installation.
 
 ## Standard Workflows
 
@@ -129,11 +150,21 @@ worktree-payments/      # Stack B: feat/payments (independent feature)
 worktree-hotfix/        # Stack C: fix/critical (independent bugfix)
 ```
 
+**Creating worktrees (auto-switches to new worktree):**
+
+```
+/crew:git:worktree       # Create and switch to new worktree
+/crew:git:worktree-switch  # Switch between existing worktrees
+```
+
+Branch names are auto-generated with username prefix: `username/type/description`
+
 **Why this works:**
 
 - Stacked PRs are sequential (depend on each other) → work naturally with machete
 - Worktrees isolate independent work → no context switching between unrelated features
 - Each worktree can use full machete commands (`traverse`, `go`) within its stack
+- Auto-switch means no manual `phantom shell` or `cd` needed
 
 **Navigation within a stack:**
 
@@ -153,6 +184,14 @@ The machete context automatically suggests next steps:
 
 - Single stack in worktree → all machete commands work normally
 - Multi-stack layout shared → warns about cross-stack navigation
+
+**Worktree management:**
+
+```
+/crew:git:worktree-list    # See all worktrees
+/crew:git:worktree-delete  # Clean up completed worktrees
+/crew:git:worktree-checkout-pr  # Review PR in isolated worktree
+```
 
 ### Code Review
 
@@ -199,16 +238,43 @@ crew/
 │   ├── design.md
 │   ├── build.md
 │   ├── check.md
-│   └── fix.md
+│   ├── fix.md
+│   └── git/
+│       ├── branch.md
+│       ├── branch-new.md
+│       ├── commit.md
+│       ├── commit-and-push.md
+│       ├── push.md
+│       ├── sync.md
+│       ├── pr.md
+│       ├── worktree.md
+│       ├── worktree-switch.md
+│       ├── worktree-list.md
+│       ├── worktree-delete.md
+│       └── worktree-checkout-pr.md
 ├── skills/
-│   └── crew/
-│       ├── SKILL.md
-│       ├── references/
-│       ├── templates/
-│       ├── workflows/
-│       └── scripts/
+│   ├── git/
+│   │   └── references/conventions.md
+│   ├── phantom/
+│   │   ├── SKILL.md
+│   │   ├── references/
+│   │   │   ├── commands.md
+│   │   │   ├── configuration.md
+│   │   │   └── mcp.md
+│   │   └── workflows/
+│   │       ├── create-worktree.md
+│   │       ├── cleanup.md
+│   │       └── github-workflow.md
+│   └── todo-tracking/
+├── scripts/
+│   └── git/
+│       ├── phantom-context.sh
+│       ├── machete-context.sh
+│       └── worktree-context.sh
 ├── hooks/
 │   └── hooks.json
+├── rules/
+│   └── phantom-workflow.md
 └── README.md
 ```
 

--- a/crew/commands/git/branch-new.md
+++ b/crew/commands/git/branch-new.md
@@ -1,0 +1,95 @@
+---
+name: crew:git:branch-new
+description: Create a new branch with username prefix naming convention
+argument-hint: "[description] [--base main|current]"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+<notes>
+CANONICAL location for branch creation with username prefix.
+Pattern: username/type/description (e.g., roderik/feat/user-auth)
+</notes>
+
+<process>
+
+<phase name="ask-type">
+**Ask for branch type:**
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What type of branch is this?",
+      header: "Type",
+      options: [
+        { label: "Feature", description: "New feature (feat/)" },
+        { label: "Bug fix", description: "Fix a bug (fix/)" },
+        { label: "Hotfix", description: "Critical fix (hotfix/)" },
+        { label: "Chore", description: "Maintenance (chore/)" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+</phase>
+
+<phase name="generate-name">
+**Generate branch name with username prefix:**
+
+```javascript
+const username = Bash({ command: "whoami" }).trim();
+const typeMap = {
+  Feature: "feat",
+  "Bug fix": "fix",
+  Hotfix: "hotfix",
+  Chore: "chore",
+};
+const type = typeMap[selectedType];
+const slug = slugify(description); // kebab-case, max 30 chars
+const suggestedName = `${username}/${type}/${slug}`;
+
+AskUserQuestion({
+  questions: [
+    {
+      question: `Use this branch name: ${suggestedName}?`,
+      header: "Name",
+      options: [
+        { label: "Use suggested", description: suggestedName },
+        { label: "Customize", description: "Enter a different name" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+
+const branchName = customName || suggestedName;
+```
+
+</phase>
+
+<phase name="create-branch">
+**Create the branch:**
+
+```bash
+# If --base main specified (or default for simple branches)
+git fetch origin main && git checkout -b <branchName> origin/main
+
+# If --base current (for stacked branches)
+git checkout -b <branchName>
+```
+
+</phase>
+
+</process>
+
+<success_criteria>
+
+- [ ] Username prefix in branch name
+- [ ] User confirmed or customized name
+- [ ] Branch created from correct base
+
+</success_criteria>

--- a/crew/commands/git/commit-and-push.md
+++ b/crew/commands/git/commit-and-push.md
@@ -17,61 +17,30 @@ allowed-tools:
   - Skill
 ---
 
-<worktree_status>
-!`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
-</worktree_status>
-
-<stack_context>
-!`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
-</stack_context>
-
 <commit_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/commit-context.sh 2>&1`
 </commit_context>
 
 <notes>
-Commit format per @rules/git-safety.md
+This command delegates to canonical skill locations for each phase.
 </notes>
 
 <process>
 
-<phase name="sync-stack">
-**Check `<stack_context>` above. If it shows "is in machete layout", sync with parent FIRST:**
-
-```bash
-# Only run if machete-managed (check stack_context output)
-if git machete is-managed "$(git branch --show-current)" 2>/dev/null; then
-  git fetch origin
-  git machete update    # Rebase onto parent (safe in worktrees)
-fi
-```
-
-</phase>
-
 <phase name="commit">
-1. If sensitive files flagged → `git reset HEAD <file>`
-2. `git add <files>`
-3. `git commit -m "type(scope): description"`
+**Create conventional commit:**
+
+```javascript
+Skill({ skill: "crew:git:commit" });
+```
 
 </phase>
 
 <phase name="push">
-```bash
-git push -u origin $(git branch --show-current)
-```
-
-Never `--force` unless explicitly requested. If rejected:
-
-- `git pull --rebase` first, then retry
-- If machete-managed: `git push --force-with-lease`
-
-</phase>
-
-<phase name="update-pr">
-**After successful push, update PR (if exists):**
+**Sync stack (if machete), push, and update PR:**
 
 ```javascript
-Skill({ skill: "crew:git:update-pr" });
+Skill({ skill: "crew:git:push" });
 ```
 
 </phase>

--- a/crew/commands/git/worktree-checkout-pr.md
+++ b/crew/commands/git/worktree-checkout-pr.md
@@ -1,0 +1,26 @@
+---
+name: crew:git:worktree-checkout-pr
+description: Create a worktree from a GitHub PR or issue
+argument-hint: "<PR or issue number>"
+allowed-tools:
+  - Bash
+---
+
+<process>
+
+```bash
+# Checkout PR or issue into a new worktree
+phantom gh checkout <number>
+```
+
+**Output:**
+
+```
+Checked out PR/issue #<number>
+Worktree created at: <path>
+
+To work on this:
+  phantom shell <branch-name>
+```
+
+</process>

--- a/crew/commands/git/worktree-delete.md
+++ b/crew/commands/git/worktree-delete.md
@@ -1,0 +1,47 @@
+---
+name: crew:git:worktree-delete
+description: Delete a phantom worktree and its branch
+argument-hint: "<worktree-name>"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+<process>
+
+**Confirm deletion if worktree has uncommitted changes:**
+
+```javascript
+// Check for uncommitted changes
+const status = Bash({ command: `phantom exec ${name} git status --porcelain` });
+if (status.trim()) {
+  AskUserQuestion({
+    questions: [
+      {
+        question: `Worktree ${name} has uncommitted changes. Delete anyway?`,
+        header: "Confirm",
+        options: [
+          {
+            label: "Delete with changes",
+            description: "Force delete, losing uncommitted work",
+          },
+          { label: "Cancel", description: "Keep the worktree" },
+        ],
+        multiSelect: false,
+      },
+    ],
+  });
+}
+```
+
+**Delete the worktree:**
+
+```bash
+# Regular delete
+phantom delete <name>
+
+# Force delete if confirmed
+phantom delete <name> --force
+```
+
+</process>

--- a/crew/commands/git/worktree-list.md
+++ b/crew/commands/git/worktree-list.md
@@ -1,0 +1,14 @@
+---
+name: crew:git:worktree-list
+description: List all phantom worktrees
+allowed-tools:
+  - Bash
+---
+
+<process>
+
+```bash
+phantom list
+```
+
+</process>

--- a/crew/commands/git/worktree-switch.md
+++ b/crew/commands/git/worktree-switch.md
@@ -1,0 +1,91 @@
+---
+name: crew:git:worktree-switch
+description: Switch to a different worktree
+argument-hint: "[worktree name]"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+skills:
+  - crew:phantom
+---
+
+<phantom_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/phantom-context.sh`
+</phantom_context>
+
+<notes>
+Switches the current shell session to a different worktree using cd.
+</notes>
+
+<process>
+
+<phase name="list-worktrees">
+**Get available worktrees:**
+
+```bash
+phantom list
+```
+
+</phase>
+
+<phase name="select-worktree">
+**If no argument provided, ask user to select:**
+
+```javascript
+// Get worktree names
+const worktrees = Bash({ command: "phantom list --names" }).trim().split("\n");
+
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which worktree do you want to switch to?",
+      header: "Worktree",
+      options: worktrees.slice(0, 4).map((wt) => ({
+        label: wt,
+        description: `Switch to ${wt}`,
+      })),
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+</phase>
+
+<phase name="switch">
+**Switch to the selected worktree:**
+
+```bash
+# Get the worktree path
+wtPath=$(phantom where <worktreeName>)
+
+# Switch to it
+cd "$wtPath"
+
+# Verify the switch
+pwd
+git branch --show-current
+```
+
+</phase>
+
+<phase name="confirm">
+**Confirm the switch:**
+
+```
+Switched to worktree: <worktreeName>
+Location: <path>
+Branch: <branch>
+```
+
+</phase>
+
+</process>
+
+<success_criteria>
+
+- [ ] Worktree selected (from arg or prompt)
+- [ ] Directory changed to worktree path
+- [ ] Current branch confirmed
+
+</success_criteria>

--- a/crew/commands/git/worktree.md
+++ b/crew/commands/git/worktree.md
@@ -1,0 +1,140 @@
+---
+name: crew:git:worktree
+description: Create a new phantom worktree for isolated development
+argument-hint: "[branch name or feature description]"
+allowed-tools:
+  - Read
+  - Bash
+  - AskUserQuestion
+  - TodoWrite
+skills:
+  - crew:phantom
+---
+
+<phantom_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/phantom-context.sh`
+</phantom_context>
+
+<notes>
+This is the CANONICAL location for worktree creation. Other commands delegate here.
+Branch names use pattern: username/type/description
+</notes>
+
+<process>
+
+<phase name="ask-type">
+**Ask for worktree type:**
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What type of worktree do you want to create?",
+      header: "Type",
+      options: [
+        { label: "Feature", description: "New feature development (feat/)" },
+        { label: "Bug fix", description: "Fix an existing bug (fix/)" },
+        { label: "Hotfix", description: "Critical production fix (hotfix/)" },
+        { label: "Experiment", description: "Test an approach (experiment/)" },
+      ],
+      multiSelect: false,
+    },
+    {
+      question: "What should it be based on?",
+      header: "Base",
+      options: [
+        {
+          label: "main",
+          description: "Start fresh from main branch (Recommended)",
+        },
+        { label: "Current branch", description: "Branch from current work" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+</phase>
+
+<phase name="generate-name">
+**Generate branch name with username prefix:**
+
+```javascript
+// Get username from system
+const username = Bash({ command: "whoami" }).trim();
+
+// Auto-generate branch name with username prefix
+const typeMap = {
+  Feature: "feat",
+  "Bug fix": "fix",
+  Hotfix: "hotfix",
+  Experiment: "experiment",
+};
+const type = typeMap[selectedType];
+const slug = slugify(description); // kebab-case, max 30 chars
+const suggestedName = `${username}/${type}/${slug}`;
+
+AskUserQuestion({
+  questions: [
+    {
+      question: `Use this branch name: ${suggestedName}?`,
+      header: "Name",
+      options: [
+        { label: "Use suggested", description: suggestedName },
+        { label: "Customize", description: "Enter a different name" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+
+const branchName = customName || suggestedName;
+```
+
+</phase>
+
+<phase name="create-worktree">
+**Create the worktree and switch to it:**
+
+```bash
+# Determine base branch
+base="${base_choice === 'main' ? 'main' : '$(git branch --show-current)'}"
+
+# Create worktree with phantom
+phantom create <branchName> --base $base
+
+# Get the worktree path and switch to it
+wtPath=$(phantom where <branchName>)
+cd "$wtPath"
+
+# Verify we're in the worktree
+pwd
+git branch --show-current
+```
+
+</phase>
+
+<phase name="confirm-switch">
+**Confirm the switch:**
+
+```
+Switched to worktree: <branchName>
+Location: <path>
+Branch: <branchName>
+
+Ready to continue working in this worktree.
+```
+
+</phase>
+
+</process>
+
+<success_criteria>
+
+- [ ] Username prefix in branch name
+- [ ] Worktree created with phantom
+- [ ] User informed of location and how to switch
+- [ ] Branch name follows conventions (username/type/description)
+
+</success_criteria>

--- a/crew/hooks/hooks.json
+++ b/crew/hooks/hooks.json
@@ -15,6 +15,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/session-start/check-phantom.sh",
+            "once": true
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/session-start/check-stack-status.sh",
             "once": true
           },

--- a/crew/rules/phantom-workflow.md
+++ b/crew/rules/phantom-workflow.md
@@ -1,0 +1,89 @@
+---
+description: Phantom worktree workflow patterns for parallel development
+globs: "**/commands/**/*.md"
+alwaysApply: true
+---
+
+# Phantom Worktree Workflow
+
+## When to Use Worktrees
+
+Choose phantom worktrees for:
+
+- **Independent features** - Work that doesn't depend on other in-progress changes
+- **Hotfixes** - Critical fixes that need isolation from feature work
+- **PR reviews** - Checkout PRs without affecting current work
+- **Experiments** - Test approaches in isolation
+
+Choose machete stacked branches for:
+
+- **Sequential changes** - Features that build on each other
+- **Related PRs** - Changes that should merge in order
+- **Refactoring chains** - Incremental improvements
+
+## Worktree Constraints
+
+**Cannot switch branches in a worktree.** Each worktree is locked to its branch.
+
+| Operation        | Safe in Worktree? | Notes                |
+| ---------------- | ----------------- | -------------------- |
+| `git commit`     | Yes               | Normal operation     |
+| `git push`       | Yes               | Normal operation     |
+| `git pull`       | Yes               | Normal operation     |
+| `git checkout`   | **NO**            | Will fail            |
+| `git switch`     | **NO**            | Will fail            |
+| `phantom create` | Yes               | Creates new worktree |
+
+## Creating Worktrees
+
+Use phantom commands (not raw git worktree):
+
+```bash
+# Create new worktree from main
+phantom create feat/my-feature --base main
+
+# Create from current branch
+phantom create feat/child --base $(git branch --show-current)
+
+# Attach existing branch
+phantom attach existing-branch
+```
+
+## Working Across Worktrees
+
+Run commands in other worktrees without switching:
+
+```bash
+# Run tests in another worktree
+phantom exec feat/other npm test
+
+# Build in another worktree
+phantom exec feat/other npm run build
+
+# Check git status
+phantom exec feat/other git status
+```
+
+## Cleanup
+
+Always clean up finished worktrees:
+
+```bash
+# Delete worktree and branch
+phantom delete feat/completed
+
+# Force delete with uncommitted changes
+phantom delete feat/abandoned -f
+```
+
+## Integration with Machete
+
+Worktrees can contain their own stacked branches:
+
+```bash
+# In a worktree, create stacked branches
+git checkout -b feat/feature-part-2
+git machete add --onto feat/feature-part-1
+```
+
+**Best Practice:** One primary stack per worktree.

--- a/crew/scripts/git/phantom-context.sh
+++ b/crew/scripts/git/phantom-context.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Provides phantom worktree context for commands
+# Outputs worktree status and available worktrees
+#
+set -euo pipefail
+
+# Check if phantom is installed
+if ! command -v phantom &>/dev/null; then
+	echo "## Phantom Worktrees"
+	echo "Phantom is not installed."
+	echo "Install with: \`brew install phantom\`"
+	echo
+	exit 0
+fi
+
+# Ensure optimal phantom configuration
+configure_phantom_setting() {
+	local key="$1"
+	local value="$2"
+	local current
+	current=$(phantom preferences get "$key" 2>/dev/null || echo "")
+	if [[ -z "$current" ]]; then
+		phantom preferences set "$key" "$value" 2>/dev/null || true
+	fi
+}
+
+# Configure defaults if not set
+configure_phantom_setting "editor" "code --reuse-window"
+configure_phantom_setting "ai" "claude"
+
+# Check if in a git repo
+if ! git rev-parse --git-dir &>/dev/null; then
+	exit 0
+fi
+
+branch=$(git branch --show-current 2>/dev/null || echo "")
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+
+echo "## Phantom Worktrees"
+echo
+
+# Determine if this is a worktree
+IS_WORKTREE="false"
+if [[ "$git_dir" != "$git_common_dir" ]]; then
+	IS_WORKTREE="true"
+fi
+
+# Get worktree list
+worktrees=$(phantom list --names 2>/dev/null || echo "")
+worktree_count=$(echo "$worktrees" | grep -c . 2>/dev/null || echo "0")
+
+if [[ $IS_WORKTREE == "true" ]]; then
+	echo "**Current location:** Phantom worktree"
+	echo "**Branch:** \`$branch\`"
+	echo "**Path:** \`$(pwd)\`"
+	echo
+	echo "### Worktree Constraints"
+	echo "- Cannot switch branches (use \`phantom create\` for new work)"
+	echo "- Use \`phantom exec <name> <cmd>\` to run commands in other worktrees"
+	echo "- Use \`phantom shell <name>\` to enter another worktree"
+else
+	echo "**Current location:** Main checkout"
+	echo "**Branch:** \`$branch\`"
+fi
+
+echo
+
+# List all worktrees
+if [[ "$worktree_count" -gt 0 ]]; then
+	echo "### Active Worktrees ($worktree_count)"
+	echo '```'
+	phantom list 2>/dev/null || echo "(unable to list worktrees)"
+	echo '```'
+	echo
+	echo "### Available Actions"
+	echo "| Action | Command |"
+	echo "|--------|---------|"
+	echo "| Create worktree | \`phantom create <name>\` |"
+	echo "| Enter worktree | \`phantom shell <name>\` |"
+	echo "| Run in worktree | \`phantom exec <name> <cmd>\` |"
+	echo "| Delete worktree | \`phantom delete <name>\` |"
+	echo "| Open editor | \`phantom edit <name>\` |"
+	echo "| Checkout PR | \`phantom gh checkout <num>\` |"
+else
+	echo "**No worktrees** - use \`phantom create <name>\` to create one"
+	echo
+	echo "### Quick Start"
+	echo '```bash'
+	echo "# Create new worktree for a feature"
+	echo "phantom create feat/my-feature --shell"
+	echo ""
+	echo "# Or checkout a GitHub PR"
+	echo "phantom gh checkout 123"
+	echo '```'
+fi
+
+echo
+
+# Show worktree directory configuration
+wt_dir=$(phantom preferences get worktreesDirectory 2>/dev/null || echo ".git/phantom/worktrees")
+echo "**Worktree directory:** \`$wt_dir\`"
+
+# Export for use in conditionals (when sourced)
+export IS_WORKTREE

--- a/crew/scripts/hooks/session-start/check-phantom.sh
+++ b/crew/scripts/hooks/session-start/check-phantom.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Check phantom installation and configure optimal settings on session start
+#
+# PERFORMANCE: Fast check, only installs if missing
+# IDEMPOTENT: Safe to run multiple times
+
+# Hooks must never fail
+set +e
+
+# Fast path: check if phantom is installed
+if command -v phantom &>/dev/null; then
+	# Ensure optimal configuration (fast, no output unless changed)
+	configure_if_unset() {
+		local key="$1"
+		local value="$2"
+		local current
+		current=$(phantom preferences get "$key" 2>/dev/null || echo "")
+		if [[ -z "$current" ]]; then
+			phantom preferences set "$key" "$value" 2>/dev/null
+			echo "Phantom: set $key=$value"
+		fi
+	}
+
+	# Configure optimal defaults if not already set
+	configure_if_unset "editor" "code --reuse-window"
+	configure_if_unset "ai" "claude"
+
+	exit 0
+fi
+
+# Phantom not installed - install via Homebrew (fast)
+echo "Installing phantom CLI for worktree management..."
+
+if command -v brew &>/dev/null; then
+	brew install phantom 2>/dev/null
+	if command -v phantom &>/dev/null; then
+		echo "Phantom installed successfully"
+
+		# Configure optimal settings
+		phantom preferences set editor "code --reuse-window" 2>/dev/null
+		phantom preferences set ai "claude" 2>/dev/null
+		echo "Phantom configured with optimal settings"
+	else
+		echo "Warning: Failed to install phantom. Install manually: brew install phantom"
+	fi
+else
+	echo "Warning: Homebrew not available. Install phantom manually: brew install phantom"
+fi
+
+exit 0

--- a/crew/skills/phantom/SKILL.md
+++ b/crew/skills/phantom/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: phantom
+description: Phantom CLI for Git worktree management. Enables parallel development across multiple features in isolated directories. Use when creating worktrees, managing parallel workstreams, or working with GitHub issues/PRs.
+triggers:
+  - "worktree"
+  - "phantom"
+  - "parallel development"
+  - "isolated branch"
+  - "new worktree"
+  - "feature isolation"
+---
+
+<objective>
+Manage Git worktrees with Phantom CLI for true parallel development. Each worktree is an isolated directory with its own branch, enabling simultaneous work on multiple features without stashing or context switching.
+</objective>
+
+<essential_principles>
+
+**Worktrees vs Stacked Branches**
+
+Choose the right approach for the task:
+
+| Approach                     | Use When                                   | Benefit                             |
+| ---------------------------- | ------------------------------------------ | ----------------------------------- |
+| **Worktree** (phantom)       | Independent features, hotfixes, PR reviews | Full isolation, no branch switching |
+| **Stacked branch** (machete) | Sequential dependent changes               | Easier rebasing, related PRs        |
+
+**Worktree Naming Convention**
+
+Phantom auto-generates worktree names from branch names. Use descriptive branch names:
+
+```
+feat/user-auth     -> worktree: feat-user-auth
+fix/login-bug      -> worktree: fix-login-bug
+hotfix/critical    -> worktree: hotfix-critical
+```
+
+**One Branch Per Worktree**
+
+Each worktree is locked to its branch. Cannot switch branches within a worktree.
+
+**Shared Git State**
+
+All worktrees share the same `.git` directory (via symlinks). Commits, stashes, and refs are visible across all worktrees.
+
+</essential_principles>
+
+<constraints>
+
+**NEVER switch branches in a worktree** - use `phantom create` for new branches
+
+**NEVER delete a worktree's branch while in that worktree** - exit first
+
+**NEVER use git checkout in a worktree** - it will fail or cause issues
+
+**ALWAYS use phantom commands** instead of raw git worktree commands for consistency
+
+</constraints>
+
+<quick_start>
+
+**Create a worktree for a new feature:**
+
+```bash
+phantom create feat/my-feature --shell
+# Now in isolated directory with new branch
+```
+
+**Work on an existing branch:**
+
+```bash
+phantom attach existing-branch --shell
+```
+
+**Run command in another worktree (without switching):**
+
+```bash
+phantom exec feat/other npm run build
+```
+
+**Open editor in worktree:**
+
+```bash
+phantom edit feat/my-feature
+```
+
+**Clean up when done:**
+
+```bash
+phantom delete feat/my-feature
+```
+
+</quick_start>
+
+<routing>
+
+| Task                      | Resource                       |
+| ------------------------- | ------------------------------ |
+| Create worktree           | `workflows/create-worktree.md` |
+| Work with GitHub PR/issue | `workflows/github-workflow.md` |
+| Clean up worktrees        | `workflows/cleanup.md`         |
+| Configure phantom         | `references/configuration.md`  |
+| All commands              | `references/commands.md`       |
+| MCP integration           | `references/mcp.md`            |
+
+</routing>
+
+<commands>
+
+| Command                     | Purpose                                  |
+| --------------------------- | ---------------------------------------- |
+| `phantom create <name>`     | Create new worktree with matching branch |
+| `phantom attach <branch>`   | Create worktree for existing branch      |
+| `phantom list`              | Show all worktrees                       |
+| `phantom shell <name>`      | Open shell in worktree                   |
+| `phantom exec <name> <cmd>` | Run command in worktree                  |
+| `phantom edit <name>`       | Open worktree in editor                  |
+| `phantom ai <name>`         | Launch AI assistant in worktree          |
+| `phantom where <name>`      | Get worktree path                        |
+| `phantom delete <name>`     | Remove worktree and branch               |
+| `phantom gh checkout <num>` | Create worktree from GitHub PR/issue     |
+
+</commands>
+
+<scripts>
+
+| Script               | Purpose                     |
+| -------------------- | --------------------------- |
+| `phantom-context.sh` | Get phantom/worktree status |
+
+</scripts>
+
+<integration_with_machete>
+
+Phantom and git-machete work together:
+
+```bash
+# In main checkout, use machete for stacked branches
+git machete traverse -W -y
+
+# For independent features, use phantom worktrees
+phantom create feat/independent-feature
+
+# Worktrees can contain their own stacked branches
+phantom shell feat/my-feature
+git checkout -b feat/my-feature-part2
+git machete add --onto feat/my-feature
+```
+
+**Best Practice:** Use phantom for main feature isolation, machete for sub-feature stacking within a worktree.
+
+</integration_with_machete>
+
+<success_criteria>
+
+- [ ] Worktree created in correct location
+- [ ] Branch naming follows conventions
+- [ ] Can run commands without switching context
+- [ ] Cleanup removes both worktree and branch
+
+</success_criteria>

--- a/crew/skills/phantom/references/commands.md
+++ b/crew/skills/phantom/references/commands.md
@@ -1,0 +1,365 @@
+---
+name: phantom-commands
+description: Complete reference for all Phantom CLI commands
+---
+
+<commands>
+
+## Worktree Management
+
+### phantom create
+
+Create a new worktree with a matching branch.
+
+```bash
+phantom create <name> [options]
+```
+
+**Options:**
+
+| Option                           | Description                              |
+| -------------------------------- | ---------------------------------------- |
+| `--shell`                        | Open interactive shell after creation    |
+| `--exec <command>`               | Execute command in new worktree          |
+| `--tmux` / `-t`                  | Open in new tmux window                  |
+| `--tmux-vertical` / `--tmux-v`   | Open in vertical tmux split              |
+| `--tmux-horizontal` / `--tmux-h` | Open in horizontal tmux split            |
+| `--copy-file <file>`             | Copy files from current worktree         |
+| `--base <branch/commit>`         | Branch/commit to base on (default: HEAD) |
+
+**Examples:**
+
+```bash
+# Create and enter shell
+phantom create feat/user-auth --shell
+
+# Create from main branch
+phantom create feat/new-feature --base main
+
+# Create and run command
+phantom create hotfix/critical --exec "npm install"
+
+# Create with files copied
+phantom create feat/test --copy-file .env --copy-file .env.local
+
+# Create in tmux window
+phantom create feat/parallel -t
+```
+
+### phantom attach
+
+Attach an existing branch as a worktree.
+
+```bash
+phantom attach <branch-name> [options]
+```
+
+**Options:** Same as `create` (--shell, --exec, --tmux, etc.)
+
+**Examples:**
+
+```bash
+# Attach and enter shell
+phantom attach feature-branch --shell
+
+# Attach in tmux horizontal split
+phantom attach fix/bug-123 --tmux-h
+```
+
+### phantom list
+
+Display all worktrees and their status.
+
+```bash
+phantom list [options]
+```
+
+**Options:**
+
+| Option    | Description                             |
+| --------- | --------------------------------------- |
+| `--fzf`   | Interactive selection with fuzzy finder |
+| `--names` | Machine-readable format (names only)    |
+
+**Examples:**
+
+```bash
+# Show all worktrees
+phantom list
+
+# Interactive selection
+phantom list --fzf
+
+# Script-friendly output
+phantom list --names
+```
+
+### phantom where
+
+Get the absolute path to a worktree.
+
+```bash
+phantom where <name> [options]
+```
+
+**Options:**
+
+| Option  | Description                   |
+| ------- | ----------------------------- |
+| `--fzf` | Select worktree interactively |
+
+**Examples:**
+
+```bash
+# Get path
+phantom where feat/user-auth
+
+# Use in scripts
+cd "$(phantom where feat/user-auth)"
+```
+
+### phantom delete
+
+Remove worktrees and their branches.
+
+```bash
+phantom delete <name...> [options]
+```
+
+**Options:**
+
+| Option           | Description                             |
+| ---------------- | --------------------------------------- |
+| `--force` / `-f` | Force deletion with uncommitted changes |
+| `--current`      | Delete current worktree                 |
+| `--fzf`          | Interactive selection                   |
+
+**Examples:**
+
+```bash
+# Delete single worktree
+phantom delete feat/completed-feature
+
+# Delete multiple
+phantom delete feat-a feat-b feat-c
+
+# Force delete with uncommitted changes
+phantom delete feat/abandoned -f
+
+# Interactive deletion
+phantom delete --fzf
+```
+
+## Working in Worktrees
+
+### phantom shell
+
+Open an interactive shell in a worktree.
+
+```bash
+phantom shell <name> [options]
+```
+
+Sets environment variables: `PHANTOM`, `PHANTOM_NAME`, `PHANTOM_PATH`
+
+**Options:** --fzf, --tmux, --tmux-vertical, --tmux-horizontal
+
+**Examples:**
+
+```bash
+# Enter worktree shell
+phantom shell feat/user-auth
+
+# In tmux vertical split
+phantom shell feat/user-auth --tmux-v
+```
+
+### phantom exec
+
+Execute commands within a worktree context.
+
+```bash
+phantom exec [options] <name> <command> [args...]
+```
+
+**Options:** --fzf, --tmux variants
+
+**Examples:**
+
+```bash
+# Run tests in another worktree
+phantom exec feat/user-auth npm test
+
+# Build in background
+phantom exec feat/user-auth npm run build
+
+# Run in tmux
+phantom exec -t feat/user-auth npm run dev
+```
+
+### phantom edit
+
+Open worktree in configured editor.
+
+```bash
+phantom edit <name> [path]
+```
+
+Uses `phantom.editor` preference, falls back to `$EDITOR`.
+
+**Examples:**
+
+```bash
+# Open entire worktree
+phantom edit feat/user-auth
+
+# Open specific file
+phantom edit feat/user-auth src/main.ts
+```
+
+### phantom ai
+
+Launch AI coding assistant in worktree.
+
+```bash
+phantom ai <name>
+```
+
+Requires `phantom.ai` preference to be set.
+
+**Examples:**
+
+```bash
+# Launch Claude in worktree
+phantom ai feat/user-auth
+```
+
+## Preferences
+
+### phantom preferences get
+
+Get a preference value.
+
+```bash
+phantom preferences get <key>
+```
+
+### phantom preferences set
+
+Set a preference value.
+
+```bash
+phantom preferences set <key> <value>
+```
+
+**Available preferences:**
+
+| Key                  | Description               | Default                  |
+| -------------------- | ------------------------- | ------------------------ |
+| `editor`             | Editor command            | `$EDITOR`                |
+| `ai`                 | AI assistant command      | (none)                   |
+| `worktreesDirectory` | Worktree storage location | `.git/phantom/worktrees` |
+
+**Examples:**
+
+```bash
+# Set editor
+phantom preferences set editor "code --reuse-window"
+
+# Set AI assistant
+phantom preferences set ai "claude"
+
+# Set worktree directory (relative to repo root)
+phantom preferences set worktreesDirectory "../phantom-worktrees"
+```
+
+### phantom preferences remove
+
+Remove a preference value.
+
+```bash
+phantom preferences remove <key>
+```
+
+## GitHub Integration
+
+### phantom github checkout
+
+Create worktrees from GitHub pull requests or issues.
+
+```bash
+phantom github checkout <number> [options]
+# Alias: phantom gh checkout <number>
+```
+
+**Options:**
+
+| Option                           | Description                                            |
+| -------------------------------- | ------------------------------------------------------ |
+| `--base <branch>`                | Base branch for issue branches (default: repo default) |
+| `--tmux` / `-t`                  | Open in new tmux window                                |
+| `--tmux-vertical` / `--tmux-v`   | Open in vertical tmux split                            |
+| `--tmux-horizontal` / `--tmux-h` | Open in horizontal tmux split                          |
+
+**Behavior:**
+
+- **Pull Requests**: Creates worktree with PR branch name
+- **Issues**: Creates worktree at `issues/<number>` with new local branch
+
+**Examples:**
+
+```bash
+# Checkout PR #123
+phantom gh checkout 123
+
+# Checkout issue #456 based on develop
+phantom gh checkout 456 --base develop
+
+# Checkout and open in tmux
+phantom gh checkout 789 -t
+```
+
+**Requirements:** GitHub CLI (`gh`) must be installed and authenticated.
+
+## Other Commands
+
+### phantom mcp
+
+Manage MCP server for AI integration.
+
+```bash
+phantom mcp serve
+```
+
+Starts the MCP server with stdio transport.
+
+### phantom version
+
+Display installed version.
+
+```bash
+phantom version
+```
+
+### phantom completion
+
+Generate shell completions.
+
+```bash
+phantom completion <shell>
+```
+
+Shells: `fish`, `zsh`, `bash`
+
+## Exit Codes
+
+| Code | Meaning                    |
+| ---- | -------------------------- |
+| 0    | Success                    |
+| 1    | General error              |
+| 2    | Invalid arguments          |
+| 3    | Git operation failure      |
+| 4    | Worktree operation failure |
+| 127  | Command not found          |
+
+</commands>

--- a/crew/skills/phantom/references/configuration.md
+++ b/crew/skills/phantom/references/configuration.md
@@ -1,0 +1,181 @@
+---
+name: phantom-configuration
+description: Configuration options for Phantom CLI
+---
+
+<configuration>
+
+## Global Preferences (Git Config)
+
+Phantom stores preferences in Git's global config under `phantom.*` namespace.
+
+```bash
+# View all phantom preferences
+git config --global --get-regexp '^phantom\.'
+
+# Set a preference
+phantom preferences set <key> <value>
+
+# Get a preference
+phantom preferences get <key>
+
+# Remove a preference
+phantom preferences remove <key>
+```
+
+### Available Preferences
+
+| Key                  | Description           | Default                  | Example                |
+| -------------------- | --------------------- | ------------------------ | ---------------------- |
+| `editor`             | Editor command        | `$EDITOR`                | `code --reuse-window`  |
+| `ai`                 | AI assistant command  | (none)                   | `claude`               |
+| `worktreesDirectory` | Worktree storage path | `.git/phantom/worktrees` | `../phantom-worktrees` |
+
+### Recommended Setup
+
+```bash
+# Use VS Code with window reuse
+phantom preferences set editor "code --reuse-window"
+
+# Enable Claude AI integration
+phantom preferences set ai "claude"
+
+# Store worktrees in a central location (outside .git)
+phantom preferences set worktreesDirectory "/path/to/worktrees"
+```
+
+## Repository Configuration (phantom.config.json)
+
+Create a `phantom.config.json` file in your repository root for project-specific settings.
+
+```json
+{
+  "postCreate": {
+    "copyFiles": [".env", ".env.local", "config/local.yml"],
+    "commands": ["npm install", "npm run db:migrate"]
+  },
+  "preDelete": {
+    "commands": ["docker compose down"]
+  }
+}
+```
+
+### postCreate.copyFiles
+
+Files to automatically copy from current worktree to newly created worktrees.
+
+```json
+{
+  "postCreate": {
+    "copyFiles": [
+      ".env",
+      ".env.local",
+      "config/database.local.yml",
+      ".vscode/settings.json"
+    ]
+  }
+}
+```
+
+**Notes:**
+
+- Paths are relative to repository root
+- Non-existent files are silently skipped
+- Glob patterns are not supported
+
+### postCreate.commands
+
+Commands to run after creating a new worktree.
+
+```json
+{
+  "postCreate": {
+    "commands": ["pnpm install", "pnpm db:migrate", "pnpm db:seed"]
+  }
+}
+```
+
+**Behavior:**
+
+- Commands execute sequentially
+- Stops on first failure
+- Runs in the new worktree directory
+
+### preDelete.commands
+
+Cleanup commands to run before deleting a worktree.
+
+```json
+{
+  "preDelete": {
+    "commands": ["docker compose down", "rm -rf node_modules/.cache"]
+  }
+}
+```
+
+**Behavior:**
+
+- Commands execute sequentially
+- If a command fails, the worktree is NOT deleted
+- Useful for stopping services, cleaning caches
+
+## Complete Example Configuration
+
+```json
+{
+  "postCreate": {
+    "copyFiles": [".env", ".env.local", ".env.development.local"],
+    "commands": [
+      "pnpm install --frozen-lockfile",
+      "pnpm run codegen",
+      "pnpm run db:migrate"
+    ]
+  },
+  "preDelete": {
+    "commands": ["docker compose down --volumes"]
+  }
+}
+```
+
+## Worktree Location Strategies
+
+### Default (.git/phantom/worktrees)
+
+```bash
+# Default - worktrees inside .git directory
+# Pros: Clean, hidden from project
+# Cons: Long paths, inside git directory
+```
+
+### Sibling Directory
+
+```bash
+phantom preferences set worktreesDirectory "../worktrees"
+
+# Results in:
+# /project/main-repo/        <- main checkout
+# /project/worktrees/feat-a/ <- worktree
+# /project/worktrees/feat-b/ <- worktree
+```
+
+### Central Location
+
+```bash
+phantom preferences set worktreesDirectory "/Users/me/.worktrees"
+
+# Results in:
+# /Users/me/.worktrees/repo-name/feat-a/
+# /Users/me/.worktrees/repo-name/feat-b/
+```
+
+### Project-Specific (Recommended for Claude Code)
+
+Store worktrees in a central location per project:
+
+```bash
+phantom preferences set worktreesDirectory "/Users/me/.conductor/worktrees"
+```
+
+This keeps worktrees organized and accessible across all projects.
+
+</configuration>

--- a/crew/skills/phantom/references/mcp.md
+++ b/crew/skills/phantom/references/mcp.md
@@ -1,0 +1,206 @@
+---
+name: phantom-mcp
+description: Phantom MCP server for AI integration
+---
+
+<mcp_integration>
+
+## Overview
+
+Phantom provides an MCP (Model Context Protocol) server that enables AI assistants to manage Git worktrees programmatically.
+
+## Installation
+
+### Claude Code
+
+```bash
+claude mcp add --scope user Phantom phantom mcp serve
+```
+
+### VS Code (Copilot)
+
+```bash
+code --add-mcp '{"name": "Phantom", "command": "phantom", "args": ["mcp", "serve"], "transport": "stdio"}'
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "Phantom": {
+      "command": "phantom",
+      "args": ["mcp", "serve"],
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+### Other AI Assistants
+
+Start the server manually:
+
+```bash
+phantom mcp serve
+```
+
+## Available MCP Tools
+
+### phantom_create_worktree
+
+Create a new Git worktree.
+
+**Parameters:**
+
+| Parameter    | Type   | Required | Description                               |
+| ------------ | ------ | -------- | ----------------------------------------- |
+| `name`       | string | Yes      | Name for the worktree and branch          |
+| `baseBranch` | string | No       | Branch to base on (default: current HEAD) |
+
+**Example:**
+
+```javascript
+phantom_create_worktree({
+  name: "feat/user-auth",
+  baseBranch: "main",
+});
+```
+
+### phantom_list_worktrees
+
+List all existing worktrees.
+
+**Parameters:** None
+
+**Returns:** Array of worktree objects with name, path, and branch info.
+
+**Example:**
+
+```javascript
+phantom_list_worktrees();
+// Returns: [
+//   { name: "feat-user-auth", path: "/path/to/worktree", branch: "feat/user-auth" },
+//   ...
+// ]
+```
+
+### phantom_delete_worktree
+
+Remove a worktree and optionally its branch.
+
+**Parameters:**
+
+| Parameter | Type    | Required | Description                             |
+| --------- | ------- | -------- | --------------------------------------- |
+| `name`    | string  | Yes      | Name of the worktree to delete          |
+| `force`   | boolean | No       | Force deletion with uncommitted changes |
+
+**Example:**
+
+```javascript
+phantom_delete_worktree({
+  name: "feat/completed-feature",
+  force: false,
+});
+```
+
+### phantom_github_checkout
+
+Create a worktree from a GitHub issue or pull request.
+
+**Parameters:**
+
+| Parameter | Type   | Required | Description                                    |
+| --------- | ------ | -------- | ---------------------------------------------- |
+| `number`  | number | Yes      | GitHub issue or PR number                      |
+| `base`    | string | No       | Base branch for issues (default: repo default) |
+
+**Example:**
+
+```javascript
+// Checkout PR #123
+phantom_github_checkout({ number: 123 });
+
+// Checkout issue #456 with develop as base
+phantom_github_checkout({ number: 456, base: "develop" });
+```
+
+## Use Cases
+
+### Parallel Feature Development
+
+AI can create isolated worktrees for different features:
+
+```javascript
+// Create worktrees for multiple features
+phantom_create_worktree({ name: "feat/auth", baseBranch: "main" });
+phantom_create_worktree({ name: "feat/dashboard", baseBranch: "main" });
+phantom_create_worktree({ name: "feat/api", baseBranch: "main" });
+```
+
+### Testing Alternative Approaches
+
+Create worktrees to test different implementation strategies:
+
+```javascript
+phantom_create_worktree({
+  name: "experiment/approach-a",
+  baseBranch: "feat/feature",
+});
+phantom_create_worktree({
+  name: "experiment/approach-b",
+  baseBranch: "feat/feature",
+});
+```
+
+### PR Review Workflow
+
+Checkout PRs for review without affecting current work:
+
+```javascript
+phantom_github_checkout({ number: 456 });
+// Run tests, review code
+phantom_delete_worktree({ name: "pr-456" });
+```
+
+### Progressive Feature Building
+
+Build features incrementally with dependent worktrees:
+
+```javascript
+phantom_create_worktree({ name: "feat/base-types", baseBranch: "main" });
+// ... implement base types ...
+phantom_create_worktree({
+  name: "feat/services",
+  baseBranch: "feat/base-types",
+});
+// ... implement services using base types ...
+```
+
+## Integration with Crew Plugin
+
+The crew plugin integrates Phantom MCP for autonomous worktree management:
+
+```json
+// In crew/.mcp.json
+{
+  "mcpServers": {
+    "Phantom": {
+      "command": "phantom",
+      "args": ["mcp", "serve"],
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+This enables:
+
+- `/crew:design` to create worktrees for feature isolation
+- `/crew:build` to execute in isolated environments
+- Background agents to work in separate worktrees
+
+</mcp_integration>

--- a/crew/skills/phantom/workflows/cleanup.md
+++ b/crew/skills/phantom/workflows/cleanup.md
@@ -1,0 +1,191 @@
+---
+name: cleanup
+description: Workflow for cleaning up worktrees
+---
+
+<workflow>
+
+## Cleanup Workflow
+
+### Step 1: Ask What to Clean
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What would you like to clean up?",
+      header: "Action",
+      options: [
+        { label: "Specific worktree", description: "Delete a named worktree" },
+        { label: "Current worktree", description: "Delete the one you're in" },
+        { label: "All merged", description: "Clean up all merged worktrees" },
+        {
+          label: "List first",
+          description: "Show all worktrees before deciding",
+        },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+### Step 2: Handle Selection
+
+**If "List first":**
+
+```bash
+phantom list
+```
+
+Then ask again what to delete.
+
+**If "Specific worktree":**
+
+```javascript
+// Show available worktrees and let user select
+const worktrees = Bash({ command: "phantom list --names" }).trim().split("\n");
+
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which worktree do you want to delete?",
+      header: "Worktree",
+      options: worktrees.slice(0, 4).map((wt) => ({
+        label: wt,
+        description: `Delete ${wt} and its branch`,
+      })),
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+### Step 3: Confirm Deletion
+
+```javascript
+// Check for uncommitted changes
+const status = Bash({ command: `phantom exec ${name} git status --porcelain` });
+if (status.trim()) {
+  AskUserQuestion({
+    questions: [
+      {
+        question: `${name} has uncommitted changes. Delete anyway?`,
+        header: "Confirm",
+        options: [
+          {
+            label: "Force delete",
+            description: "Delete and lose uncommitted work",
+          },
+          { label: "Cancel", description: "Keep the worktree" },
+        ],
+        multiSelect: false,
+      },
+    ],
+  });
+}
+```
+
+### Step 4: Execute Deletion
+
+```bash
+# Regular delete
+phantom delete <name>
+
+# Force delete if confirmed
+phantom delete <name> --force
+```
+
+**Note:** After deleting current worktree, navigate elsewhere:
+
+```bash
+cd "$(git worktree list | head -1 | awk '{print $1}')"
+```
+
+### Cleanup Merged Worktrees
+
+Pattern for cleaning up worktrees after PRs are merged:
+
+```bash
+# List all worktrees
+for wt in $(phantom list --names); do
+  # Check if branch is merged
+  if git branch --merged main | grep -q "$wt"; then
+    echo "Merged: $wt"
+  fi
+done
+```
+
+### Safe Cleanup Checklist
+
+Before deleting a worktree:
+
+1. **Check for uncommitted changes:**
+
+   ```bash
+   phantom exec <name> git status
+   ```
+
+2. **Check for unpushed commits:**
+
+   ```bash
+   phantom exec <name> git log origin/$(git branch --show-current)..HEAD
+   ```
+
+3. **Verify PR is merged (if applicable):**
+   ```bash
+   gh pr view --state merged
+   ```
+
+### preDelete Hooks
+
+If you have cleanup commands in `phantom.config.json`:
+
+```json
+{
+  "preDelete": {
+    "commands": ["docker compose down", "rm -rf .cache"]
+  }
+}
+```
+
+These run automatically before deletion. If they fail, deletion is aborted.
+
+### Recovery from Accidental Delete
+
+Git worktree branches aren't immediately deleted from refs:
+
+```bash
+# Check if branch still exists
+git branch -a | grep <name>
+
+# If branch exists, recreate worktree
+phantom attach <branch-name>
+
+# Check reflog for recent activity
+git reflog show <branch-name>
+```
+
+### Bulk Cleanup Script
+
+```bash
+#!/usr/bin/env bash
+# Clean all merged worktrees
+
+MAIN_BRANCH="${1:-main}"
+
+for wt in $(phantom list --names); do
+  # Skip main checkout
+  if [[ "$wt" == "." ]]; then
+    continue
+  fi
+
+  # Check if merged
+  if git branch --merged "$MAIN_BRANCH" | grep -qw "$wt"; then
+    echo "Deleting merged worktree: $wt"
+    phantom delete "$wt"
+  fi
+done
+```
+
+</workflow>

--- a/crew/skills/phantom/workflows/create-worktree.md
+++ b/crew/skills/phantom/workflows/create-worktree.md
@@ -1,0 +1,182 @@
+---
+name: create-worktree
+description: Workflow for creating a new worktree with phantom
+---
+
+<workflow>
+
+## Create Worktree Workflow
+
+### Step 1: Ask for Worktree Type
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What type of worktree do you want to create?",
+      header: "Type",
+      options: [
+        { label: "Feature", description: "New feature development (feat/)" },
+        { label: "Bug fix", description: "Fix an existing bug (fix/)" },
+        { label: "Hotfix", description: "Critical production fix (hotfix/)" },
+        { label: "Experiment", description: "Test an approach (experiment/)" },
+      ],
+      multiSelect: false,
+    },
+    {
+      question: "What should it be based on?",
+      header: "Base",
+      options: [
+        {
+          label: "main",
+          description: "Start fresh from main branch (Recommended)",
+        },
+        { label: "Current branch", description: "Branch from current work" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+### Step 2: Generate and Confirm Branch Name
+
+Auto-generate a name with username prefix, then let user confirm or customize:
+
+```javascript
+// Get username from system
+const username = Bash({ command: "whoami" }).trim();
+
+// Pattern: username/type/short-description
+const type = selectedType; // feat, fix, hotfix, experiment
+const description = slugify(taskDescription); // kebab-case, max 30 chars
+const suggestedName = `${username}/${type}/${description}`;
+
+AskUserQuestion({
+  questions: [
+    {
+      question: `Use this branch name: ${suggestedName}?`,
+      header: "Name",
+      options: [
+        { label: "Use suggested", description: suggestedName },
+        { label: "Customize", description: "Enter a different name" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+
+// If "Customize" selected, user provides name via "Other" option
+```
+
+**Naming conventions:**
+
+| Pattern                             | Example                         |
+| ----------------------------------- | ------------------------------- |
+| `username/feat/<description>`       | `roderik/feat/user-auth`        |
+| `username/fix/<description>`        | `roderik/fix/login-bug`         |
+| `username/hotfix/<description>`     | `roderik/hotfix/critical`       |
+| `username/experiment/<description>` | `roderik/experiment/approach-a` |
+
+### Step 3: Create Worktree and Switch
+
+```bash
+# Create from main (default for new features)
+phantom create <branchName> --base main
+
+# Or create from current branch (for related work)
+phantom create <branchName> --base $(git branch --show-current)
+
+# Auto-switch to the new worktree
+wtPath=$(phantom where <branchName>)
+cd "$wtPath"
+
+# Verify the switch
+pwd
+git branch --show-current
+```
+
+### Step 4: Confirm Switch
+
+After creation and switch:
+
+```
+Switched to worktree: <branchName>
+Location: /path/to/worktree
+Branch: <branchName>
+
+Ready to continue working.
+```
+
+### Step 5: Ask About Next Steps
+
+Since we're already in the worktree, offer relevant options:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What would you like to do next?",
+      header: "Next",
+      options: [
+        {
+          label: "Continue here",
+          description: "Stay in worktree and continue work",
+        },
+        {
+          label: "Open in editor",
+          description: "Also open worktree in VS Code",
+        },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+Handle responses:
+
+- "Continue here" → Already switched, continue with task
+- "Open in editor" → `Bash({ command: "code ." })`
+
+## Common Patterns
+
+### Independent Feature
+
+```bash
+phantom create feat/independent --base main
+wtPath=$(phantom where feat/independent)
+cd "$wtPath"
+```
+
+### Hotfix from Production
+
+```bash
+phantom create hotfix/critical --base origin/production
+wtPath=$(phantom where hotfix/critical)
+cd "$wtPath"
+```
+
+### Review a PR
+
+```bash
+phantom gh checkout 123
+wtPath=$(phantom where 123)
+cd "$wtPath"
+# Work is done in isolated worktree
+# When done: phantom delete 123
+```
+
+### Parallel Experiments
+
+Note: For parallel experiments, use separate terminal sessions or `phantom exec`:
+
+```bash
+phantom create experiment/approach-a --base feat/feature
+phantom create experiment/approach-b --base feat/feature
+# Run commands in each without switching:
+phantom exec experiment/approach-a npm test
+phantom exec experiment/approach-b npm test
+```
+
+</workflow>

--- a/crew/skills/phantom/workflows/github-workflow.md
+++ b/crew/skills/phantom/workflows/github-workflow.md
@@ -1,0 +1,199 @@
+---
+name: github-workflow
+description: Workflow for working with GitHub PRs and issues via phantom
+---
+
+<workflow>
+
+## GitHub Integration Workflow
+
+### Step 1: Ask What to Checkout
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What would you like to check out?",
+      header: "Type",
+      options: [
+        {
+          label: "Pull Request",
+          description: "Review or contribute to an existing PR",
+        },
+        { label: "Issue", description: "Start work on an issue" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+### Step 2: Get the Number
+
+If not provided in the command, ask:
+
+```javascript
+// User provides the PR/issue number
+// Auto-detect if it's a PR or issue from GitHub API
+```
+
+### Step 3: Checkout
+
+**For Pull Requests:**
+
+```bash
+phantom gh checkout <number>
+```
+
+**What happens:**
+
+1. Phantom queries GitHub API for PR details
+2. For same-repo PRs: Fetches the actual branch
+3. For fork PRs: Fetches `origin/pull/<number>/head`
+4. Creates worktree with the PR branch name
+
+**For Issues:**
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What branch should the issue be based on?",
+      header: "Base",
+      options: [
+        { label: "main", description: "Default branch (Recommended)" },
+        { label: "develop", description: "Development branch" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+```bash
+phantom gh checkout <number> --base <selected-base>
+```
+
+**What happens:**
+
+1. Phantom queries GitHub API for issue details
+2. Creates new branch named `issues/<number>`
+3. Creates worktree based on selected branch
+
+### Step 4: Ask Next Action
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What would you like to do with this checkout?",
+      header: "Action",
+      options: [
+        {
+          label: "Open shell",
+          description: "Enter the worktree (Recommended)",
+        },
+        { label: "Open editor", description: "Open in VS Code" },
+        { label: "Run tests", description: "Execute test suite" },
+        { label: "Just checkout", description: "Stay in current directory" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+Handle responses:
+
+- "Open shell" → Tell user: `phantom shell <branch-name>`
+- "Open editor" → `Bash({ command: "phantom edit <branch-name>" })`
+- "Run tests" → `Bash({ command: "phantom exec <branch-name> npm test" })`
+- "Just checkout" → Done, inform user of location
+
+### Recommended PR Review Flow
+
+```bash
+# 1. Checkout the PR
+phantom gh checkout 123 --shell
+
+# 2. Run tests in the PR context
+npm test
+npm run build
+
+# 3. Explore the changes
+git log --oneline main..HEAD
+git diff main...HEAD
+
+# 4. Leave review comments via gh
+gh pr review 123 --comment --body "Looks good!"
+# or
+gh pr review 123 --approve
+# or
+gh pr review 123 --request-changes --body "Please fix X"
+
+# 5. Exit and cleanup
+exit
+phantom delete 123
+```
+
+### Contributing to a PR
+
+```bash
+# 1. Checkout the PR
+phantom gh checkout 123 --shell
+
+# 2. Make your changes
+# ... edit files ...
+
+# 3. Commit and push
+git commit -m "fix: address review feedback"
+git push
+
+# 4. Exit
+exit
+```
+
+### Working on Multiple PRs Simultaneously
+
+```bash
+# Checkout multiple PRs in parallel
+phantom gh checkout 123
+phantom gh checkout 456
+phantom gh checkout 789
+
+# Work on them in different terminals/tmux
+phantom shell 123
+# In another terminal:
+phantom shell 456
+
+# Run tests across all
+phantom exec 123 npm test
+phantom exec 456 npm test
+phantom exec 789 npm test
+
+# Cleanup when done
+phantom delete 123 456 789
+```
+
+### Issue to PR Workflow
+
+```bash
+# 1. Checkout issue
+phantom gh checkout 42 --shell
+
+# 2. Implement the feature
+# ... write code ...
+
+# 3. Commit
+git commit -m "feat: implement feature for issue #42"
+
+# 4. Push and create PR
+git push -u origin issues/42
+gh pr create --title "Implement feature for issue #42" \
+  --body "Closes #42"
+
+# 5. Exit worktree (keep for future work)
+exit
+```
+
+</workflow>


### PR DESCRIPTION
## Summary

- Add comprehensive Phantom CLI skill with full reference documentation
- Add 5 worktree commands with auto-switch capability (no manual `phantom shell` needed)
- Add `crew:git:branch-new` for canonical branch creation with username prefix
- Refactor existing commands to use `Skill()` delegation to canonical locations
- Add session-start hook for phantom auto-installation

## What Changed

### New Phantom Skill (`crew/skills/phantom/`)
- **SKILL.md**: Main skill with routing, triggers, essential principles
- **references/commands.md**: Complete CLI command reference
- **references/configuration.md**: Config options and preferences
- **references/mcp.md**: MCP server integration guide
- **workflows/**: create-worktree, cleanup, github-workflow

### New Worktree Commands
| Command | Purpose |
|---------|---------|
| `crew:git:worktree` | Create worktree and auto-switch via `cd` |
| `crew:git:worktree-switch` | Switch between existing worktrees |
| `crew:git:worktree-list` | List all worktrees |
| `crew:git:worktree-delete` | Delete worktrees with safety checks |
| `crew:git:worktree-checkout-pr` | Checkout PR into isolated worktree |

### Refactored Commands (Skill Delegation)
- **commit-and-push**: Now delegates to `commit` → `push`
- **branch**: Delegates to `worktree` / `branch-new` / `stack-add`
- **design**: Delegates to `worktree` / `branch-new` / `stack-add`

### Branch Naming Convention
All branches now use username prefix pattern: `username/type/description`
- Example: `roderik/feat/user-auth`
- Auto-generated with `whoami`, user can customize via AskUserQuestion

### Infrastructure
- `phantom-context.sh`: Context script for worktree status
- `check-phantom.sh`: Session-start hook for auto-installation
- Phantom MCP server added to `.mcp.json`
- README updated with worktree docs and prerequisites

## Test Plan

- [ ] Run `/crew:git:worktree` - should create worktree and auto-switch
- [ ] Run `/crew:git:worktree-switch` - should switch between worktrees
- [ ] Run `/crew:git:branch` - should offer worktree/stacked/simple options
- [ ] Verify username prefix in generated branch names
- [ ] Check phantom auto-install on fresh session (if not installed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Phantom worktree support with a new Phantom skill, auto-switching worktree commands, and canonical branch creation. Also refactors key git flows to delegate to canonical skills for consistency.

- **New Features**
  - Phantom CLI skill with docs and workflows; auto-install/config on session start; MCP server wired in .mcp.json.
  - Worktree commands: create, switch, list, delete, checkout PR — auto-switches via cd (no phantom shell needed).
  - crew:git:branch-new for username/type/description naming.
  - Refactors: branch, design, and commit-and-push delegate to canonical skills.

- **Migration**
  - Install Phantom CLI (brew install phantom) or rely on the auto-install hook; GitHub CLI required for checkout PR.
  - Use /crew:git:worktree and /crew:git:worktree-switch; do not git checkout inside a worktree.
  - Branches default to username/type/description; confirm or customize during creation.

<sup>Written for commit f9946ee02e768fa161b04ef528719cf00e7b3c8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

