### PR TITLE
fix(crew): make quality review mandatory after Ralph Loop

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /crew:plan, /crew:work commands with parallel agent execution.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/work.md
+++ b/crew/commands/work.md
@@ -181,7 +181,22 @@ Follow it EXACTLY. No implementation without failing test first. No exceptions.
 });
 ```
 
-## Step 5: Git Action (After Loop Completes)
+## Step 5: Final Quality Review (MANDATORY)
+
+**After Ralph Loop completes, ALWAYS run the quality review to ensure all findings are captured.**
+
+```javascript
+// Run the seven-leg quality review
+Skill({ skill: "crew:work:review", args: slug });
+```
+
+This step is mandatory because:
+
+1. Ralph Loop may have introduced new issues in final iterations
+2. Ensures consistent review summary format for the user
+3. Catches any issues the loop missed
+
+## Step 6: Git Action (After Review Completes)
 
 ```javascript
 AskUserQuestion({
@@ -299,6 +314,7 @@ Read({ file_path: "/tmp/feature-after-submit.png" });
 - [ ] Browser testing for UI stories
 - [ ] Feature video recorded for UI/frontend work
 - [ ] `<promise>WORK COMPLETE</promise>` output when genuinely done
+- [ ] **Final quality review run after Ralph Loop** (Step 5)
 - [ ] Git action question asked (PR/commit/push/stop)
 
 </success_criteria>


### PR DESCRIPTION
The crew:work command had quality review (crew:work:review) only as text instructions inside the Ralph Loop prompt. Ralph Loop was not reliably executing this step, so reviews had to be run manually.

Changes:
- Add explicit Step 5 to run crew:work:review after Ralph Loop completes
- Renumber Git Action step to Step 6
- Add success criteria for mandatory final review

This ensures the seven-leg quality review always runs before git actions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the final quality review mandatory in crew:work by adding an explicit Step 5 that runs crew:work:review after the Ralph Loop. This ensures the seven-leg review runs before any git action.

- **Bug Fixes**
  - Added explicit Step 5 to run crew:work:review; renumbered Git Action to Step 6.
  - Added success criteria requiring the final review.
  - Bumped plugin version to 3.0.2.

<sup>Written for commit 1b2f7ed2273f39f1c0bfa80462b937368722359e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

