### PR TITLE
feat(crew): add Claude Code 2.1.2 enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ Modern development tools with MCP-first skills. Uses Context7 for up-to-date lib
 
 **Key feature:** Every skill fetches documentation from MCP before implementing, ensuring up-to-date API usage.
 
+## Configuration
+
+### Environment Variables
+
+Configure in `.claude/settings.json` under the `env` key:
+
+| Variable                    | Values        | Default  | Purpose                                                                                               |
+| --------------------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `FORCE_AUTOUPDATE_PLUGINS`  | `"1"` / `"0"` | Disabled | Force reinstall all plugins on every startup. Useful for development. Adds ~2-5s to startup time.    |
+
+Example:
+
+```json
+{
+  "env": {
+    "FORCE_AUTOUPDATE_PLUGINS": "1"
+  }
+}
+```
+
 ## Acknowledgments
 
 This plugin builds on ideas and patterns from:

--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.58.0",
+  "version": "1.59.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/README.md
+++ b/crew/README.md
@@ -227,6 +227,27 @@ The machete context automatically suggests next steps:
 - Auto-lint on file modifications
 - Git commit validation (requires CI pass)
 - PR creation validation
+- Agent type detection (skip hooks for subagents since Claude Code 2.1.2)
+
+### Auto-Update Behavior
+
+Set `FORCE_AUTOUPDATE_PLUGINS=1` in `.claude/settings.json` to force plugin reinstall on every startup:
+
+```json
+{
+  "env": {
+    "FORCE_AUTOUPDATE_PLUGINS": "1"
+  }
+}
+```
+
+**When to use:**
+
+- Developing plugin locally
+- Testing latest marketplace versions
+- Troubleshooting plugin issues
+
+**Trade-off:** Adds ~2-5 seconds to startup time.
 
 ## Structure
 

--- a/crew/commands/git/worktree.md
+++ b/crew/commands/git/worktree.md
@@ -95,7 +95,7 @@ const branchName = customName || suggestedName;
 </phase>
 
 <phase name="create-worktree">
-**Create the worktree and switch to it:**
+**Create the worktree:**
 
 ```bash
 # Determine base branch
@@ -104,26 +104,49 @@ base="${base_choice === 'main' ? 'main' : '$(git branch --show-current)'}"
 # Create worktree with phantom
 phantom create <branchName> --base $base
 
-# Get the worktree path and switch to it
+# Get the worktree path for display
 wtPath=$(phantom where <branchName>)
-cd "$wtPath"
-
-# Verify we're in the worktree
-pwd
-git branch --show-current
+echo "Worktree created at: $wtPath"
 ```
 
 </phase>
 
-<phase name="confirm-switch">
-**Confirm the switch:**
+<phase name="open-editor">
+**Open editor in the new worktree (non-blocking):**
+
+```bash
+# Open editor in the new worktree
+# Uses configured editor (phantom preferences get editor)
+# Defaults to VS Code if not set
+phantom edit <branchName> 2>/dev/null || true
+```
+
+**Note:** Editor opens asynchronously. If it fails, continue without error.
+</phase>
+
+<phase name="confirm-and-instruct">
+**Tell user exactly what to do next:**
 
 ```
-Switched to worktree: <branchName>
-Location: <path>
-Branch: <branchName>
+✅ Worktree created successfully!
 
-Ready to continue working in this worktree.
+**Branch:** <branchName>
+**Location:** <path>
+
+**IMPORTANT: To continue working in the new worktree:**
+
+Option 1 - New terminal:
+  cd <path>
+  claude
+
+Option 2 - Phantom shell (if using iTerm/Terminal):
+  phantom shell <branchName>
+
+Option 3 - Editor opened automatically
+  The editor should have opened at the worktree location.
+  Start a new Claude Code session there.
+
+⚠️ Do NOT use 'git checkout' or 'git switch' - worktrees have dedicated branches.
 ```
 
 </phase>
@@ -134,7 +157,9 @@ Ready to continue working in this worktree.
 
 - [ ] Username prefix in branch name
 - [ ] Worktree created with phantom
-- [ ] User informed of location and how to switch
+- [ ] Editor opened automatically (phantom edit)
+- [ ] Clear instructions shown for how to switch to worktree
+- [ ] User informed that auto-switch doesn't work in Claude Code
 - [ ] Branch name follows conventions (username/type/description)
 
 </success_criteria>

--- a/crew/scripts/hooks/session-start/check-phantom.sh
+++ b/crew/scripts/hooks/session-start/check-phantom.sh
@@ -7,44 +7,53 @@
 # Hooks must never fail
 set +e
 
+# Read stdin to check agent_type (since v2.1.2)
+INPUT=$(cat)
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // ""' 2>/dev/null)
+
+# Skip for subagents - they don't need phantom setup
+if [[ -n "$AGENT_TYPE" && "$AGENT_TYPE" != "null" ]]; then
+  exit 0
+fi
+
 # Fast path: check if phantom is installed
 if command -v phantom &>/dev/null; then
-	# Ensure optimal configuration (fast, no output unless changed)
-	configure_if_unset() {
-		local key="$1"
-		local value="$2"
-		local current
-		current=$(phantom preferences get "$key" 2>/dev/null || echo "")
-		if [[ -z "$current" ]]; then
-			phantom preferences set "$key" "$value" 2>/dev/null
-			echo "Phantom: set $key=$value"
-		fi
-	}
+  # Ensure optimal configuration (fast, no output unless changed)
+  configure_if_unset() {
+    local key="$1"
+    local value="$2"
+    local current
+    current=$(phantom preferences get "$key" 2>/dev/null || echo "")
+    if [[ -z "$current" ]]; then
+      phantom preferences set "$key" "$value" 2>/dev/null
+      echo "Phantom: set $key=$value"
+    fi
+  }
 
-	# Configure optimal defaults if not already set
-	configure_if_unset "editor" "code --reuse-window"
-	configure_if_unset "ai" "claude"
+  # Configure optimal defaults if not already set
+  configure_if_unset "editor" "code --reuse-window"
+  configure_if_unset "ai" "claude"
 
-	exit 0
+  exit 0
 fi
 
 # Phantom not installed - install via Homebrew (fast)
 echo "Installing phantom CLI for worktree management..."
 
 if command -v brew &>/dev/null; then
-	brew install phantom 2>/dev/null
-	if command -v phantom &>/dev/null; then
-		echo "Phantom installed successfully"
+  brew install phantom 2>/dev/null
+  if command -v phantom &>/dev/null; then
+    echo "Phantom installed successfully"
 
-		# Configure optimal settings
-		phantom preferences set editor "code --reuse-window" 2>/dev/null
-		phantom preferences set ai "claude" 2>/dev/null
-		echo "Phantom configured with optimal settings"
-	else
-		echo "Warning: Failed to install phantom. Install manually: brew install phantom"
-	fi
+    # Configure optimal settings
+    phantom preferences set editor "code --reuse-window" 2>/dev/null
+    phantom preferences set ai "claude" 2>/dev/null
+    echo "Phantom configured with optimal settings"
+  else
+    echo "Warning: Failed to install phantom. Install manually: brew install phantom"
+  fi
 else
-	echo "Warning: Homebrew not available. Install phantom manually: brew install phantom"
+  echo "Warning: Homebrew not available. Install phantom manually: brew install phantom"
 fi
 
 exit 0

--- a/crew/scripts/hooks/session-start/check-stack-status.sh
+++ b/crew/scripts/hooks/session-start/check-stack-status.sh
@@ -7,6 +7,15 @@
 # Hooks must never fail
 set +e
 
+# Read stdin to check agent_type (since v2.1.2)
+INPUT=$(cat)
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // ""' 2>/dev/null)
+
+# Skip for subagents - they don't need stack status info
+if [[ -n "$AGENT_TYPE" && "$AGENT_TYPE" != "null" ]]; then
+  exit 0
+fi
+
 # Check if in a git repo
 if ! git rev-parse --git-dir &>/dev/null 2>&1; then
   exit 0

--- a/crew/scripts/hooks/session-start/inject-skills.sh
+++ b/crew/scripts/hooks/session-start/inject-skills.sh
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 # Inject available crew skills and commands at session start
 # Helps Claude know what tools are available
+#
+# AGENT_TYPE DETECTION (Claude Code 2.1.2+):
+# Subagents (task, background, etc.) get no output to reduce context noise
 
 set +e
+
+# Read stdin to get hook input (includes agent_type since v2.1.2)
+INPUT=$(cat)
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // ""' 2>/dev/null)
+AGENT_TYPE="${AGENT_TYPE:-}"
+
+# Skip output for subagents - they have specific missions and don't need the full banner
+# Known subagent types: task, background, Bash, Explore, Plan, haiku, general-purpose
+if [[ -n "$AGENT_TYPE" && "$AGENT_TYPE" != "null" ]]; then
+  # Any non-empty agent_type means this is a subagent, skip output
+  exit 0
+fi
 
 cat <<'EOF'
 ## Crew Plugin - Available Commands & Skills

--- a/crew/scripts/hooks/session-start/restore-session-state.sh
+++ b/crew/scripts/hooks/session-start/restore-session-state.sh
@@ -15,9 +15,15 @@ set +e
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-# Read stdin to get event info
+# Read stdin to get event info (includes agent_type since v2.1.2)
 INPUT=$(cat)
 EVENT_TYPE=$(echo "$INPUT" | jq -r '.type // "unknown"' 2>/dev/null)
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // ""' 2>/dev/null)
+
+# Skip for subagents - they don't need session state restoration
+if [[ -n "$AGENT_TYPE" && "$AGENT_TYPE" != "null" ]]; then
+  exit 0
+fi
 
 # Get branch info (handle detached HEAD)
 BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo '')


### PR DESCRIPTION
## Summary

- Add agent_type detection to SessionStart hooks (skip output for subagents)
- Document FORCE_AUTOUPDATE_PLUGINS env var in README files
- Add interview phase to /crew:design (contextual questions before research)
- Add triage phase to /crew:design (select P1/P2/P3 stories)
- Add auto-open editor to worktree creation (phantom edit)
- Fix worktree flow to EXIT with clear instructions (no auto-switch)

## Changes

### SessionStart Hooks (agent_type detection)
All hooks now detect `agent_type` from stdin JSON and skip output for subagents:
- `inject-skills.sh` - Skip banner for subagents
- `restore-session-state.sh` - Skip state restoration for subagents
- `check-linters.sh` - Skip linter installation for subagents
- `check-stack-status.sh` - Skip stack status for subagents
- `check-phantom.sh` - Skip phantom setup for subagents

### Design Flow Improvements
- **Interview phase**: Asks 2-4 contextual questions (scope, constraints, success, priority) before research
- **Triage phase**: Lets users select P1/P2/P3 stories after plan generation
- **Worktree exit flow**: When worktree is chosen, command EXITS with clear instructions instead of trying to auto-switch

### Worktree Creation
- Opens editor automatically via `phantom edit`
- Shows clear 3-option instructions for how to switch to worktree
- No longer attempts auto-switch (doesn't work in Claude Code sessions)

## Test plan

- [ ] Run `/crew:design` on main, choose "New worktree" → verify it exits with instructions
- [ ] Run `/crew:design` on main, choose "Simple branch" → verify interview/triage phases work
- [ ] Start new session as subagent → verify no hook output
- [ ] Create worktree → verify editor opens and instructions shown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances the crew plugin for Claude Code 2.1.2 with smarter session hooks, an improved /crew:design flow, and a clearer worktree UX. Also documents the FORCE_AUTOUPDATE_PLUGINS env var.

- **New Features**
  - Session hooks detect agent_type and stay quiet for subagents.
  - /crew:design adds a short interview before research.
  - /crew:design adds triage to choose P1/P2/P3 stories.
  - Worktree creation auto-opens the editor via phantom edit.
  - README updates for FORCE_AUTOUPDATE_PLUGINS.

- **Bug Fixes**
  - Worktree command no longer tries to auto-switch; it exits with clear instructions and the worktree path.

<sup>Written for commit a71b83b3fd1955a0f4b575a9e340b01f4ba0e82f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

