### PR TITLE
fix(crew:git:pr:fix-reviews): use pre-fetched data from dynamic commands

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /crew:plan, /crew:work commands with parallel agent execution.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/git/pr/fix-reviews.md
+++ b/crew/commands/git/pr/fix-reviews.md
@@ -30,11 +30,24 @@ Fix PR comments and CI failures, resolve threads, update PR. Max 3 CI iterations
 
 </objective>
 
+<data_usage>
+
+**CRITICAL: The sections above (`<pr_info>`, `<unresolved_threads>`, `<ci_status>`) contain ALREADY-FETCHED data.**
+
+- Parse the text content directly from these sections
+- DO NOT run `gh pr view`, `gh api graphql`, or any other fetch commands
+- The thread IDs (PRRT_xxx) are extracted from the `<unresolved_threads>` section
+- If a section shows "No PR found" or "No unresolved threads", that IS the result
+
+</data_usage>
+
 <workflow>
 
-## Step 1: Validate PR
+## Step 1: Parse Pre-Fetched Data
 
-If no PR found → ask user to create or specify PR number.
+Read the `<pr_info>`, `<unresolved_threads>`, and `<ci_status>` sections above. These are already populated with current data.
+
+If `<pr_info>` shows "No PR found" → ask user to create or specify PR number.
 
 ## Step 2: Create Todo List
 


### PR DESCRIPTION
## Summary

The `/crew:git:pr:fix-reviews` command uses dynamic `!` commands to pre-fetch PR data via scripts, but the workflow never told Claude to use that data. Instead, Claude attempted to re-fetch using incorrect API queries, causing failures.

## Root cause

The command file has `<pr_info>`, `<unresolved_threads>`, and `<ci_status>` sections that are populated at runtime via scripts like `gh-pr-threads.sh` (which use the GraphQL API). However, the workflow instructions never explicitly instructed Claude to parse this pre-fetched data. Without clear guidance, Claude followed the workflow steps literally and attempted its own data fetches, using incorrect `gh pr view --json` commands that don't support `reviewThreads` field.

## The fix

Added a new `<data_usage>` section with explicit, unambiguous instructions:
- Parse data directly from the pre-populated sections
- DO NOT run any fetch commands
- Extract thread IDs from the already-present data

Updated Step 1 from "Validate PR" to "Parse Pre-Fetched Data" to reinforce this intent.

## Why this approach

This is the minimal change needed to fix the issue without modifying the scripts or data fetching logic (which is already correct). The instructions explicitly tell Claude what to do, eliminating the ambiguity that led to re-fetching attempts.

## How to verify

Before this fix: Running `/crew:git:pr:fix-reviews` on a PR with unresolved threads would fail with "Unknown JSON field: reviewThreads".

After this fix: The command correctly parses the pre-fetched thread data and proceeds with resolution steps.

## Risk assessment

**Low risk.** This is a documentation/instruction change only. The scripts and data fetching logic remain unchanged. Only the interpretation of how to use the data changes.

## Checklist

- [x] Fixed the root cause (ambiguous workflow instructions)
- [x] No changes to data fetching scripts
- [x] Checked related commands (`update.md`, `sync.md`) - they use standard REST API fields so less vulnerable
- [x] Updated version in plugin.json for tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes /crew:git:pr:fix-reviews by using pre-fetched PR data instead of re-fetching. Prevents failures from invalid gh queries and correctly parses unresolved review threads.

- **Bug Fixes**
  - Added <data_usage> with clear instructions to parse <pr_info>, <unresolved_threads>, and <ci_status> and not run fetch commands.
  - Renamed Step 1 to "Parse Pre-Fetched Data" to match behavior.
  - Leaves scripts and data fetching unchanged; resolves "Unknown JSON field: reviewThreads" error.
  - Bumped plugin version to 3.1.1.

<sup>Written for commit f164f63a359c0d3bdc573f7737e4067349437f02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

