### PR TITLE
feat(crew): add universal TDD enforcement across all code changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,40 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Claude Code plugin marketplace repository. It contains the `crew` plugin - an orchestration system for work execution, skill management, and git workflows. This is NOT a traditional application with build/test pipelines.
 
+## TDD Required (MANDATORY)
+
+**ALL code changes MUST follow Test-Driven Development. NO EXCEPTIONS.**
+
+### Before Writing ANY Implementation Code
+
+```javascript
+// Load the TDD skill FIRST
+Skill({ skill: "devtools:tdd-typescript" })
+```
+
+### RED-GREEN-REFACTOR Cycle
+
+| Phase | Action | Verification |
+|-------|--------|--------------|
+| **RED** | Write failing test FIRST | `bun run test` - MUST fail |
+| **GREEN** | Write minimal code | `bun run test` - MUST pass |
+| **REFACTOR** | Improve while green | `bun run test` - STILL pass |
+
+### Coverage Requirements (Non-Negotiable)
+
+- Line coverage: **80% minimum**
+- Branch coverage: **75% minimum**
+- Function coverage: **90% minimum**
+- Critical paths: **100%**
+
+### The Three Laws
+
+1. Write NO production code until a failing test exists
+2. Write ONLY enough test to demonstrate failure
+3. Write ONLY enough code to pass the test
+
+**Hooks enforce TDD on every Edit/Write operation. Follow the workflow.**
+
 ## Plugin Structure
 
 ```

--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /crew:plan, /crew:work commands with parallel agent execution.",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/hooks/hooks.json
+++ b/crew/hooks/hooks.json
@@ -49,6 +49,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/suggest-skill.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/enforce-tdd.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -82,6 +91,10 @@
     "UserPromptSubmit": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/user-prompt-submit/enforce-tdd.sh"
+          },
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/user-prompt-submit/enforce-task-first.sh"

--- a/crew/scripts/hooks/pre-tool/enforce-tdd.sh
+++ b/crew/scripts/hooks/pre-tool/enforce-tdd.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Enforce TDD workflow before ANY code modification
+# Triggered on PreToolUse for Edit, MultiEdit, Write operations
+#
+# This is the universal TDD enforcement point - no code changes without tests.
+
+set +e
+
+# Read tool input from stdin
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)
+
+# Only process file modification tools
+if [[ ! "$TOOL_NAME" =~ ^(Edit|MultiEdit|Write)$ ]]; then
+	exit 0
+fi
+
+# Skip if no file path
+if [[ -z $FILE_PATH ]]; then
+	exit 0
+fi
+
+# Extract filename and extension
+FILENAME=$(basename "$FILE_PATH")
+EXTENSION="${FILENAME##*.}"
+
+# Check if this is a code file that needs TDD enforcement
+IS_TEST_FILE=false
+
+case "$EXTENSION" in
+ts | tsx | js | jsx | py | rb | go | rs | java | kt | swift | c | cpp | cs)
+	# Code file - continue to check if test
+	;;
+*)
+	# Not a code file - skip TDD enforcement
+	exit 0
+	;;
+esac
+
+# Check if this is a test file (allow test files without TDD warning)
+if echo "$FILE_PATH" | grep -qE '(\.test\.|\.spec\.|_test\.|_spec\.|/tests?/|/__tests__/)'; then
+	IS_TEST_FILE=true
+fi
+
+# Check if this is a fixture, mock, or test utility
+if echo "$FILE_PATH" | grep -qE '(fixtures?/|mocks?/|__mocks__|test-utils|test-helpers|\.mock\.|\.fixture\.)'; then
+	IS_TEST_FILE=true
+fi
+
+# If it's a test file, allow it - this is the RED phase
+if [[ $IS_TEST_FILE == true ]]; then
+	exit 0
+fi
+
+# For implementation files, enforce TDD
+cat <<'EOF'
+
+<tdd-enforcement>
+## TDD Required: Test First
+
+You are about to modify **implementation code**. TDD discipline requires:
+
+### RED-GREEN-REFACTOR Cycle
+
+1. **RED** - Write a failing test FIRST
+   - The test MUST fail before you write implementation
+   - Run tests to confirm failure: `bun run test` or `vitest run`
+
+2. **GREEN** - Write minimal code to pass
+   - Only enough code to make the test pass
+   - No extra functionality
+
+3. **REFACTOR** - Improve while keeping tests green
+   - Clean up, optimize, clarify
+   - Tests must still pass
+
+### Before This Edit
+
+**Ask yourself:**
+- Have I written a failing test for this functionality?
+- Did I run the tests and confirm they fail?
+- Am I writing the minimum code to pass?
+
+### Load the TDD Skill
+
+```javascript
+Skill({ skill: "devtools:tdd-typescript" })
+```
+
+**If you haven't written a failing test first, STOP and write the test now.**
+
+Coverage Requirements:
+- Line coverage: 80% minimum
+- Branch coverage: 75% minimum
+- Function coverage: 90% minimum
+- Critical paths: 100% mandatory
+
+</tdd-enforcement>
+
+EOF

--- a/crew/scripts/hooks/session-start/inject-skills.sh
+++ b/crew/scripts/hooks/session-start/inject-skills.sh
@@ -33,9 +33,19 @@ cat <<'EOF'
 | `/crew:git:branch:new` | Create feature branch |
 | `/crew:git:sync` | Sync branch with main |
 
+### TDD ENFORCEMENT (MANDATORY)
+**ALL code changes require Test-Driven Development:**
+1. Load skill: `Skill({ skill: "devtools:tdd-typescript" })`
+2. Write failing test FIRST (RED)
+3. Write minimal code to pass (GREEN)
+4. Refactor while green (REFACTOR)
+
+Coverage: 80% lines, 75% branches, 90% functions, 100% critical paths
+
 ### Skills - Crew Plugin (auto-loaded by triggers)
 | Skill | Triggers | Purpose |
 |-------|----------|---------|
+| tdd-enforcement | implement, add, create, fix | Universal TDD enforcement |
 | ast-grep | rename, replace, refactor, imports | AST-aware code search & refactor |
 | git | commit, branch, pr | Git conventions and workflows |
 | skill-builder | skill, create skill | Skill creation framework |

--- a/crew/scripts/hooks/user-prompt-submit/enforce-tdd.sh
+++ b/crew/scripts/hooks/user-prompt-submit/enforce-tdd.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Enforce TDD workflow for ANY code-related request
+# Broader pattern matching than devtools - catches all implementation scenarios
+#
+# This fires on UserPromptSubmit to prime the session for TDD before any work.
+
+set +e
+
+# Read user message from stdin
+INPUT=$(cat)
+USER_MESSAGE=$(echo "$INPUT" | jq -r '.content // ""' 2>/dev/null)
+
+# Skip empty messages
+if [[ -z $USER_MESSAGE ]]; then
+	exit 0
+fi
+
+# Skip very short messages (likely steering)
+if [[ ${#USER_MESSAGE} -lt 15 ]]; then
+	exit 0
+fi
+
+# Convert to lowercase for pattern matching
+MSG_LOWER=$(echo "$USER_MESSAGE" | tr '[:upper:]' '[:lower:]')
+
+# Skip questions and explanations (not code requests)
+if echo "$MSG_LOWER" | grep -qE '^(what|how|why|where|when|explain|show|describe|list|find|search|read|check)'; then
+	exit 0
+fi
+
+# Skip slash commands - they have their own workflows
+if echo "$USER_MESSAGE" | grep -qE '^/'; then
+	exit 0
+fi
+
+# Skip purely git/commit/pr operations
+if echo "$MSG_LOWER" | grep -qE '^(commit|push|pull|merge|rebase|checkout|branch|pr|git|revert)'; then
+	exit 0
+fi
+
+# Comprehensive code change patterns - much broader than devtools
+CODE_PATTERNS='(implement|add|create|build|make|write|develop|introduce|fix|bug|broken|error|change|update|modify|refactor|improve|enhance|optimize|rewrite|restructure|extend|new|feature|function|class|method|component|endpoint|api|service|handler|controller|model|view|route|hook|util|helper|module|package|library)'
+
+# Check if this looks like a code change request
+if ! echo "$MSG_LOWER" | grep -qE "$CODE_PATTERNS"; then
+	exit 0
+fi
+
+# Skip if message is clearly about reviewing/reading code only
+if echo "$MSG_LOWER" | grep -qE '^(review|look at|examine|analyze|audit|inspect|check)' && ! echo "$MSG_LOWER" | grep -qE '(and fix|and change|and update|then)'; then
+	exit 0
+fi
+
+# Output TDD enforcement guidance
+cat <<'EOF'
+
+<tdd-enforcement-required>
+
+## TDD Workflow Required
+
+This appears to involve code changes. **Test-Driven Development (TDD) is mandatory.**
+
+### The Three Laws of TDD
+
+1. **Write NO production code** until a failing test exists
+2. **Write ONLY enough test** to demonstrate failure
+3. **Write ONLY enough code** to pass the test
+
+### Before ANY Code Change
+
+```javascript
+// Load the TDD skill FIRST
+Skill({ skill: "devtools:tdd-typescript" })
+```
+
+### RED-GREEN-REFACTOR Cycle
+
+| Phase | Action | Verification |
+|-------|--------|--------------|
+| RED | Write failing test | `bun run test` - must FAIL |
+| GREEN | Write minimal code | `bun run test` - must PASS |
+| REFACTOR | Improve code | `bun run test` - still PASS |
+
+### Coverage Requirements (Non-Negotiable)
+
+- Line coverage: **80% minimum**
+- Branch coverage: **75% minimum**
+- Function coverage: **90% minimum**
+- Critical paths (auth, payments, permissions): **100%**
+
+### Workflow
+
+1. **Understand** - Read existing code, understand context
+2. **Test First** - Write a failing test for the desired behavior
+3. **Run Tests** - Confirm the test fails (RED phase)
+4. **Implement** - Write minimum code to pass
+5. **Run Tests** - Confirm tests pass (GREEN phase)
+6. **Refactor** - Clean up while keeping tests green
+7. **Verify** - Run full test suite, check coverage
+
+**NO EXCEPTIONS. Tests first, always.**
+
+</tdd-enforcement-required>
+
+EOF

--- a/crew/skills/tdd-enforcement/SKILL.md
+++ b/crew/skills/tdd-enforcement/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: tdd-enforcement
+description: Universal TDD enforcement for all code changes. Wraps devtools:tdd-typescript with crew-specific enforcement patterns.
+triggers:
+  - "implement"
+  - "add"
+  - "create"
+  - "build"
+  - "make"
+  - "write"
+  - "develop"
+  - "fix"
+  - "change"
+  - "update"
+  - "modify"
+  - "refactor"
+  - "new.*feature"
+  - "new.*function"
+  - "new.*component"
+  - "new.*endpoint"
+alwaysApply: true
+---
+
+<objective>
+Enforce Test-Driven Development (TDD) for ALL code changes in the crew workflow. This skill wraps `devtools:tdd-typescript` and ensures no implementation code is written without failing tests first. Applies universally - whether from commands, direct requests, or any other context.
+</objective>
+
+<essential_principles>
+
+**TDD is Non-Negotiable**
+
+Every code change follows this sequence:
+
+1. **TEST FIRST** - Write the test before ANY implementation
+2. **FAIL FIRST** - Run tests, confirm they FAIL (RED phase)
+3. **PASS MINIMAL** - Write minimum code to pass (GREEN phase)
+4. **REFACTOR SAFELY** - Improve while keeping tests green
+
+**The Three Laws of TDD**
+
+1. Write NO production code until a failing test exists
+2. Write ONLY enough test to demonstrate failure
+3. Write ONLY enough code to pass the test
+
+**Coverage Requirements (Non-Negotiable)**
+
+| Metric            | Minimum | Critical Paths |
+| ----------------- | ------- | -------------- |
+| Line coverage     | 80%     | 100%           |
+| Branch coverage   | 75%     | 100%           |
+| Function coverage | 90%     | 100%           |
+
+Critical paths include: authentication, authorization, payments, data persistence.
+
+</essential_principles>
+
+<quick_start>
+
+**For ANY code change, immediately load the full TDD workflow:**
+
+```javascript
+Skill({ skill: "devtools:tdd-typescript" });
+```
+
+Then follow the complete RED-GREEN-REFACTOR cycle defined there.
+
+**Enforcement Points in Crew**
+
+1. **UserPromptSubmit Hook** - Fires on any code-related request
+2. **PreToolUse Hook** - Fires before Edit/MultiEdit/Write
+3. **crew:work Command** - Mandates TDD skill at Step 0
+4. **Ralph Loop** - Requires TDD skill at each iteration
+
+**No Escape Routes**
+
+- Direct code requests → TDD enforced via hooks
+- Commands → TDD enforced in workflow
+- Agent tasks → TDD enforced via skill requirements
+- Manual edits → TDD enforced via PreToolUse hook
+
+</quick_start>
+
+<workflow>
+
+## Universal TDD Workflow
+
+### 1. Understand Before Testing
+
+Read existing code to understand:
+
+- Current behavior
+- API contracts
+- Edge cases to cover
+
+### 2. Write Failing Test (RED)
+
+```bash
+# Create test file if needed
+touch src/__tests__/feature.test.ts
+
+# Write test for desired behavior
+# Test should describe WHAT, not HOW
+```
+
+### 3. Verify Test Fails
+
+```bash
+bun run test
+# OR
+vitest run
+```
+
+**The test MUST fail.** If it passes:
+
+- Feature already exists, or
+- Test is wrong
+
+### 4. Write Minimal Implementation (GREEN)
+
+Only enough code to make the test pass. No more.
+
+```bash
+# After implementation
+bun run test
+# Must pass
+```
+
+### 5. Refactor (REFACTOR)
+
+Improve code quality while keeping tests green:
+
+- Extract methods
+- Rename for clarity
+- Remove duplication
+- Improve performance
+
+```bash
+# After refactoring
+bun run test
+# Must still pass
+```
+
+### 6. Check Coverage
+
+```bash
+bun run test --coverage
+```
+
+Verify coverage requirements are met.
+
+</workflow>
+
+<integration>
+
+**Works With:**
+
+- `devtools:tdd-typescript` - Full TDD workflow and phase gates
+- `devtools:vitest` - Test syntax and assertions
+- `crew:work` - Execution workflow with TDD mandatory
+- `crew:work:ci` - CI checks for test failures
+- `crew:work:review` - Quality review includes test coverage
+
+**Command Integration:**
+
+All crew commands that touch code reference this skill or `devtools:tdd-typescript`:
+
+| Command          | TDD Integration                |
+| ---------------- | ------------------------------ |
+| crew:work        | Step 0: Mandatory skill load   |
+| crew:plan        | No code allowed, TDD N/A       |
+| crew:work:review | Coverage in quality criteria   |
+| crew:work:ci     | Test failures block completion |
+
+</integration>
+
+<success_criteria>
+
+TDD enforcement is successful when:
+
+- [ ] Test written BEFORE any implementation code
+- [ ] Test verified to FAIL before implementation
+- [ ] Minimal code written to pass test
+- [ ] Tests pass after implementation
+- [ ] Refactoring keeps tests green
+- [ ] Coverage meets requirements (80%+ lines, 75%+ branches, 90%+ functions)
+- [ ] Critical paths have 100% coverage
+- [ ] No untested code in production
+
+</success_criteria>


### PR DESCRIPTION
## Summary

- Add **PreToolUse hook** that fires on Edit/MultiEdit/Write for all code files, enforcing TDD before any implementation change
- Add **UserPromptSubmit hook** with comprehensive keyword matching to catch all code-related requests
- Create **crew:tdd-enforcement skill** with `alwaysApply: true` for universal TDD guidance
- Update **CLAUDE.md** with mandatory TDD section at top level
- Update **session start banner** with prominent TDD enforcement reminder

## Motivation

TDD was optional or only triggered by specific keywords. Code could be written without tests first by:
- Using different wording in requests
- Bypassing commands that enforce TDD
- Direct Edit/Write calls without loading TDD skill

This PR ensures **no escape routes** - TDD is enforced at:
- Hook level (PreToolUse on code files)
- User prompt level (UserPromptSubmit on code keywords)
- Command level (crew:work Step 0)
- Project level (CLAUDE.md instructions)

## Changes

| File | Change |
|------|--------|
| `crew/scripts/hooks/pre-tool/enforce-tdd.sh` | New hook - fires on Edit/MultiEdit/Write |
| `crew/scripts/hooks/user-prompt-submit/enforce-tdd.sh` | New hook - broad keyword matching |
| `crew/skills/tdd-enforcement/SKILL.md` | New skill with alwaysApply trigger |
| `crew/hooks/hooks.json` | Register new hooks |
| `CLAUDE.md` | Add mandatory TDD section |
| `crew/scripts/hooks/session-start/inject-skills.sh` | Add TDD enforcement banner |
| `crew/.claude-plugin/plugin.json` | Version 3.0.2 → 3.1.0 |

## Test Plan

- [ ] Start new session → TDD banner visible
- [ ] Request "implement X" → TDD guidance appears
- [ ] Edit code file → PreToolUse TDD reminder fires
- [ ] Edit test file → No TDD warning (allows RED phase)
- [ ] Run `/crew:work` → TDD skill loaded in Step 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make TDD mandatory for all code changes via universal hooks and an always-on crew skill. Users get TDD guidance before implementation edits and on code-related prompts.

- **New Features**
  - PreToolUse hook on Edit/MultiEdit/Write for code files; test/mocks are exempt.
  - UserPromptSubmit hook catches broad code requests and shows TDD rules.
  - New tdd-enforcement skill with alwaysApply; wraps devtools:tdd-typescript.
  - CLAUDE.md gains a mandatory TDD section.
  - Session start banner highlights TDD steps.
  - hooks.json updated; plugin version bumped to 3.1.0.

- **Migration**
  - Expect TDD reminders before changing implementation code.
  - Write a failing test first (RED), then minimal code (GREEN), then refactor.
  - Load Skill({ skill: "devtools:tdd-typescript" }) at the start of work.
  - Maintain required coverage, including 100% on critical paths.

<sup>Written for commit 9cf4010c87017e1b10e797773fef7da02b235cea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

