### PR TITLE
feat(crew): upgrade Explore agent from haiku to opus

### DIFF
--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /crew:plan, /crew:work commands with parallel agent execution.",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/plan.md
+++ b/crew/commands/plan.md
@@ -108,12 +108,12 @@ githubSearchPullRequests(owner, repo, keywords)
 
 ### Agent Selection
 
-| Task Type              | Model   | Agent Type        |
-| ---------------------- | ------- | ----------------- |
-| Find files/patterns    | `haiku` | `Explore`         |
-| Read documentation     | `haiku` | `Explore`         |
-| Analyze patterns       | `opus`  | `general-purpose` |
-| Architecture decisions | `opus`  | `general-purpose` |
+| Task Type              | Model  | Agent Type        |
+| ---------------------- | ------ | ----------------- |
+| Find files/patterns    | `opus` | `Explore`         |
+| Read documentation     | `opus` | `Explore`         |
+| Analyze patterns       | `opus` | `general-purpose` |
+| Architecture decisions | `opus` | `general-purpose` |
 
 ### Worker Preamble (REQUIRED)
 

--- a/crew/commands/work.md
+++ b/crew/commands/work.md
@@ -157,7 +157,7 @@ mcp__plugin_crew_codex__codex({
 
 ## Phase 1: Setup
 
-Spawn a haiku worker to:
+Spawn an opus worker to:
 
 1. Verify not on main branch
 2. Read the plan file and return story list
@@ -165,7 +165,7 @@ Spawn a haiku worker to:
 ```javascript
 Task({
   subagent_type: "Explore",
-  model: "haiku",
+  model: "opus",
   description: "Load plan",
   prompt: `WORKER TASK: Read plan and return stories.
 
@@ -203,13 +203,13 @@ Use patterns from `n-skills:orchestration`:
 
 ### Agent/Model Selection
 
-| Task Complexity        | Model   | Agent Type        |
-| ---------------------- | ------- | ----------------- |
-| Single file, simple    | `opus`  | `general-purpose` |
-| Multi-file, moderate   | `opus`  | `general-purpose` |
-| Security-critical      | `opus`  | `general-purpose` |
-| Architecture decisions | `opus`  | `Plan`            |
-| Exploration/research   | `haiku` | `Explore`         |
+| Task Complexity        | Model  | Agent Type        |
+| ---------------------- | ------ | ----------------- |
+| Single file, simple    | `opus` | `general-purpose` |
+| Multi-file, moderate   | `opus` | `general-purpose` |
+| Security-critical      | `opus` | `general-purpose` |
+| Architecture decisions | `opus` | `Plan`            |
+| Exploration/research   | `opus` | `Explore`         |
 
 ### Execution Loop
 


### PR DESCRIPTION
Upgrade Explore agent model from haiku to opus for improved reasoning quality.

## Changes

- Update plan.md: Explore agent selection now uses opus instead of haiku
- Update work.md: Explore agent selection and code examples updated to opus
- Version bump: crew plugin 3.12.0 → 3.13.0

## Why

Opus provides significantly better reasoning for complex exploration and research tasks, improving the quality of plan and work orchestration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Explore agent from haiku to opus to improve reasoning for exploration and research tasks. Updates docs and bumps the crew plugin to 3.13.0.

- **Refactors**
  - Update agent selection in plan.md and work.md: Explore now uses opus
  - Change example worker config to model: "opus"
  - Bump plugin version 3.12.0 → 3.13.0

<sup>Written for commit fab6a0801d0d72cbaee3eb613de6c8699cb19522. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

