### PR TITLE
feat(crew:git): add haiku model to all git commands for speed and cost

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /crew:plan, /crew:work commands with parallel agent execution.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/git/branch/create.md
+++ b/crew/commands/git/branch/create.md
@@ -1,6 +1,7 @@
 ---
 name: crew:git:branch:create
 description: Create a feature branch
+model: haiku
 allowed-tools:
   - Skill
 ---

--- a/crew/commands/git/branch/new.md
+++ b/crew/commands/git/branch/new.md
@@ -2,6 +2,7 @@
 name: crew:git:branch:new
 description: Create a new branch with username prefix naming convention
 argument-hint: "[description] [--type feat|fix|hotfix|chore] [--base main|current]"
+model: haiku
 allowed-tools:
   - Bash
   - AskUserQuestion

--- a/crew/commands/git/clean.md
+++ b/crew/commands/git/clean.md
@@ -1,6 +1,7 @@
 ---
 name: crew:git:clean
 description: Clean up stale branches (deleted on remote)
+model: haiku
 allowed-tools:
   - Bash
 context: fork

--- a/crew/commands/git/commit-and-push.md
+++ b/crew/commands/git/commit-and-push.md
@@ -2,6 +2,7 @@
 name: crew:git:commit-and-push
 description: Create a conventional commit and push to origin
 argument-hint: "[commit message]"
+model: haiku
 allowed-tools:
   - Skill
 ---

--- a/crew/commands/git/commit.md
+++ b/crew/commands/git/commit.md
@@ -2,6 +2,7 @@
 name: crew:git:commit
 description: Create a conventional commit
 argument-hint: "[commit message]"
+model: haiku
 allowed-tools:
   - Bash
 ---

--- a/crew/commands/git/pr/create.md
+++ b/crew/commands/git/pr/create.md
@@ -1,6 +1,7 @@
 ---
 name: crew:git:pr:create
 description: Commit, push, and open a PR
+model: haiku
 allowed-tools:
   - Bash
   - AskUserQuestion
@@ -69,12 +70,23 @@ AskUserQuestion({
 
 ## Step 4: Generate PR Body
 
-Select template based on commit type:
+Select and read template based on commit type:
 
-- `feat` → `skills/git/templates/pr-feature.md`
-- `fix` → `skills/git/templates/pr-fix.md`
-- `refactor/docs/test` → `skills/git/templates/pr-refactor.md`
-- Other → `skills/git/templates/pr-default.md`
+```javascript
+// Determine template based on primary commit type
+const templateMap = {
+  feat: "pr-feature.md",
+  fix: "pr-fix.md",
+  refactor: "pr-refactor.md",
+  docs: "pr-refactor.md",
+  test: "pr-refactor.md",
+  chore: "pr-refactor.md",
+};
+const template = templateMap[commitType] || "pr-default.md";
+Read({
+  file_path: `${CLAUDE_PLUGIN_ROOT}/skills/git/templates/${template}`,
+});
+```
 
 Check for plan file: `ls .claude/plans/*.md 2>/dev/null`
 If exists, extract motivation and design decisions.

--- a/crew/commands/git/pr/update.md
+++ b/crew/commands/git/pr/update.md
@@ -2,6 +2,7 @@
 name: crew:git:pr:update
 description: Update PR title and body
 argument-hint: "[PR number, defaults to current branch PR]"
+model: haiku
 allowed-tools:
   - Bash
 ---
@@ -38,7 +39,25 @@ ls .claude/plans/*.md 2>/dev/null
 
 ## Step 4: Generate Body
 
-Select template based on commit type. Sources:
+Select and read template based on commit type:
+
+```javascript
+// Determine template based on primary commit type
+const templateMap = {
+  feat: "pr-feature.md",
+  fix: "pr-fix.md",
+  refactor: "pr-refactor.md",
+  docs: "pr-refactor.md",
+  test: "pr-refactor.md",
+  chore: "pr-refactor.md",
+};
+const template = templateMap[commitType] || "pr-default.md";
+Read({
+  file_path: `${CLAUDE_PLUGIN_ROOT}/skills/git/templates/${template}`,
+});
+```
+
+Sources:
 
 - **Summary**: From commit messages
 - **Why**: From plan file or commit bodies

--- a/crew/commands/git/push.md
+++ b/crew/commands/git/push.md
@@ -2,6 +2,7 @@
 name: crew:git:push
 description: Push current branch to origin
 argument-hint: "[branch name]"
+model: haiku
 allowed-tools:
   - Bash
   - Skill

--- a/crew/commands/git/sync.md
+++ b/crew/commands/git/sync.md
@@ -1,6 +1,7 @@
 ---
 name: crew:git:sync
 description: Sync current branch with main
+model: haiku
 allowed-tools:
   - Bash
   - Skill

--- a/crew/commands/git/undo.md
+++ b/crew/commands/git/undo.md
@@ -1,6 +1,7 @@
 ---
 name: crew:git:undo
 description: Undo last commit (keeps changes staged)
+model: haiku
 allowed-tools:
   - Bash
 ---


### PR DESCRIPTION
## Summary

Configures all git commands in the crew plugin to use haiku model by default, reducing latency and API costs for routine git operations. Also fixes PR template paths to use `${CLAUDE_PLUGIN_ROOT}` for proper resolution.

## Why

Git operations like commit, push, sync, and branch creation are straightforward tasks that don't require the full reasoning capabilities of larger models. Using haiku for these operations significantly reduces response time and costs while maintaining quality.

## Design decisions

- **Model at command level**: Added `model: haiku` to command frontmatter rather than individual Task calls, giving consistent behavior across each command
- **Excluded fix-reviews**: This command stays with the default model because it involves complex multi-file fixes, code quality reviews, and PR comment resolution that benefit from stronger reasoning
- **Template path fix**: Updated `pr/create.md` and `pr/update.md` to use `${CLAUDE_PLUGIN_ROOT}/skills/git/templates/` for proper template resolution

## What changed

- Added `model: haiku` to 10 git commands:
  - `commit.md`, `commit-and-push.md`, `push.md`, `sync.md`, `undo.md`, `clean.md`
  - `branch/create.md`, `branch/new.md`
  - `pr/create.md`, `pr/update.md`
- Fixed PR template paths in `pr/create.md` and `pr/update.md`
- Version bump: 3.7.0 → 3.8.0

## How to test

1. Run any git command (e.g., `/crew:git:commit`) and verify it uses haiku
2. Run `/crew:git:pr:fix-reviews` and verify it still uses the default model
3. Create a PR and verify templates are loaded correctly

## Checklist

- [x] Self-reviewed the diff
- [x] No console.log or debug code left behind

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted routine git commands to the haiku model for faster, cheaper runs. Also fixed PR template path resolution so PR create/update load the correct templates.

- **Refactors**
  - Set model: haiku in frontmatter for commit, commit-and-push, push, sync, undo, clean, branch create/new, and PR create/update.
  - Kept fix-reviews on the default model for complex multi-file work.
  - Bumped plugin version to 3.8.0.

- **Bug Fixes**
  - PR templates now resolve via ${CLAUDE_PLUGIN_ROOT}/skills/git/templates in pr/create.md and pr/update.md.

<sup>Written for commit bcf3d1943fe99d9d856a72cffa69e1ac92b59990. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

