### PR TITLE
feat(crew): auto-detect merged branches and trigger cleanup

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /design, /build, /check, /fix commands with parallel agent execution.",
-  "version": "1.62.0",
+  "version": "1.63.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"


### PR DESCRIPTION
## Summary

Enhances the session-start hook to detect when a feature branch's remote has been deleted (typically after a PR was merged) and automatically recover.

## Behavior

When Claude starts a session on a branch whose remote tracking branch no longer exists:

1. **Detects the stale state** - Checks if upstream branch exists after fetch
2. **Switches to main** - Automatically checks out main/master branch
3. **Pulls latest** - Gets the latest changes from remote
4. **Prompts for cleanup** - Tells Claude to run `Skill({ skill: "crew:git:clean" })` to delete stale local branches

## Example Output

```
🔄 **BRANCH CLEANUP DETECTED**
  Branch 'feat/my-feature' was tracking 'origin/feat/my-feature' which no longer exists.
  This typically means the PR was merged or closed.

  Switching to main and pulling latest...

  ✓ Now on 'main' branch with latest changes

  **ACTION REQUIRED:** Run cleanup to remove stale branches:
  ```javascript
  Skill({ skill: "crew:git:clean" })
  ```
```

## Benefits

- Prevents confusion when starting work on merged branches
- Automatically recovers to a clean state
- Uses existing `/crew:git:clean` command for actual branch deletion
- Works with both `main` and `master` as default branch names

## Test plan

- [ ] Test on a branch with deleted remote (merged PR)
- [ ] Verify switch to main works
- [ ] Verify cleanup suggestion appears
- [ ] Test that branches without upstream are unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detects when the current branch’s remote was deleted (usually after a PR merge) and auto-recovers by switching to the default branch, pulling latest, and prompting cleanup. This prevents starting work on stale branches.

- **New Features**
  - Detects deleted upstream after fetch and flags stale feature branches.
  - Automatically checks out main or master and pulls latest changes.
  - Prompts to run Skill({ skill: "crew:git:clean" }) to remove stale local branches.

<sup>Written for commit f7778aeb5cb1523f2b04e931493b990e8cb72f50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

