### PR TITLE
feat(git): add GitButler detection and docs for compatibility

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /crew:plan, /crew:work commands with parallel agent execution.",
-  "version": "1.87.1",
+  "version": "1.91.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/.mcp.json
+++ b/crew/.mcp.json
@@ -28,6 +28,11 @@
       "type": "stdio",
       "command": "phantom",
       "args": ["mcp", "serve"]
+    },
+    "gitbutler": {
+      "type": "stdio",
+      "command": "but",
+      "args": ["mcp"]
     }
   }
 }

--- a/crew/commands/git/butler/assign.md
+++ b/crew/commands/git/butler/assign.md
@@ -1,0 +1,120 @@
+---
+name: crew:git:butler:assign
+description: Assign files to a GitButler virtual branch
+argument-hint: "<file> <branch>"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<objective>
+
+Manually assign files to a virtual branch using the `rub` command.
+
+</objective>
+
+<workflow>
+
+## Step 1: Check GitButler Active
+
+If `GITBUTLER_ACTIVE=false`:
+
+```
+GitButler is not initialized. File assignment requires GitButler.
+```
+
+Exit if not active.
+
+## Step 2: Get Current State
+
+```bash
+but branch list
+```
+
+## Step 3: Parse Arguments or Ask
+
+If both file and branch provided, proceed.
+
+Otherwise:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What operation?",
+      header: "Operation",
+      options: [
+        {
+          label: "Assign file to branch",
+          description: "Move file to specific branch",
+        },
+        {
+          label: "Unassign file",
+          description: "Remove file from all branches",
+        },
+        { label: "Move commit to branch", description: "Relocate a commit" },
+        { label: "Squash commits", description: "Combine two commits" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 4: Execute Rub Command
+
+**Assign file to branch:**
+
+```bash
+but rub ${file} ${branch}
+```
+
+**Unassign file:**
+
+```bash
+but rub ${file} 00
+```
+
+**Move commit to branch:**
+
+```bash
+but rub ${commitSha} ${branch}
+```
+
+**Squash commits:**
+
+```bash
+but rub ${commit1} ${commit2}
+```
+
+## Step 5: Confirm
+
+```bash
+but branch list
+```
+
+</workflow>
+
+<rub_reference>
+
+| Operation   | Command                   | Result                  |
+| ----------- | ------------------------- | ----------------------- |
+| Assign file | `but rub FILE BRANCH`     | File moves to branch    |
+| Unassign    | `but rub FILE 00`         | File becomes unassigned |
+| Amend       | `but rub FILE COMMIT`     | Add file to commit      |
+| Move commit | `but rub COMMIT BRANCH`   | Commit moves to branch  |
+| Squash      | `but rub COMMIT1 COMMIT2` | Commits combined        |
+
+</rub_reference>
+
+<success_criteria>
+
+- [ ] Operation executed successfully
+- [ ] Branch state updated
+- [ ] User understands rub command options
+
+</success_criteria>

--- a/crew/commands/git/butler/branch.md
+++ b/crew/commands/git/butler/branch.md
@@ -1,0 +1,82 @@
+---
+name: crew:git:butler:branch
+description: Create a new GitButler virtual branch
+argument-hint: "[branch name]"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<objective>
+
+Create a new virtual branch for parallel feature development.
+
+</objective>
+
+<workflow>
+
+## Step 1: Check GitButler Active
+
+If `GITBUTLER_ACTIVE=false`:
+
+```
+GitButler is not initialized. Run: but init --target-branch origin/main
+```
+
+Exit if not active.
+
+## Step 2: Get Branch Name
+
+If no argument provided, ask:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What type of branch?",
+      header: "Type",
+      options: [
+        { label: "Feature (Recommended)", description: "New functionality" },
+        { label: "Fix", description: "Bug fix" },
+        { label: "Refactor", description: "Code improvement" },
+        { label: "Chore", description: "Maintenance task" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+Then generate name: `{type}-{description}` (kebab-case)
+
+## Step 3: Create Branch
+
+```bash
+but branch new ${branchName}
+```
+
+## Step 4: Confirm
+
+```bash
+but branch list
+```
+
+Show the new branch and remind user:
+
+- Changes are auto-assigned based on rules
+- Use `but rub FILE BRANCH` to manually assign files
+- Use `crew:git:butler:commit` when ready to commit
+
+</workflow>
+
+<success_criteria>
+
+- [ ] Virtual branch created
+- [ ] Branch appears in list
+- [ ] User informed about next steps
+
+</success_criteria>

--- a/crew/commands/git/butler/commit.md
+++ b/crew/commands/git/butler/commit.md
@@ -1,0 +1,103 @@
+---
+name: crew:git:butler:commit
+description: Commit changes using GitButler MCP or CLI with conventional format
+argument-hint: "[commit message]"
+allowed-tools:
+  - Bash
+  - mcp__gitbutler__gitbutler_update_branches
+---
+
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<objective>
+
+Commit changes using GitButler. Prefer MCP tool for AI-driven workflows, CLI for manual commits.
+
+</objective>
+
+<workflow>
+
+## Step 1: Check GitButler Active
+
+If `GITBUTLER_ACTIVE=false`:
+
+```
+GitButler is not initialized. Use regular git or run: but init
+```
+
+Exit if not active.
+
+## Step 2: Check for Sensitive Files
+
+```bash
+git status --porcelain | grep -E '\.(env|pem|key)$|credentials|secrets' && \
+  echo "⚠️ Sensitive files detected - review before committing"
+```
+
+## Step 3: Commit Using MCP (Preferred for AI workflows)
+
+Use the GitButler MCP tool to auto-commit changes with context:
+
+```javascript
+mcp__gitbutler__gitbutler_update_branches({
+  fullPrompt: "The original user request that led to these changes",
+  changesSummary: "- Added X\n- Modified Y\n- Fixed Z",
+  currentWorkingDirectory: "/path/to/project",
+});
+```
+
+The MCP tool will:
+
+- Auto-assign changes to appropriate virtual branches
+- Generate semantic commit messages
+- Handle the commit workflow automatically
+
+## Step 4: Alternative - CLI Commit (Manual)
+
+If MCP not available or for manual control:
+
+```bash
+but commit -m "type(scope): description"
+```
+
+Or let GitButler AI-generate the message:
+
+```bash
+but commit
+```
+
+## Step 5: Confirm
+
+```bash
+but branch list
+```
+
+</workflow>
+
+<commit_format>
+
+Use conventional commit format:
+
+```
+type(scope): description
+```
+
+| Type     | Use For       |
+| -------- | ------------- |
+| feat     | New feature   |
+| fix      | Bug fix       |
+| refactor | Code change   |
+| docs     | Documentation |
+| chore    | Maintenance   |
+
+</commit_format>
+
+<success_criteria>
+
+- [ ] No sensitive files committed
+- [ ] Conventional format used
+- [ ] Commit created successfully
+
+</success_criteria>

--- a/crew/commands/git/butler/push.md
+++ b/crew/commands/git/butler/push.md
@@ -1,0 +1,81 @@
+---
+name: crew:git:butler:push
+description: Push GitButler virtual branch to remote
+argument-hint: "[branch name]"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<objective>
+
+Push a virtual branch to remote, making it a normal Git branch for review.
+
+</objective>
+
+<workflow>
+
+## Step 1: Check GitButler Active
+
+If `GITBUTLER_ACTIVE=false`:
+
+```
+GitButler is not initialized. Use regular git push.
+```
+
+Exit if not active.
+
+## Step 2: List Branches if No Argument
+
+```bash
+but branch list
+```
+
+If multiple branches, ask which to push:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which branch to push?",
+      header: "Branch",
+      options: branches.map((b) => ({
+        label: b.name,
+        description: `${b.commits} commits`,
+      })),
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 3: Push Branch
+
+```bash
+but push ${branchName}
+```
+
+## Step 4: Confirm and Next Steps
+
+```bash
+but branch list
+```
+
+Inform user:
+
+- Branch is now on remote
+- Create PR with `gh pr create` or `crew:git:pr:create`
+- Or use `but publish` for GitButler's PR creation
+
+</workflow>
+
+<success_criteria>
+
+- [ ] Branch pushed to remote
+- [ ] User informed about PR creation options
+
+</success_criteria>

--- a/crew/commands/git/butler/status.md
+++ b/crew/commands/git/butler/status.md
@@ -1,0 +1,63 @@
+---
+name: crew:git:butler:status
+description: Show GitButler virtual branches and base status
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+  - Skill
+---
+
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<objective>
+
+Show virtual branch status and upstream integration state. Suggest actions for common situations.
+
+</objective>
+
+<workflow>
+
+## Step 1: Check GitButler Active
+
+If `GITBUTLER_ACTIVE=false`:
+
+```
+GitButler is not initialized in this repository.
+
+To initialize: but init --target-branch origin/main
+```
+
+## Step 2: Show Virtual Branches
+
+```bash
+but branch list
+```
+
+## Step 3: Show Base Status
+
+```bash
+but base check
+```
+
+## Step 4: Suggest Actions
+
+Based on output:
+
+| Situation           | Suggestion                           |
+| ------------------- | ------------------------------------ |
+| Upstream ahead      | Run `crew:git:butler:sync` to rebase |
+| Uncommitted changes | Run `crew:git:butler:commit`         |
+| Branch ready        | Run `crew:git:butler:push`           |
+| Conflicts detected  | Edit files, then commit resolution   |
+
+</workflow>
+
+<success_criteria>
+
+- [ ] Virtual branches listed
+- [ ] Base status shown
+- [ ] Actions suggested for current state
+
+</success_criteria>

--- a/crew/commands/git/butler/sync.md
+++ b/crew/commands/git/butler/sync.md
@@ -1,0 +1,78 @@
+---
+name: crew:git:butler:sync
+description: Sync GitButler branches with upstream (rebase on target branch)
+allowed-tools:
+  - Bash
+---
+
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<objective>
+
+Rebase all virtual branches on the latest upstream changes. Remove integrated branches.
+
+</objective>
+
+<workflow>
+
+## Step 1: Check GitButler Active
+
+If `GITBUTLER_ACTIVE=false`:
+
+```
+GitButler is not initialized. Use git pull --rebase instead.
+```
+
+Exit if not active.
+
+## Step 2: Check Upstream Status
+
+```bash
+but base check
+```
+
+Review what will happen:
+
+- Branches to rebase
+- Integrated branches to remove
+- Potential conflicts
+
+## Step 3: Update Base
+
+```bash
+but base update
+```
+
+This automatically:
+
+- Rebases all virtual branches on upstream
+- Removes branches that have been merged
+- Detects and preserves conflicts for resolution
+
+## Step 4: Handle Conflicts
+
+If conflicts detected:
+
+```
+Conflicts detected. Edit the conflicted files directly, then:
+  but commit -m "fix: resolve merge conflicts"
+```
+
+## Step 5: Show Result
+
+```bash
+but branch list
+but base check
+```
+
+</workflow>
+
+<success_criteria>
+
+- [ ] Branches rebased on upstream
+- [ ] Integrated branches removed
+- [ ] Conflicts identified (if any)
+
+</success_criteria>

--- a/crew/commands/git/butler/undo.md
+++ b/crew/commands/git/butler/undo.md
@@ -1,0 +1,100 @@
+---
+name: crew:git:butler:undo
+description: Undo last GitButler operation or restore to snapshot
+argument-hint: "[snapshot sha - optional]"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<objective>
+
+Undo the last GitButler operation or restore to a specific snapshot.
+
+</objective>
+
+<workflow>
+
+## Step 1: Check GitButler Active
+
+If `GITBUTLER_ACTIVE=false`:
+
+```
+GitButler is not initialized. Use git reflog for recovery.
+```
+
+Exit if not active.
+
+## Step 2: Show Operation Log
+
+```bash
+but oplog
+```
+
+## Step 3: Choose Action
+
+If no argument provided:
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "What would you like to do?",
+      header: "Action",
+      options: [
+        {
+          label: "Undo last operation (Recommended)",
+          description: "Revert the most recent change",
+        },
+        {
+          label: "Restore to specific snapshot",
+          description: "Pick a point from the operation log",
+        },
+        { label: "Create manual snapshot", description: "Save current state" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+```
+
+## Step 4: Execute
+
+**Undo last:**
+
+```bash
+but undo
+```
+
+**Restore to snapshot:**
+
+```bash
+but restore ${snapshotSha}
+```
+
+**Create snapshot:**
+
+```bash
+but snapshot -m "manual checkpoint before risky operation"
+```
+
+## Step 5: Confirm
+
+```bash
+but branch list
+but oplog | head -5
+```
+
+</workflow>
+
+<success_criteria>
+
+- [ ] Operation undone or snapshot restored
+- [ ] Current state confirmed
+- [ ] User understands recovery options
+
+</success_criteria>

--- a/crew/commands/git/stacked/add.md
+++ b/crew/commands/git/stacked/add.md
@@ -8,9 +8,34 @@ allowed-tools:
   - Skill
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/advance.md
+++ b/crew/commands/git/stacked/advance.md
@@ -6,6 +6,10 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <worktree_status>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
 </worktree_status>
@@ -13,6 +17,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/checkout-prs.md
+++ b/crew/commands/git/stacked/checkout-prs.md
@@ -8,6 +8,10 @@ allowed-tools:
   - Skill
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <worktree_status>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
 </worktree_status>
@@ -15,6 +19,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/cleanup.md
+++ b/crew/commands/git/stacked/cleanup.md
@@ -10,6 +10,10 @@ hooks:
   PreToolUse: false
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <worktree_status>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
 </worktree_status>
@@ -17,6 +21,27 @@ hooks:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/discover.md
+++ b/crew/commands/git/stacked/discover.md
@@ -6,6 +6,10 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <worktree_status>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
 </worktree_status>
@@ -13,6 +17,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/go.md
+++ b/crew/commands/git/stacked/go.md
@@ -8,6 +8,10 @@ allowed-tools:
   - Skill
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <worktree_status>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
 </worktree_status>
@@ -15,6 +19,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/restack.md
+++ b/crew/commands/git/stacked/restack.md
@@ -6,6 +6,10 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <pr_info>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-info.sh 2>&1`
 </pr_info>
@@ -13,6 +17,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/retarget.md
+++ b/crew/commands/git/stacked/retarget.md
@@ -7,6 +7,10 @@ allowed-tools:
   - Skill
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <pr_info>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/gh-pr-info.sh 2>&1`
 </pr_info>
@@ -14,6 +18,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/setup.md
+++ b/crew/commands/git/stacked/setup.md
@@ -7,6 +7,31 @@ allowed-tools:
   - Skill
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
+
 <objective>
 
 Install git-machete if needed. Configure optimal settings. Initialize layout.

--- a/crew/commands/git/stacked/slide-out.md
+++ b/crew/commands/git/stacked/slide-out.md
@@ -6,6 +6,10 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <worktree_status>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
 </worktree_status>
@@ -13,6 +17,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/status.md
+++ b/crew/commands/git/stacked/status.md
@@ -11,9 +11,34 @@ hooks:
   PreToolUse: false
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/stacked/traverse.md
+++ b/crew/commands/git/stacked/traverse.md
@@ -7,6 +7,10 @@ allowed-tools:
   - Skill
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <worktree_status>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/worktree-context.sh 2>&1`
 </worktree_status>
@@ -14,6 +18,27 @@ allowed-tools:
 <stack_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/machete-context.sh 2>&1`
 </stack_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Stacked branches (git-machete) are not compatible with GitButler virtual branches.
+
+GitButler has its own stacking system. Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:sync` - Sync with upstream
+
+To use machete, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with machete commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/worktree/checkout-pr.md
+++ b/crew/commands/git/worktree/checkout-pr.md
@@ -6,6 +6,32 @@ allowed-tools:
   - Bash
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Git worktrees are not compatible with GitButler virtual branches.
+
+GitButler uses virtual branches instead of worktrees for parallel development.
+
+For PR checkout with GitButler, use:
+- `gh pr checkout <number>` - Standard checkout (exits GitButler mode)
+- Or work directly on virtual branches
+
+To use worktrees, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with worktree commands.
+
+</gitbutler_incompatible>
+
 <objective>
 
 Checkout PR or issue into a new phantom worktree.

--- a/crew/commands/git/worktree/create.md
+++ b/crew/commands/git/worktree/create.md
@@ -7,9 +7,36 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <phantom_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/phantom-context.sh`
 </phantom_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Git worktrees are not compatible with GitButler virtual branches.
+
+GitButler uses virtual branches instead of worktrees for parallel development.
+All virtual branches exist in the same working directory simultaneously.
+
+Use these instead:
+- `crew:git:butler:branch` - Create virtual branch
+- `crew:git:butler:status` - View virtual branches
+
+To use worktrees, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with worktree commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/commands/git/worktree/delete.md
+++ b/crew/commands/git/worktree/delete.md
@@ -7,6 +7,33 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Git worktrees are not compatible with GitButler virtual branches.
+
+GitButler uses virtual branches instead of worktrees for parallel development.
+All virtual branches exist in the same working directory simultaneously.
+
+Use these instead:
+- `crew:git:butler:status` - View virtual branches
+- `but branch delete <name>` - Delete virtual branch
+
+To use worktrees, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with worktree commands.
+
+</gitbutler_incompatible>
+
 <objective>
 
 Delete worktree. Confirm if uncommitted changes exist.

--- a/crew/commands/git/worktree/list.md
+++ b/crew/commands/git/worktree/list.md
@@ -5,6 +5,33 @@ allowed-tools:
   - Bash
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Git worktrees are not compatible with GitButler virtual branches.
+
+GitButler uses virtual branches instead of worktrees for parallel development.
+All virtual branches exist in the same working directory simultaneously.
+
+Use these instead:
+- `crew:git:butler:status` - View virtual branches (equivalent to worktree list)
+- `crew:git:butler:branch` - Create virtual branch (equivalent to worktree create)
+
+To use worktrees, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with worktree commands.
+
+</gitbutler_incompatible>
+
 <objective>
 
 List all phantom worktrees.

--- a/crew/commands/git/worktree/switch.md
+++ b/crew/commands/git/worktree/switch.md
@@ -7,9 +7,36 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+<butler_context>
+!`${CLAUDE_PLUGIN_ROOT}/scripts/git/gitbutler-context.sh`
+</butler_context>
+
 <phantom_context>
 !`${CLAUDE_PLUGIN_ROOT}/scripts/git/phantom-context.sh`
 </phantom_context>
+
+<gitbutler_incompatible>
+
+**This command does not work with GitButler.**
+
+If `GITBUTLER_ACTIVE=true` from `<butler_context>`:
+
+```
+Git worktrees are not compatible with GitButler virtual branches.
+
+GitButler uses virtual branches instead of worktrees for parallel development.
+All virtual branches exist in the same working directory - no switching needed!
+
+With GitButler, you work on multiple branches simultaneously:
+- `crew:git:butler:status` - View all virtual branches
+- `crew:git:butler:assign` - Move files between branches
+
+To use worktrees, first disable GitButler in this repository.
+```
+
+Exit immediately. Do not proceed with worktree commands.
+
+</gitbutler_incompatible>
 
 <objective>
 

--- a/crew/scripts/git/gitbutler-context.sh
+++ b/crew/scripts/git/gitbutler-context.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# GitButler context detection script
+# Checks if GitButler is active and provides status
+
+set -euo pipefail
+
+# Check if but CLI is available
+if ! command -v but &>/dev/null; then
+	echo "GITBUTLER_AVAILABLE=false"
+	echo "GITBUTLER_ACTIVE=false"
+	exit 0
+fi
+
+echo "GITBUTLER_AVAILABLE=true"
+
+# Check if GitButler is initialized in this repo
+if [[ -d ".git/gitbutler" ]]; then
+	echo "GITBUTLER_ACTIVE=true"
+
+	# Get virtual branches
+	if branches=$(but branch list 2>/dev/null); then
+		echo "VIRTUAL_BRANCHES:"
+		echo "$branches" | sed 's/^/  /'
+	fi
+
+	# Get base branch status
+	if base_status=$(but base check 2>/dev/null); then
+		echo "BASE_STATUS:"
+		echo "$base_status" | head -5 | sed 's/^/  /'
+	fi
+else
+	echo "GITBUTLER_ACTIVE=false"
+fi

--- a/crew/skills/git/SKILL.md
+++ b/crew/skills/git/SKILL.md
@@ -40,29 +40,65 @@ Git workflow guidance: conventional commits, branch naming, PR workflows.
 
 <commands>
 
-| Command                                          | Purpose                               |
-| ------------------------------------------------ | ------------------------------------- |
-| `Skill({ skill: "crew:git:stacked:setup" })`             | Configure git + machete optimally     |
-| `Skill({ skill: "crew:git:stacked:discover" })`          | Auto-detect branch layout             |
-| `Skill({ skill: "crew:git:pr:create" })`                | Create PR with template               |
-| `Skill({ skill: "crew:git:pr:update" })`         | Update PR title/body                  |
-| `Skill({ skill: "crew:git:stacked:status" })`      | View branch stack status              |
-| `Skill({ skill: "crew:git:stacked:add" })`         | Add branch to stack                   |
-| `Skill({ skill: "crew:git:stacked:traverse" })`          | Sync all stacked branches             |
-| `Skill({ skill: "crew:git:sync" })`              | Sync current branch with parent       |
-| `Skill({ skill: "crew:git:stacked:slide-out" })`         | Remove merged branch from stack       |
-| `Skill({ skill: "crew:git:stacked:advance" })`           | Fast-forward merge child into current |
-| `Skill({ skill: "crew:git:stacked:go" })`                | Navigate stack (up/down/next/prev)    |
-| `Skill({ skill: "crew:git:stacked:checkout-prs" })`      | Checkout PRs from GitHub              |
-| `Skill({ skill: "crew:git:stacked:retarget" })`       | Change PR base branch                 |
-| `Skill({ skill: "crew:git:stacked:restack" })`        | Retarget + force push atomically      |
-| `Skill({ skill: "crew:git:stacked:cleanup" })` | Delete branches not in layout         |
-| `Skill({ skill: "crew:git:commit" })`            | Create conventional commit            |
-| `Skill({ skill: "crew:git:branch:new" })`            | Create feature branch                 |
-| `Skill({ skill: "crew:git:push" })`              | Push current branch                   |
-| `Skill({ skill: "crew:git:clean" })`             | Clean stale branches                  |
+| Command                                             | Purpose                               |
+| --------------------------------------------------- | ------------------------------------- |
+| `Skill({ skill: "crew:git:stacked:setup" })`        | Configure git + machete optimally     |
+| `Skill({ skill: "crew:git:stacked:discover" })`     | Auto-detect branch layout             |
+| `Skill({ skill: "crew:git:pr:create" })`            | Create PR with template               |
+| `Skill({ skill: "crew:git:pr:update" })`            | Update PR title/body                  |
+| `Skill({ skill: "crew:git:stacked:status" })`       | View branch stack status              |
+| `Skill({ skill: "crew:git:stacked:add" })`          | Add branch to stack                   |
+| `Skill({ skill: "crew:git:stacked:traverse" })`     | Sync all stacked branches             |
+| `Skill({ skill: "crew:git:sync" })`                 | Sync current branch with parent       |
+| `Skill({ skill: "crew:git:stacked:slide-out" })`    | Remove merged branch from stack       |
+| `Skill({ skill: "crew:git:stacked:advance" })`      | Fast-forward merge child into current |
+| `Skill({ skill: "crew:git:stacked:go" })`           | Navigate stack (up/down/next/prev)    |
+| `Skill({ skill: "crew:git:stacked:checkout-prs" })` | Checkout PRs from GitHub              |
+| `Skill({ skill: "crew:git:stacked:retarget" })`     | Change PR base branch                 |
+| `Skill({ skill: "crew:git:stacked:restack" })`      | Retarget + force push atomically      |
+| `Skill({ skill: "crew:git:stacked:cleanup" })`      | Delete branches not in layout         |
+| `Skill({ skill: "crew:git:commit" })`               | Create conventional commit            |
+| `Skill({ skill: "crew:git:branch:new" })`           | Create feature branch                 |
+| `Skill({ skill: "crew:git:push" })`                 | Push current branch                   |
+| `Skill({ skill: "crew:git:clean" })`                | Clean stale branches                  |
 
 </commands>
+
+<butler_commands>
+
+**GitButler Virtual Branch Commands** (use when GitButler is active):
+
+| Command                                      | Purpose                               |
+| -------------------------------------------- | ------------------------------------- |
+| `Skill({ skill: "crew:git:butler:status" })` | View virtual branches and base status |
+| `Skill({ skill: "crew:git:butler:branch" })` | Create virtual branch                 |
+| `Skill({ skill: "crew:git:butler:commit" })` | Commit with conventional format       |
+| `Skill({ skill: "crew:git:butler:push" })`   | Push virtual branch to remote         |
+| `Skill({ skill: "crew:git:butler:sync" })`   | Sync with upstream (rebase all)       |
+| `Skill({ skill: "crew:git:butler:undo" })`   | Undo last operation or restore        |
+| `Skill({ skill: "crew:git:butler:assign" })` | Assign files to branches (rub)        |
+
+**MCP Tool for Auto-Commit:**
+
+```javascript
+mcp__gitbutler__gitbutler_update_branches({
+  fullPrompt: "Original user request",
+  changesSummary: "- What changed\n- Why it changed",
+  currentWorkingDirectory: "/path/to/project",
+});
+```
+
+Use this MCP tool after making code changes to auto-commit with context.
+
+**Detection:** Check `.git/gitbutler` directory or run `but branch list`.
+
+**Incompatibility:** When GitButler is active:
+
+- Stacked commands (`crew:git:stacked:*`) do not work
+- Worktree commands (`crew:git:worktree:*`) do not work
+- Use butler commands instead for parallel development
+
+</butler_commands>
 
 <scripts>
 

--- a/crew/skills/gitbutler/SKILL.md
+++ b/crew/skills/gitbutler/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: gitbutler
+description: GitButler virtual branch management and Butler Flow workflow. Use when working with GitButler, virtual branches, the `but` CLI, or parallel feature development without context switching.
+triggers:
+  - "gitbutler"
+  - "\\bbut\\b"
+  - "virtual branch"
+  - "butler"
+---
+
+<objective>
+
+GitButler reimagines source code management with virtual branches - work on multiple independent branches simultaneously in a single working directory. This skill guides usage of the `but` CLI and MCP server for branch management, commits, and AI integration.
+
+</objective>
+
+<essential_principles>
+
+**Virtual Branches Are Different**
+
+Virtual branches exist only in GitButler, not as traditional Git branches. All uncommitted changes must belong to a virtual branch. Changes are "assigned" to branches before committing, then pushed as normal Git branches for review.
+
+**Butler Flow**
+
+1. Work stems from a "target branch" (typically `origin/main`)
+2. Changes immediately exist in virtual branches
+3. Share early with team via push
+4. Test integration locally before merging
+5. Branches auto-cleanup when integrated
+
+**MCP Server Available**
+
+GitButler provides an MCP server enabling AI tools to manage commits automatically. Use `mcp__gitbutler__gitbutler_update_branches` to auto-commit changes with context.
+
+</essential_principles>
+
+<quick_start>
+
+**MCP Auto-Commit (Preferred for AI workflows):**
+
+```javascript
+mcp__gitbutler__gitbutler_update_branches({
+  fullPrompt: "User's original request",
+  changesSummary: "- Added X\n- Modified Y",
+  currentWorkingDirectory: "/path/to/project",
+});
+```
+
+**CLI - Create and work on a branch:**
+
+```bash
+but branch new feature-name
+# ... make changes ...
+but commit -m "feat: add new feature"
+but push feature-name
+```
+
+**Check upstream status:**
+
+```bash
+but base check    # View integration state
+but base update   # Rebase on upstream changes
+```
+
+**Recovery:**
+
+```bash
+but oplog         # View operation history
+but undo          # Revert last operation
+```
+
+</quick_start>
+
+<routing>
+
+| Task                    | Resource                         |
+| ----------------------- | -------------------------------- |
+| CLI commands            | `references/cli-commands.md`     |
+| Virtual branch concepts | `references/virtual-branches.md` |
+| MCP/AI integration      | `references/mcp-integration.md`  |
+
+</routing>
+
+<common_patterns>
+
+<pattern name="ai_workflow">
+```javascript
+// After making code changes, auto-commit with context
+mcp__gitbutler__gitbutler_update_branches({
+  fullPrompt: "Add user authentication with login form",
+  changesSummary: "- Created auth controller\n- Added login component\n- Updated routes",
+  currentWorkingDirectory: process.cwd()
+})
+// Then push when ready
+// but push branch-name
+```
+</pattern>
+
+<pattern name="typical_workflow">
+```bash
+# Start feature
+but branch new add-user-auth
+
+# Work and commit iteratively
+
+but commit -m "feat: add login form"
+but commit -m "feat: add session handling"
+
+# Push for review
+
+but push add-user-auth
+
+# After upstream merge
+
+but base update
+
+````
+</pattern>
+
+<pattern name="parallel_features">
+```bash
+# Create multiple branches
+but branch new feature-a
+but branch new feature-b
+
+# Assign files to specific branches (using rub)
+but rub src/feature-a.ts feature-a
+but rub src/feature-b.ts feature-b
+
+# Commit each independently
+but commit -m "feat(a): implement feature A"
+but commit -m "feat(b): implement feature B"
+````
+
+</pattern>
+
+<pattern name="recovery">
+```bash
+# Made a mistake? View history
+but oplog
+
+# Undo last operation
+
+but undo
+
+# Or restore to specific snapshot
+
+but restore <snapshot-sha>
+
+```
+</pattern>
+
+</common_patterns>
+
+<success_criteria>
+
+- Virtual branches created for features
+- Changes assigned to appropriate branches
+- Commits follow conventional format (via MCP or CLI)
+- Branches pushed for review
+- Integration tested with `but base check`
+
+</success_criteria>
+```

--- a/crew/skills/gitbutler/references/cli-commands.md
+++ b/crew/skills/gitbutler/references/cli-commands.md
@@ -1,0 +1,194 @@
+<objective>
+
+Complete reference for the GitButler CLI (`but` command). All commands for branch management, committing, pushing, and recovery.
+
+</objective>
+
+<initialization>
+
+```bash
+but init                    # Initialize GitButler in repo
+but init --target-branch origin/main  # Specify target branch
+```
+
+Sets up GitButler tracking and establishes the target branch (production code baseline).
+
+</initialization>
+
+<branch_commands>
+
+**Create and manage virtual branches:**
+
+| Command                   | Description                           |
+| ------------------------- | ------------------------------------- |
+| `but branch new [NAME]`   | Create branch (auto-named if omitted) |
+| `but branch delete NAME`  | Remove branch                         |
+| `but branch unapply NAME` | Hide branch without deleting          |
+| `but branch list`         | List all virtual branches             |
+
+</branch_commands>
+
+<commit_commands>
+
+**Create commits:**
+
+| Command                   | Description                           |
+| ------------------------- | ------------------------------------- |
+| `but commit -m "message"` | Commit assigned changes               |
+| `but commit --only`       | Commit only explicitly assigned files |
+| `but commit`              | AI-generates commit message           |
+
+GitButler auto-generates semantic prefixes (feat:, fix:, refactor:) when using AI message generation.
+
+**Edit commits:**
+
+| Command                     | Description                          |
+| --------------------------- | ------------------------------------ |
+| `but describe [SHA/BRANCH]` | Edit commit message or rename branch |
+| `but new [TARGET]`          | Insert blank commit for splitting    |
+
+</commit_commands>
+
+<rub_command>
+
+The `rub` command combines entities for versatile operations:
+
+| Operation        | Command                   | Result                                   |
+| ---------------- | ------------------------- | ---------------------------------------- |
+| Amend commit     | `but rub FILE COMMIT`     | Add file to existing commit              |
+| Squash           | `but rub COMMIT1 COMMIT2` | Combine commits                          |
+| Assign to branch | `but rub FILE BRANCH`     | Move file to branch                      |
+| Move commit      | `but rub COMMIT BRANCH`   | Move commit to branch                    |
+| Unassign         | `but rub FILE 00`         | Remove assignment (ID `00` = unassigned) |
+
+<examples>
+
+```bash
+# Assign file to branch
+but rub app/models/user.rb add-user-feature
+
+# Amend last commit with file
+but rub config/routes.rb HEAD
+
+# Squash commit into previous
+but rub abc123 def456
+
+# Unassign file
+but rub app/temp.rb 00
+```
+
+</examples>
+
+</rub_command>
+
+<base_commands>
+
+**Manage relationship with upstream:**
+
+| Command           | Description                             |
+| ----------------- | --------------------------------------- |
+| `but base check`  | View upstream status, integration state |
+| `but base update` | Rebase active branches on upstream      |
+
+`but base update` automatically:
+
+- Rebases all virtual branches on latest upstream
+- Detects conflicts
+- Removes integrated branches
+
+</base_commands>
+
+<push_commands>
+
+**Push to remote:**
+
+| Command                | Description           |
+| ---------------------- | --------------------- |
+| `but push [BRANCH_ID]` | Push branch to remote |
+| `but push --all`       | Push all branches     |
+
+**Gerrit-specific flags:**
+
+| Flag            | Description              |
+| --------------- | ------------------------ |
+| `--wip`         | Push as work-in-progress |
+| `--ready`       | Mark ready for review    |
+| `--hashtag TAG` | Add hashtag              |
+| `--topic TOPIC` | Set topic                |
+
+</push_commands>
+
+<forge_commands>
+
+**GitHub/GitLab integration:**
+
+| Command                 | Description              |
+| ----------------------- | ------------------------ |
+| `but forge auth`        | Authenticate with GitHub |
+| `but publish [OPTIONS]` | Create PRs for branches  |
+
+</forge_commands>
+
+<recovery_commands>
+
+**Operations log and undo:**
+
+| Command                 | Description                  |
+| ----------------------- | ---------------------------- |
+| `but oplog`             | Display operation history    |
+| `but undo`              | Revert last operation        |
+| `but restore SHA`       | Restore to specific snapshot |
+| `but snapshot -m "msg"` | Create manual checkpoint     |
+
+<recovery_example>
+
+```bash
+# View recent operations
+but oplog
+
+# Output shows:
+# [abc123] 5 min ago - committed to feature-branch
+# [def456] 10 min ago - created branch feature-branch
+
+# Undo last operation
+but undo
+
+# Or restore to specific snapshot
+but restore def456
+```
+
+</recovery_example>
+
+</recovery_commands>
+
+<data_locations>
+
+GitButler stores data in platform-specific locations:
+
+| Platform | Path                                                    |
+| -------- | ------------------------------------------------------- |
+| macOS    | `~/Library/Application Support/com.gitbutler.app/`      |
+| Windows  | `C:\Users\[username]\AppData\Roaming\com.gitbutler.app` |
+| Linux    | `~/.local/share/gitbutler-tauri/`                       |
+
+**Git references:**
+Virtual branches stored as `refs/gitbutler/[branch-name]`
+
+```bash
+# View virtual branch directly
+git show refs/gitbutler/feature-branch
+
+# Push virtual branch manually (escape hatch)
+git push origin refs/gitbutler/feature:refs/heads/feature
+```
+
+</data_locations>
+
+<success_criteria>
+
+- Commands executed without errors
+- Virtual branches created and managed
+- Changes committed and pushed
+- Recovery operations restore expected state
+
+</success_criteria>

--- a/crew/skills/gitbutler/references/mcp-integration.md
+++ b/crew/skills/gitbutler/references/mcp-integration.md
@@ -1,0 +1,200 @@
+<objective>
+
+GitButler's MCP server and AI integration. Enable AI tools (Claude Code, Cursor, VS Code) to manage commits automatically.
+
+</objective>
+
+<mcp_server>
+
+Start the MCP server:
+
+```bash
+but mcp
+```
+
+The MCP server provides the `gitbutler_update_branches` tool for AI agents to auto-commit changes to isolated branches.
+
+**Configuration in Claude Code:**
+
+Add to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "gitbutler": {
+      "type": "stdio",
+      "command": "but",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+</mcp_server>
+
+<hook_integration>
+
+Register GitButler hooks in Claude Code settings (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": ["but claude pre-tool"],
+    "PostToolUse": ["but claude post-tool"],
+    "Stop": ["but claude stop"]
+  }
+}
+```
+
+**Hook behavior:**
+
+- `PreToolUse`: Prepares context before AI tool execution
+- `PostToolUse`: Updates GitButler state after tool execution
+- `Stop`: Finalizes session, auto-commits remaining changes
+
+</hook_integration>
+
+<agents_tab>
+
+GitButler's desktop client includes an Agents tab for managing AI sessions:
+
+**Per-branch sessions:**
+
+- Isolated contexts per virtual branch
+- Token/cost monitoring
+- Model selection (Claude Sonnet, etc.)
+- Thinking mode variations
+
+**Features:**
+
+- Automatic TODO breakout from agent plans
+- Prompt templates
+- Auto-commits with AI-generated messages
+
+</agents_tab>
+
+<auto_commit_workflow>
+
+With MCP integration, AI agents can:
+
+1. Make changes to files
+2. GitButler auto-detects changes
+3. Changes assigned to appropriate virtual branch (based on rules)
+4. Agent calls `gitbutler_update_branches`
+5. Changes committed with AI-generated message
+6. Branch ready for push
+
+**Example session:**
+
+```
+User: "Add user authentication"
+AI: [Creates auth files, modifies routes]
+GitButler: [Assigns to 'add-auth' branch, commits: "feat: add user authentication system"]
+User: but push add-auth
+```
+
+</auto_commit_workflow>
+
+<mcp_tool_usage>
+
+**MCP Tool: `mcp__gitbutler__gitbutler_update_branches`**
+
+Call this tool after making code changes to auto-commit them:
+
+```javascript
+mcp__gitbutler__gitbutler_update_branches({
+  fullPrompt: "Add user authentication with login form",
+  changesSummary:
+    "- Created auth controller\n- Added login form component\n- Updated routes",
+  currentWorkingDirectory: "/Users/user/project",
+});
+```
+
+**Parameters:**
+
+| Parameter                 | Required | Description                                          |
+| ------------------------- | -------- | ---------------------------------------------------- |
+| `fullPrompt`              | Yes      | The original user request that triggered the changes |
+| `changesSummary`          | Yes      | Bullet list of what changed and why                  |
+| `currentWorkingDirectory` | Yes      | Full path to the git project root                    |
+
+**When to use:**
+
+- After completing a set of related code changes
+- When you want GitButler to auto-assign and commit changes
+- At natural stopping points in the workflow
+
+**Note:** Other operations (branch creation, pushing, status) still use CLI commands. The MCP tool is specifically for committing changes with context.
+
+</mcp_tool_usage>
+
+<rules_for_ai>
+
+GitButler can auto-assign AI changes using rules:
+
+**Session ID Rule:**
+Claude Code session ID can be captured to assign all changes from that session to a specific branch.
+
+**Path-based rules:**
+
+```
+Path: src/auth/*
+Branch: add-auth
+```
+
+**Content-based rules:**
+
+```
+Content: /authenticate|login|session/
+Branch: add-auth
+```
+
+Rules are evaluated in order. Multiple matching rules combine with AND logic.
+
+</rules_for_ai>
+
+<commit_message_generation>
+
+GitButler generates commit messages using AI:
+
+**Features:**
+
+- Semantic prefix selection (feat, fix, refactor, etc.)
+- Character limit enforcement (50 title, 72 body)
+- Context-aware from diff content
+- Streaming generation display
+- Customizable prompts per project
+
+**CLI usage:**
+
+```bash
+# Let GitButler generate message
+but commit
+
+# Or provide your own
+but commit -m "feat: add login form"
+```
+
+</commit_message_generation>
+
+<internal_mode>
+
+For deeper integration:
+
+```bash
+but mcp --internal
+```
+
+Internal mode provides additional capabilities for tight editor integration.
+
+</internal_mode>
+
+<success_criteria>
+
+- MCP server configured and running
+- Hooks registered in Claude Code settings
+- AI changes auto-assigned to branches
+- Commits generated with meaningful messages
+- Branches ready for push after AI session
+
+</success_criteria>

--- a/crew/skills/gitbutler/references/virtual-branches.md
+++ b/crew/skills/gitbutler/references/virtual-branches.md
@@ -1,0 +1,177 @@
+<objective>
+
+Understanding GitButler's virtual branches - how they differ from Git branches and how to work with them effectively.
+
+</objective>
+
+<core_concepts>
+
+**What Are Virtual Branches?**
+
+Virtual branches exist only within GitButler. They allow multiple independent lines of work in a single working directory simultaneously. Traditional Git requires checking out one branch at a time; GitButler removes this limitation.
+
+**Key Differences from Git:**
+
+| Aspect            | Git Branches                      | Virtual Branches              |
+| ----------------- | --------------------------------- | ----------------------------- |
+| Existence         | In `.git/refs/heads/`             | In GitButler state            |
+| Working directory | One at a time                     | Multiple simultaneously       |
+| Changes           | All uncommitted belong to current | Assigned to specific branches |
+| Context switching | Requires checkout, stashing       | Instant - no stashing         |
+
+**Lifecycle:**
+
+1. Create virtual branch with `but branch new`
+2. Assign changes to branch (automatic or via `but rub`)
+3. Commit changes with `but commit`
+4. Push to remote - becomes normal Git branch
+5. After merge, branch auto-removed with `but base update`
+
+</core_concepts>
+
+<change_assignment>
+
+Changes must be assigned to a virtual branch before committing. GitButler handles this automatically based on rules, or you can assign manually.
+
+**Automatic Assignment:**
+
+- New files in branch's directory pattern
+- Changes matching content rules
+- Files touched by Claude Code session
+
+**Manual Assignment:**
+
+```bash
+# Assign file to branch
+but rub path/to/file.ts my-branch
+
+# Unassign file (back to unassigned state)
+but rub path/to/file.ts 00
+```
+
+**Rules System:**
+
+Rules auto-assign files to branches based on:
+
+1. **Path Matches Regex** - File location patterns
+2. **Content Matches Regex** - Changed line patterns
+3. **Claude Code Session ID** - AI-generated rules (lower priority)
+
+Multiple rules combine with AND logic. Rules evaluate sequentially.
+
+</change_assignment>
+
+<stacked_branches>
+
+Virtual branches can be stacked for dependent changes:
+
+```
+main
+  └── feature-base (PR #1 → main)
+        └── feature-extension (PR #2 → feature-base)
+              └── feature-polish (PR #3 → feature-extension)
+```
+
+**Creating stacks:**
+
+```bash
+but branch new feature-base
+# ... work and commit ...
+but branch new feature-extension
+# ... work depending on feature-base ...
+```
+
+**Requirements for stacked PRs:**
+
+- Enable GitHub automatic branch deletion
+- Use "Merge" strategy (not squash) for cleaner experience
+- Each PR targets its parent branch (except bottom → main)
+
+</stacked_branches>
+
+<applied_unapplied>
+
+Branches exist in two states:
+
+**Applied:** Active in working directory, changes visible
+**Unapplied:** Hidden but preserved, changes not visible
+
+```bash
+# Hide branch without deleting
+but branch unapply feature-branch
+
+# Show branch again
+but branch apply feature-branch
+
+# List all branches (both states)
+but branch list
+```
+
+Use unapply for:
+
+- Temporarily setting aside work
+- Reducing working directory complexity
+- Preserving context for later
+
+</applied_unapplied>
+
+<conflict_handling>
+
+GitButler handles conflicts differently than Git:
+
+1. Stores conflicted commits rather than stopping rebase
+2. Shows "Resolve conflict" button in UI
+3. Direct file editing with conflict markers visible
+4. Saves changes and rebases dependent commits automatically
+
+**In CLI:**
+
+```bash
+# Check for conflicts after base update
+but base check
+
+# If conflicts exist, edit files directly
+# Then commit the resolution
+but commit -m "fix: resolve merge conflicts"
+```
+
+</conflict_handling>
+
+<integration_with_git>
+
+Virtual branches become Git branches when pushed:
+
+```bash
+# Virtual branch → Git branch
+but push feature-branch
+# Creates origin/feature-branch
+```
+
+**Direct Git access (escape hatch):**
+
+```bash
+# View virtual branch in Git
+git show refs/gitbutler/feature-branch
+
+# Manual push if needed
+git push origin refs/gitbutler/feature:refs/heads/feature
+```
+
+**WIP commits:**
+GitButler may create WIP (work-in-progress) commits to preserve uncommitted state. These are internal and auto-cleaned.
+
+**Integration commits:**
+When viewing applied state, GitButler creates integration commits showing combined branch state.
+
+</integration_with_git>
+
+<success_criteria>
+
+- Understand difference between virtual and Git branches
+- Know how to assign changes to branches
+- Can create and manage stacked branches
+- Understand applied/unapplied states
+- Know how to resolve conflicts
+- Can access virtual branches via Git when needed
+
+</success_criteria>


### PR DESCRIPTION
Add a gitbutler-context script that detects whether GitButler is
available and active in the repository, and prints basic virtual-branch
and base status information.

Embed the new context into stacked commands (advance, cleanup, status)
so the UI can detect GitButler presence. For the machete-backed stacked
commands add an explicit incompatible notice that warns the user when
GITBUTLER_ACTIVE=true, explains that git-machete stacking conflicts with
GitButler virtual branches, suggests the corresponding crew:git:butler
commands, and instructs the user to disable GitButler before using
machete commands.

Add a draft crew:git:butler:push command doc that outlines pushing a
GitButler virtual branch to remote (argument handling, branch listing,
push step, and follow-up), so users have guidance on managing virtual
branches and transitioning them to normal remote branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitButler detection and guardrails, plus a full set of GitButler commands and docs. Stacked (machete) and worktree commands now stop with a clear message when GitButler is active and point to safe alternatives.

- New Features
  - Added gitbutler-context.sh and embedded it into stacked/worktree commands to detect GitButler and show virtual-branch/base status.
  - Added incompatibility notices: machete and worktree commands exit when GITBUTLER_ACTIVE=true and suggest crew:git:butler:* equivalents.
  - New GitButler command docs: status, branch, commit (MCP or CLI), assign (rub), push, sync, undo.
  - Added GitButler SKILL and references (virtual branches, CLI, MCP integration); updated git SKILL to route to butler commands.
  - Enabled GitButler MCP server in .mcp.json; bumped plugin version to 1.91.0.

- Migration
  - If GitButler is active, use crew:git:butler:* instead of machete/worktree commands, or disable GitButler to continue with those flows.

<sup>Written for commit 0b799bc52a1f22a961488f75a7bfdc284afe2521. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

