### PR TITLE
feat(devtools): add react-best-practices and vercel-design-guidelines skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,18 @@ Self-contained knowledge modules with:
 - Required tags: `<objective>`, `<quick_start>`, `<success_criteria>`
 - Optional: `<routing>`, `<workflow>`, `<references>`, `<templates>`, `<scripts>`
 
+**Skill Reference Format (MANDATORY):** When referencing skills in documentation, always use the `Skill()` call format:
+
+```javascript
+// Correct - executable format
+Skill({ skill: "devtools:react-best-practices" })
+
+// Wrong - plain text reference
+Load `devtools:react-best-practices`
+```
+
+This ensures skills can be loaded programmatically when users follow the documentation.
+
 ### State Management
 
 - Branch state: `.claude/branches/{branch}/state.json`

--- a/crew/.claude-plugin/plugin.json
+++ b/crew/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crew",
   "description": "Unified orchestration for work execution, skill creation, git conventions, and system management. Provides /crew:plan, /crew:work commands with parallel agent execution.",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/crew/commands/plan.md
+++ b/crew/commands/plan.md
@@ -40,6 +40,9 @@ The orchestration skill defines all patterns. You decide WHICH patterns based on
 - NO implementation work
 - Research and planning ONLY
 - Output limited to `.claude/plans/<slug>.yaml`
+- This codebase will outlive you. Every shortcut becomes someone else's burden. Every hack compounds into technical debt that slows the whole team down.
+- You are not just writing code. You are shaping the future of this project. The patterns you establish will be copied. The corners you cut will be cut again.
+- Fight entropy. Leave the codebase better than you found it.
 
 </constraints>
 
@@ -127,6 +130,53 @@ RULES:
 - Use tools directly (Read, Glob, Grep, WebFetch, MCPSearch, etc.)
 - Do NOT spawn sub-agents or manage tasks
 - Report findings with absolute file paths
+
+SKILL LOADING (MANDATORY):
+Before starting work, load relevant skills using Skill() tool.
+
+FRONTEND:
+- Skill({ skill: "devtools:react" }) - React 19, Tailwind v4, shadcn/ui
+- Skill({ skill: "devtools:react-best-practices" }) - Performance, bundle size, waterfalls
+- Skill({ skill: "devtools:shadcn" }) - shadcn/ui components, MCP integration
+- Skill({ skill: "devtools:radix" }) - Radix UI accessible primitives
+- Skill({ skill: "devtools:motion" }) - Motion/Framer animations
+- Skill({ skill: "devtools:tanstack-start" }) - TanStack Start full-stack framework
+- Skill({ skill: "devtools:recharts" }) - React data visualization
+- Skill({ skill: "devtools:i18n" }) - i18next internationalization
+
+DESIGN:
+- Skill({ skill: "devtools:design-principles" }) - Linear/Notion/Stripe design system
+- Skill({ skill: "devtools:vercel-design-guidelines" }) - UI/UX audit, accessibility
+
+TESTING:
+- Skill({ skill: "devtools:vitest" }) - Unit testing, mocking, coverage
+- Skill({ skill: "devtools:playwright" }) - E2E testing, Page Object pattern
+- Skill({ skill: "devtools:tdd-typescript" }) - TDD RED-GREEN-REFACTOR cycle
+
+BACKEND/API:
+- Skill({ skill: "devtools:api" }) - oRPC API routes, 5-file pattern
+- Skill({ skill: "devtools:drizzle" }) - PostgreSQL ORM, migrations, Zod
+- Skill({ skill: "devtools:restate" }) - Durable execution, workflows
+- Skill({ skill: "devtools:pino" }) - Fast JSON logging
+- Skill({ skill: "devtools:better-auth" }) - Authentication patterns
+- Skill({ skill: "devtools:zod" }) - Zod v4 schema validation
+
+BLOCKCHAIN:
+- Skill({ skill: "devtools:solidity" }) - Smart contracts, Foundry
+- Skill({ skill: "devtools:viem" }) - Ethereum client, transactions
+- Skill({ skill: "devtools:thegraph" }) - Subgraph development, Matchstick
+
+DEVOPS/INFRASTRUCTURE:
+- Skill({ skill: "devtools:helm" }) - Kubernetes Helm charts
+- Skill({ skill: "devtools:terraform" }) - Infrastructure as code (READ-ONLY)
+- Skill({ skill: "devtools:turbo" }) - Turborepo monorepo builds
+- Skill({ skill: "devtools:troubleshooting" }) - Structured debugging workflow
+
+CREW SKILLS:
+- Skill({ skill: "crew:ast-grep" }) - Mass rename/replace across codebase
+- Skill({ skill: "crew:git" }) - Git conventions, commits, branches
+- Skill({ skill: "crew:skill-builder" }) - Skill creation framework
+- Skill({ skill: "crew:todo-tracking" }) - File-based task management
 
 LIBRARY VERIFICATION (MANDATORY):
 When researching ANY library/framework, ALWAYS:
@@ -260,6 +310,7 @@ AskUserQuestion({
 
 - [ ] Feature branch created
 - [ ] All research done by background workers
+- [ ] Workers load relevant skills (devtools:react, devtools:drizzle, etc.) BEFORE researching
 - [ ] Valid YAML at `.claude/plans/<slug>.yaml`
 - [ ] Stories with priorities and acceptance criteria
 - [ ] User presented with next step options

--- a/crew/commands/work.md
+++ b/crew/commands/work.md
@@ -41,6 +41,14 @@ The orchestration skill defines all patterns. You decide WHICH patterns based on
 
 </orchestration_role>
 
+<constraints>
+
+- This codebase will outlive you. Every shortcut becomes someone else's burden. Every hack compounds into technical debt that slows the whole team down.
+- You are not just writing code. You are shaping the future of this project. The patterns you establish will be copied. The corners you cut will be cut again.
+- Fight entropy. Leave the codebase better than you found it.
+
+</constraints>
+
 <worker_requirements>
 
 ### TDD Enforcement (For All Workers)
@@ -69,6 +77,69 @@ RULES:
 - Do NOT spawn sub-agents or manage tasks
 - Follow TDD: write failing test FIRST, then implement
 - Report completion with absolute file paths
+
+SKILL LOADING (MANDATORY - load BEFORE starting work):
+Use Skill() tool to load domain-specific knowledge. Skills contain patterns, constraints, and success criteria.
+
+FRONTEND:
+| Domain | Load Skill |
+|--------|------------|
+| React/Next.js | Skill({ skill: "devtools:react" }) |
+| React performance | Skill({ skill: "devtools:react-best-practices" }) |
+| UI components | Skill({ skill: "devtools:shadcn" }) |
+| Radix primitives | Skill({ skill: "devtools:radix" }) |
+| Animations | Skill({ skill: "devtools:motion" }) |
+| TanStack Start | Skill({ skill: "devtools:tanstack-start" }) |
+| Charts | Skill({ skill: "devtools:recharts" }) |
+| i18n | Skill({ skill: "devtools:i18n" }) |
+
+DESIGN:
+| Domain | Load Skill |
+|--------|------------|
+| Design system | Skill({ skill: "devtools:design-principles" }) |
+| UI/UX audit | Skill({ skill: "devtools:vercel-design-guidelines" }) |
+
+TESTING:
+| Domain | Load Skill |
+|--------|------------|
+| Unit tests | Skill({ skill: "devtools:vitest" }) |
+| E2E tests | Skill({ skill: "devtools:playwright" }) |
+| TDD workflow | Skill({ skill: "devtools:tdd-typescript" }) |
+
+BACKEND/API:
+| Domain | Load Skill |
+|--------|------------|
+| API routes | Skill({ skill: "devtools:api" }) |
+| Database | Skill({ skill: "devtools:drizzle" }) |
+| Durable execution | Skill({ skill: "devtools:restate" }) |
+| Logging | Skill({ skill: "devtools:pino" }) |
+| Authentication | Skill({ skill: "devtools:better-auth" }) |
+| Validation | Skill({ skill: "devtools:zod" }) |
+
+BLOCKCHAIN:
+| Domain | Load Skill |
+|--------|------------|
+| Smart contracts | Skill({ skill: "devtools:solidity" }) |
+| Ethereum client | Skill({ skill: "devtools:viem" }) |
+| Subgraphs | Skill({ skill: "devtools:thegraph" }) |
+
+DEVOPS:
+| Domain | Load Skill |
+|--------|------------|
+| Helm charts | Skill({ skill: "devtools:helm" }) |
+| Terraform | Skill({ skill: "devtools:terraform" }) |
+| Monorepo builds | Skill({ skill: "devtools:turbo" }) |
+| Debugging | Skill({ skill: "devtools:troubleshooting" }) |
+
+CREW:
+| Domain | Load Skill |
+|--------|------------|
+| Mass refactoring | Skill({ skill: "crew:ast-grep" }) |
+| Git conventions | Skill({ skill: "crew:git" }) |
+| Skill creation | Skill({ skill: "crew:skill-builder" }) |
+| Task tracking | Skill({ skill: "crew:todo-tracking" }) |
+
+Load relevant skills FIRST based on the task domain.
 
 LIBRARY VERIFICATION (MANDATORY):
 Before using ANY library/framework API, ALWAYS verify current usage:
@@ -315,12 +386,17 @@ Task({
 
 CONTEXT: Implementation complete. Verify architectural consistency.
 
+SKILLS TO LOAD FIRST:
+- Skill({ skill: "devtools:react" }) - for React/component patterns
+- Skill({ skill: "devtools:design-principles" }) - for UI architecture
+
 TOOLS:
 - Use Codex MCP for design analysis
 - MCPSearch to load: mcp__plugin_crew_codex__codex
 
 CHECKLIST:
 - [ ] Follows existing codebase patterns
+- [ ] Follows skill constraints (check <constraints> sections)
 - [ ] Proper separation of concerns
 - [ ] No circular dependencies introduced
 - [ ] Consistent naming conventions
@@ -328,11 +404,45 @@ CHECKLIST:
 - [ ] No premature optimization
 
 PROCESS:
-1. Get changed files: ${changedFiles}
-2. Compare patterns to existing codebase
-3. Use Codex to analyze design decisions
+1. Load relevant skills for the domain
+2. Get changed files: ${changedFiles}
+3. Compare patterns to skill constraints
+4. Use Codex to analyze design decisions
 
 OUTPUT: JSON array of findings with file, pattern_violation, recommendation`,
+  run_in_background: true,
+});
+
+// 2b. UI/UX Review (for frontend changes)
+Task({
+  subagent_type: "general-purpose",
+  model: "opus",
+  description: "UI/UX review",
+  prompt: `WORKER TASK: UI/UX quality review against design guidelines.
+
+CONTEXT: Implementation complete. Check UI quality and accessibility.
+
+SKILLS TO LOAD FIRST (MANDATORY):
+- Skill({ skill: "devtools:vercel-design-guidelines" })
+- Skill({ skill: "devtools:design-principles" })
+
+CHECKLIST (from skills):
+- [ ] Keyboard accessibility (focus management, tab order)
+- [ ] Hit targets ≥24px (44px on mobile)
+- [ ] Loading states don't flicker
+- [ ] prefers-reduced-motion respected
+- [ ] Form labels and error handling
+- [ ] Color contrast meets APCA standards
+- [ ] Spacing on 4px grid
+- [ ] Consistent depth strategy (shadows/borders)
+
+PROCESS:
+1. Load both skills above
+2. Get changed .tsx files: ${changedFiles} | grep -E "\\.(tsx|css)$"
+3. For each UI file, check against skill success_criteria
+4. Run validation scripts from design-principles skill
+
+OUTPUT: JSON array with file, line, category (Interactions/Animations/Layout/etc), severity, issue, fix`,
   run_in_background: true,
 });
 
@@ -345,6 +455,10 @@ Task({
 
 CONTEXT: Implementation complete. Verify test adequacy.
 
+SKILLS TO LOAD FIRST:
+- Skill({ skill: "devtools:vitest" }) - for unit test patterns
+- Skill({ skill: "devtools:playwright" }) - for E2E test patterns
+
 CHECKLIST:
 - [ ] All new functions have tests
 - [ ] Edge cases covered
@@ -352,12 +466,14 @@ CHECKLIST:
 - [ ] Integration points tested
 - [ ] Mocks are appropriate (not over-mocking)
 - [ ] Tests are deterministic
+- [ ] Follows skill test patterns and locator strategies
 
 PROCESS:
-1. Get changed implementation files: ${changedFiles}
-2. Find corresponding test files
-3. Analyze coverage gaps
-4. Check test quality (not just quantity)
+1. Load relevant test skills
+2. Get changed implementation files: ${changedFiles}
+3. Find corresponding test files
+4. Analyze coverage gaps against skill success_criteria
+5. Check test quality (not just quantity)
 
 OUTPUT: JSON array with file, coverage_gap, missing_test_case`,
   run_in_background: true,
@@ -372,6 +488,11 @@ Task({
 
 CONTEXT: Implementation complete. Check quality metrics.
 
+SKILLS TO LOAD FIRST:
+- For React code: Skill({ skill: "devtools:react-best-practices" })
+- For UI components: Skill({ skill: "devtools:vercel-design-guidelines" })
+- For design patterns: Skill({ skill: "devtools:design-principles" })
+
 CHECKLIST:
 - [ ] Cognitive complexity acceptable (<15 per function)
 - [ ] No dead code introduced
@@ -379,11 +500,13 @@ CHECKLIST:
 - [ ] Type safety (no 'any' unless justified)
 - [ ] Error handling complete
 - [ ] Logging appropriate
+- [ ] Follows skill success_criteria for relevant domains
 
 PROCESS:
-1. Get changed files: ${changedFiles}
-2. Analyze each for quality issues
-3. Check for anti-patterns
+1. Load relevant skills based on file types
+2. Get changed files: ${changedFiles}
+3. Analyze each for quality issues against skill constraints
+4. Check for anti-patterns defined in skills
 
 OUTPUT: JSON array with file, line, issue, suggestion`,
   run_in_background: true,
@@ -395,10 +518,11 @@ OUTPUT: JSON array with file, line, issue, suggestion`,
 After all reviewers complete, collect and triage:
 
 ```javascript
-// Wait for all review agents
+// Wait for all review agents (5 reviewers now including UI/UX)
 const results = await Promise.all([
   TaskOutput({ task_id: securityReview.id }),
   TaskOutput({ task_id: architectureReview.id }),
+  TaskOutput({ task_id: uiuxReview.id }),
   TaskOutput({ task_id: testReview.id }),
   TaskOutput({ task_id: qualityReview.id }),
 ]);
@@ -480,9 +604,11 @@ AskUserQuestion({
 <success_criteria>
 
 - [ ] All work done by background workers (orchestrator never uses Read/Write/Edit)
+- [ ] Workers load relevant skills BEFORE starting (devtools:react, devtools:vitest, etc.)
 - [ ] TDD followed (failing tests before implementation)
 - [ ] Code refinement applied (code-simplifier used on changed files)
-- [ ] Multi-domain review completed (security, architecture, tests, quality)
+- [ ] Multi-domain review completed (security, architecture, UI/UX, tests, quality)
+- [ ] UI/UX review uses devtools:vercel-design-guidelines and devtools:design-principles
 - [ ] P1/P2 findings fixed before CI
 - [ ] TodoWrite shows real-time progress
 - [ ] Stories executed in priority order

--- a/crew/scripts/hooks/pre-tool/suggest-skill.sh
+++ b/crew/scripts/hooks/pre-tool/suggest-skill.sh
@@ -5,10 +5,10 @@
 set +e
 
 is_truthy() {
-  case "${1:-}" in
-    1 | true | yes | on) return 0 ;;
-    *) return 1 ;;
-  esac
+	case "${1:-}" in
+	1 | true | yes | on) return 0 ;;
+	*) return 1 ;;
+	esac
 }
 
 QUIET="${CLAUDE_QUIET:-${CREW_QUIET:-}}"
@@ -17,7 +17,7 @@ TIPS_MODE="${CREW_TIPS:-}"
 
 # Allow opt-out for tips
 if is_truthy "$QUIET" || [[ "$TIPS_MODE" =~ ^(0|off|false)$ ]]; then
-  exit 0
+	exit 0
 fi
 
 INPUT=$(cat)
@@ -37,61 +37,66 @@ SUGGESTION=""
 # Optional dedupe per session (default) to save tokens
 MARKER=""
 if is_truthy "$TOKEN_SAVER" || [[ "$TIPS_MODE" != "all" ]]; then
-  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-  BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo '')
-  [[ -z $BRANCH ]] && BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
-  SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
-  BRANCH_DIR="$PROJECT_DIR/.claude/branches/$SAFE_BRANCH"
-  SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
-  MARKER="$BRANCH_DIR/.tips-shown-${SESSION_ID}"
-  [[ -f $MARKER ]] && exit 0
+	PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+	BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo '')
+	[[ -z $BRANCH ]] && BRANCH=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
+	SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
+	BRANCH_DIR="$PROJECT_DIR/.claude/branches/$SAFE_BRANCH"
+	SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
+	MARKER="$BRANCH_DIR/.tips-shown-${SESSION_ID}"
+	[[ -f $MARKER ]] && exit 0
 fi
 
 # Git commit - suggest git skill
 if [[ $CMD_LINE =~ ^git\ commit ]]; then
-  SUGGESTION="Tip: use Skill(skill: \"crew:git:commit\") for guided commits."
+	SUGGESTION="Tip: use Skill(skill: \"crew:git:commit\") for guided commits."
 fi
 
 # Direct test/lint commands - suggest /crew:work:ci
 if [[ $CMD_LINE =~ (npm|bun|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(test|lint|format|typecheck)([[:space:]]|$) ]] ||
-  [[ $CMD_LINE =~ ^[[:space:]]*(vitest|jest|biome|eslint|prettier|tsc)[[:space:]] ]]; then
-  SUGGESTION="Tip: use Skill(skill: \"crew:work:ci\") to run CI in background."
+	[[ $CMD_LINE =~ ^[[:space:]]*(vitest|jest|biome|eslint|prettier|tsc)[[:space:]] ]]; then
+	SUGGESTION="Tip: use Skill(skill: \"crew:work:ci\") to run CI in background."
 fi
 
 # Git push - remind about CI
 if [[ $CMD_LINE =~ ^git\ push ]]; then
-  SUGGESTION="Tip: run Skill(skill: \"crew:work:ci\") before push."
+	SUGGESTION="Tip: run Skill(skill: \"crew:work:ci\") before push."
 fi
 
 # Sed/grep patterns that look like code refactoring - suggest ast-grep
 # Patterns: sed with s/ replacement, for loops with sed/grep, grep -l piped to xargs
 if [[ $CMD_LINE =~ sed[[:space:]]+-i?[[:space:]]*[\'\"]?s/ ]] ||
-  [[ $CMD_LINE =~ for[[:space:]]+.*in.*\$\(.*grep ]] ||
-  [[ $CMD_LINE =~ grep[[:space:]]+-[lr].*\|.*sed ]] ||
-  [[ $CMD_LINE =~ grep[[:space:]]+-[lr].*\|.*xargs ]] ||
-  [[ $COMMAND =~ import.*from ]] && [[ $CMD_LINE =~ sed ]]; then
-  SUGGESTION="Tip: use Skill(skill: \"crew:ast-grep\") for syntax-aware refactors."
+	[[ $CMD_LINE =~ for[[:space:]]+.*in.*\$\(.*grep ]] ||
+	[[ $CMD_LINE =~ grep[[:space:]]+-[lr].*\|.*sed ]] ||
+	[[ $CMD_LINE =~ grep[[:space:]]+-[lr].*\|.*xargs ]] ||
+	[[ $COMMAND =~ import.*from ]] && [[ $CMD_LINE =~ sed ]]; then
+	SUGGESTION="Tip: use Skill(skill: \"crew:ast-grep\") for syntax-aware refactors."
 fi
 
 # Package installation - suggest Context7 for docs
 if [[ $CMD_LINE =~ (npm|bun|pnpm|yarn)[[:space:]]+(install|add|i)[[:space:]] ]]; then
-  SUGGESTION="Tip: use MCPSearch({ query: \"select:mcp__plugin_crew_context7__query-docs\" }) to verify library APIs."
+	SUGGESTION="Tip: use MCPSearch({ query: \"select:mcp__plugin_crew_context7__query-docs\" }) to verify library APIs."
 fi
 
 # Package.json reading - suggest checking docs
 if [[ $CMD_LINE =~ cat.*package\.json ]] || [[ $CMD_LINE =~ jq.*package\.json ]]; then
-  SUGGESTION="Tip: use Context7 MCP to verify library APIs are current."
+	SUGGESTION="Tip: use Context7 MCP to verify library APIs are current."
+fi
+
+# Next.js builds - suggest react-best-practices for performance
+if [[ $CMD_LINE =~ next\ (build|dev|start) ]]; then
+	SUGGESTION="Tip: check devtools:react-best-practices for React/Next.js performance patterns."
 fi
 
 # Output suggestion if we have one
 if [[ -n $SUGGESTION ]]; then
-  # Mark as shown for this session (token saver)
-  if [[ -n $MARKER ]]; then
-    mkdir -p "$(dirname "$MARKER")" 2>/dev/null
-    touch "$MARKER" 2>/dev/null
-  fi
-  # Use jq to properly escape the suggestion for JSON
-  jq -n --arg msg "$SUGGESTION" '{
+	# Mark as shown for this session (token saver)
+	if [[ -n $MARKER ]]; then
+		mkdir -p "$(dirname "$MARKER")" 2>/dev/null
+		touch "$MARKER" 2>/dev/null
+	fi
+	# Use jq to properly escape the suggestion for JSON
+	jq -n --arg msg "$SUGGESTION" '{
     "hookSpecificOutput": {
       "hookEventName": "PreToolUse",
       "message": $msg

--- a/devtools/.claude-plugin/plugin.json
+++ b/devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devtools",
   "description": "Modern development tools for React, APIs, blockchain, databases, and testing. MCP-first skills with Context7 integration for up-to-date documentation.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "author": {
     "name": "SettleMint",
     "email": "support@settlemint.com"

--- a/devtools/scripts/hooks/pre-tool/suggest-skill.sh
+++ b/devtools/scripts/hooks/pre-tool/suggest-skill.sh
@@ -6,8 +6,8 @@ set +e
 
 is_truthy() {
 	case "${1:-}" in
-		1|true|yes|on) return 0 ;;
-		*) return 1 ;;
+	1 | true | yes | on) return 0 ;;
+	*) return 1 ;;
 	esac
 }
 
@@ -70,6 +70,16 @@ fi
 # Helm
 if [[ $CMD_LINE =~ helm|kubectl ]]; then
 	SUGGESTION="Tip: check devtools:helm for chart and values.yaml conventions."
+fi
+
+# Next.js - suggest react-best-practices for performance patterns
+if [[ $CMD_LINE =~ next\ (build|dev|start)|npm\ run\ (build|dev)|bun\ run\ (build|dev) ]]; then
+	SUGGESTION="Tip: check devtools:react-best-practices for React/Next.js performance patterns."
+fi
+
+# React component creation - suggest react-best-practices
+if [[ $CMD_LINE =~ create.*component|generate.*component ]]; then
+	SUGGESTION="Tip: check devtools:react-best-practices for optimal component patterns."
 fi
 
 # Output suggestion if we have one

--- a/devtools/skills/design-principles/SKILL.md
+++ b/devtools/skills/design-principles/SKILL.md
@@ -335,6 +335,24 @@ echo "Border-radius variations:" && grep -rhoE "border-radius:\s*[0-9]+px" --inc
 **Note:** These checks validate implementation consistency. The initial design direction choice (warm vs cool, dense vs generous) requires understanding product context - agents should use AskUserQuestion to clarify with the user before implementing.
 </agent_verification>
 
+<related_skills>
+
+**Comprehensive UI audit:** Load via `Skill({ skill: "devtools:vercel-design-guidelines" })` when:
+
+- Auditing against Vercel's official design guidelines
+- Checking accessibility (keyboard, focus, hit targets)
+- Reviewing animations and reduced motion support
+- Validating form design and error handling
+- Checking copywriting and content patterns
+
+**React performance:** Load via `Skill({ skill: "devtools:react-best-practices" })` when:
+
+- Implementing components following performance best practices
+- Optimizing bundle size and loading performance
+- Implementing data fetching patterns
+
+</related_skills>
+
 <success*criteria>
 Every interface should look designed by a team that obsesses over 1-pixel differences. Not stripped — \_crafted*. And designed for its specific context.
 

--- a/devtools/skills/motion/SKILL.md
+++ b/devtools/skills/motion/SKILL.md
@@ -304,6 +304,22 @@ test("modal animation completes", async ({ page }) => {
 **Key principle:** Validate animation correctness through code patterns, state testing, and performance metrics. Reserve "natural feel" judgment for human review, but ensure the implementation is technically sound.
 </agent_verification>
 
+<related_skills>
+
+**Design guidelines:** Load via `Skill({ skill: "devtools:vercel-design-guidelines" })` when:
+
+- Verifying animations respect `prefers-reduced-motion`
+- Checking animation timing and interruptibility
+- Auditing transition patterns against best practices
+
+**Design system:** Load via `Skill({ skill: "devtools:design-principles" })` when:
+
+- Establishing animation timing values (150ms micro, 200-250ms larger)
+- Choosing appropriate easing curves
+- Avoiding spring/bouncy effects in enterprise UI
+
+</related_skills>
+
 <success_criteria>
 
 - [ ] Context7 docs fetched for current API
@@ -312,7 +328,3 @@ test("modal animation completes", async ({ page }) => {
 - [ ] Performance-friendly properties animated
 - [ ] Spring transitions for natural feel
       </success_criteria>
-
-```
-
-```

--- a/devtools/skills/playwright/SKILL.md
+++ b/devtools/skills/playwright/SKILL.md
@@ -146,6 +146,21 @@ npx playwright show-report             # View HTML report
 ```
 </commands>
 
+<related_skills>
+
+**Design guidelines:** Load via `Skill({ skill: "devtools:vercel-design-guidelines" })` when:
+
+- Testing accessibility patterns (keyboard, focus, ARIA)
+- Validating interaction patterns
+- Checking responsive design behavior
+
+**Design system:** Load via `Skill({ skill: "devtools:design-principles" })` when:
+
+- Verifying design consistency across views
+- Testing visual hierarchy and spacing
+
+</related_skills>
+
 <success_criteria>
 
 - [ ] Context7 docs fetched for current API

--- a/devtools/skills/radix/SKILL.md
+++ b/devtools/skills/radix/SKILL.md
@@ -213,6 +213,22 @@ const MyTrigger = forwardRef((props, ref) => (
 - Test with screen readers
   </constraints>
 
+<related_skills>
+
+**Design guidelines:** Load via `Skill({ skill: "devtools:vercel-design-guidelines" })` when:
+
+- Auditing keyboard accessibility and focus management
+- Checking hit targets and loading states
+- Validating form labels and error handling patterns
+
+**Design system:** Load via `Skill({ skill: "devtools:design-principles" })` when:
+
+- Styling Radix components with consistent design tokens
+- Establishing depth strategy (borders vs shadows)
+- Creating isolated control containers
+
+</related_skills>
+
 <success_criteria>
 
 - [ ] Context7 docs fetched for current API

--- a/devtools/skills/react-best-practices/SKILL.md
+++ b/devtools/skills/react-best-practices/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: react-best-practices
+description: React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.
+---
+
+# React Best Practices
+
+## Overview
+
+Performance optimization guide for React and Next.js applications, ordered by impact. Apply these patterns when writing or reviewing code to maximize performance gains.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing new React components or Next.js pages
+- Implementing data fetching (client or server-side)
+- Reviewing code for performance issues
+- Refactoring existing React/Next.js code
+- Optimizing bundle size or load times
+
+## Priority-Ordered Guidelines
+
+Rules are prioritized by impact:
+
+| Priority | Category | Impact |
+|----------|----------|--------|
+| 1 | Eliminating Waterfalls | CRITICAL |
+| 2 | Bundle Size Optimization | CRITICAL |
+| 3 | Server-Side Performance | HIGH |
+| 4 | Client-Side Data Fetching | MEDIUM-HIGH |
+| 5 | Re-render Optimization | MEDIUM |
+| 6 | Rendering Performance | MEDIUM |
+| 7 | JavaScript Performance | LOW-MEDIUM |
+| 8 | Advanced Patterns | LOW |
+
+## Quick Reference
+
+### Critical Patterns (Apply First)
+
+**Eliminate Waterfalls:**
+- Use `Promise.all()` for independent async operations
+- Start promises early, await late
+- Use `better-all` for partial dependencies
+- Use Suspense boundaries to stream content
+
+**Reduce Bundle Size:**
+- Avoid barrel file imports (import directly from source)
+- Use `next/dynamic` for heavy components
+- Defer non-critical third-party libraries
+- Preload based on user intent
+
+### High-Impact Server Patterns
+
+- Use `React.cache()` for per-request deduplication
+- Use LRU cache for cross-request caching
+- Minimize serialization at RSC boundaries
+- Parallelize data fetching with component composition
+
+### Medium-Impact Client Patterns
+
+- Use SWR for automatic request deduplication
+- Defer state reads to usage point
+- Use derived state subscriptions
+- Apply `startTransition` for non-urgent updates
+
+## References
+
+Full documentation with code examples is available in:
+
+- `references/react-performance-guidelines.md` - Complete guide with all patterns
+- `references/rules/` - Individual rule files organized by category
+
+To look up a specific pattern, grep the rules directory:
+```
+grep -l "suspense" references/rules/
+grep -l "barrel" references/rules/
+grep -l "swr" references/rules/
+```
+
+## Rule Categories in `references/rules/`
+
+- `async-*` - Waterfall elimination patterns
+- `bundle-*` - Bundle size optimization
+- `server-*` - Server-side performance
+- `client-*` - Client-side data fetching
+- `rerender-*` - Re-render optimization
+- `rendering-*` - DOM rendering performance
+- `js-*` - JavaScript micro-optimizations
+- `advanced-*` - Advanced patterns

--- a/devtools/skills/react-best-practices/references/react-performance-guidelines.md
+++ b/devtools/skills/react-best-practices/references/react-performance-guidelines.md
@@ -1,0 +1,1573 @@
+# React Performance Guidelines
+
+**Version 0.1.0**  
+Vercel Engineering  
+January 2026
+
+> **Note:**  
+> This document is mainly for agents and LLMs to follow when maintaining,  
+> generating, or refactoring React and Next.js codebases at Vercel. Humans  
+> may also find it useful, but guidance here is optimized for automation  
+> and consistency by AI-assisted workflows.
+
+---
+
+## Abstract
+
+Performance optimization guide for React and Next.js applications, ordered by impact. Rules are prioritized from highest to lowest impact, focusing first on eliminating waterfalls and reducing bundle size for maximum performance gains.
+
+---
+
+## Table of Contents
+
+1. [Eliminating Waterfalls](#1-eliminating-waterfalls) — **CRITICAL**
+   - 1.1 [Defer Await Until Needed](#11)
+   - 1.2 [Dependency-Based Parallelization](#12)
+   - 1.3 [Prevent Waterfall Chains in API Routes](#13)
+   - 1.4 [Promise.all() for Independent Operations](#14)
+   - 1.5 [Strategic Suspense Boundaries](#15)
+2. [Bundle Size Optimization](#2-bundle-size-optimization) — **CRITICAL**
+   - 2.1 [Avoid Barrel File Imports](#21)
+   - 2.2 [Conditional Module Loading](#22)
+   - 2.3 [Defer Non-Critical Third-Party Libraries](#23)
+   - 2.4 [Dynamic Imports for Heavy Components](#24)
+   - 2.5 [Preload Based on User Intent](#25)
+3. [Server-Side Performance](#3-server-side-performance) — **HIGH**
+   - 3.1 [Cross-Request LRU Caching](#31)
+   - 3.2 [Minimize Serialization at RSC Boundaries](#32)
+   - 3.3 [Parallel Data Fetching with Component Composition](#33)
+   - 3.4 [Per-Request Deduplication with React.cache()](#34)
+4. [Client-Side Data Fetching](#4-client-side-data-fetching) — **MEDIUM-HIGH**
+   - 4.1 [Deduplicate Global Event Listeners](#41)
+   - 4.2 [Use SWR for Automatic Deduplication](#42)
+5. [Re-render Optimization](#5-re-render-optimization) — **MEDIUM**
+   - 5.1 [Defer State Reads to Usage Point](#51)
+   - 5.2 [Extract to Memoized Components](#52)
+   - 5.3 [Narrow Effect Dependencies](#53)
+   - 5.4 [Subscribe to Derived State](#54)
+   - 5.5 [Use Lazy State Initialization](#55)
+   - 5.6 [Use Transitions for Non-Urgent Updates](#56)
+6. [Rendering Performance](#6-rendering-performance) — **MEDIUM**
+   - 6.1 [CSS content-visibility for Long Lists](#61)
+   - 6.2 [Hoist Static JSX Elements](#62)
+   - 6.3 [Optimize SVG Precision](#63)
+   - 6.4 [Use Activity Component for Show/Hide](#64)
+   - 6.5 [Use Explicit Conditional Rendering](#65)
+7. [JavaScript Performance](#7-javascript-performance) — **LOW-MEDIUM**
+   - 7.1 [Build Index Maps for Repeated Lookups](#71)
+   - 7.2 [Cache Property Access in Loops](#72)
+   - 7.3 [Cache Repeated Function Calls](#73)
+   - 7.4 [Cache Storage API Calls](#74)
+   - 7.5 [Combine Multiple Array Iterations](#75)
+   - 7.6 [Early Return from Functions](#76)
+   - 7.7 [Hoist RegExp Creation](#77)
+   - 7.8 [Use Set/Map for O(1) Lookups](#78)
+8. [Advanced Patterns](#8-advanced-patterns) — **LOW**
+   - 8.1 [Store Event Handlers in Refs](#81)
+   - 8.2 [useLatest for Stable Callback Refs](#82)
+
+---
+
+## 1. Eliminating Waterfalls
+
+**Impact: CRITICAL**
+
+Waterfalls are the #1 performance killer. Each sequential await adds full network latency. Eliminating them yields the largest gains.
+
+### 1.1 Defer Await Until Needed
+
+Move `await` operations into the branches where they're actually used to avoid blocking code paths that don't need them.
+
+**Incorrect: blocks both branches**
+
+```typescript
+async function handleRequest(userId: string, skipProcessing: boolean) {
+  const userData = await fetchUserData(userId)
+  
+  if (skipProcessing) {
+    // Returns immediately but still waited for userData
+    return { skipped: true }
+  }
+  
+  // Only this branch uses userData
+  return processUserData(userData)
+}
+```
+
+**Correct: only blocks when needed**
+
+```typescript
+async function handleRequest(userId: string, skipProcessing: boolean) {
+  if (skipProcessing) {
+    // Returns immediately without waiting
+    return { skipped: true }
+  }
+  
+  // Fetch only when needed
+  const userData = await fetchUserData(userId)
+  return processUserData(userData)
+}
+```
+
+**Another example: early return optimization**
+
+```typescript
+// Incorrect: always fetches permissions
+async function updateResource(resourceId: string, userId: string) {
+  const permissions = await fetchPermissions(userId)
+  const resource = await getResource(resourceId)
+  
+  if (!resource) {
+    return { error: 'Not found' }
+  }
+  
+  if (!permissions.canEdit) {
+    return { error: 'Forbidden' }
+  }
+  
+  return await updateResourceData(resource, permissions)
+}
+
+// Correct: fetches only when needed
+async function updateResource(resourceId: string, userId: string) {
+  const resource = await getResource(resourceId)
+  
+  if (!resource) {
+    return { error: 'Not found' }
+  }
+  
+  const permissions = await fetchPermissions(userId)
+  
+  if (!permissions.canEdit) {
+    return { error: 'Forbidden' }
+  }
+  
+  return await updateResourceData(resource, permissions)
+}
+```
+
+This optimization is especially valuable when the skipped branch is frequently taken, or when the deferred operation is expensive.
+
+### 1.2 Dependency-Based Parallelization
+
+For operations with partial dependencies, use `better-all` to maximize parallelism. It automatically starts each task at the earliest possible moment.
+
+**Incorrect: profile waits for config unnecessarily**
+
+```typescript
+const [user, config] = await Promise.all([
+  fetchUser(),
+  fetchConfig()
+])
+const profile = await fetchProfile(user.id)
+```
+
+**Correct: config and profile run in parallel**
+
+```typescript
+import { all } from 'better-all'
+
+const { user, config, profile } = await all({
+  async user() { return fetchUser() },
+  async config() { return fetchConfig() },
+  async profile() {
+    return fetchProfile((await this.$.user).id)
+  }
+})
+```
+
+Reference: [https://github.com/shuding/better-all](https://github.com/shuding/better-all)
+
+### 1.3 Prevent Waterfall Chains in API Routes
+
+In API routes and Server Actions, start independent operations immediately, even if you don't await them yet.
+
+**Incorrect: config waits for auth, data waits for both**
+
+```typescript
+export async function GET(request: Request) {
+  const session = await auth()
+  const config = await fetchConfig()
+  const data = await fetchData(session.user.id)
+  return Response.json({ data, config })
+}
+```
+
+**Correct: auth and config start immediately**
+
+```typescript
+export async function GET(request: Request) {
+  const sessionPromise = auth()
+  const configPromise = fetchConfig()
+  const session = await sessionPromise
+  const [config, data] = await Promise.all([
+    configPromise,
+    fetchData(session.user.id)
+  ])
+  return Response.json({ data, config })
+}
+```
+
+For operations with more complex dependency chains, use `better-all` to automatically maximize parallelism (see Dependency-Based Parallelization).
+
+### 1.4 Promise.all() for Independent Operations
+
+When async operations have no interdependencies, execute them concurrently using `Promise.all()`.
+
+**Incorrect: sequential execution, 3 round trips**
+
+```typescript
+const user = await fetchUser()
+const posts = await fetchPosts()
+const comments = await fetchComments()
+```
+
+**Correct: parallel execution, 1 round trip**
+
+```typescript
+const [user, posts, comments] = await Promise.all([
+  fetchUser(),
+  fetchPosts(),
+  fetchComments()
+])
+```
+
+### 1.5 Strategic Suspense Boundaries
+
+Instead of awaiting data in async components before returning JSX, use Suspense boundaries to show the wrapper UI faster while data loads.
+
+**Incorrect: wrapper blocked by data fetching**
+
+```tsx
+async function Page() {
+  const data = await fetchData() // Blocks entire page
+  
+  return (
+    <div>
+      <div>Sidebar</div>
+      <div>Header</div>
+      <div>
+        <DataDisplay data={data} />
+      </div>
+      <div>Footer</div>
+    </div>
+  )
+}
+```
+
+The entire layout waits for data even though only the middle section needs it.
+
+**Correct: wrapper shows immediately, data streams in**
+
+```tsx
+function Page() {
+  return (
+    <div>
+      <div>Sidebar</div>
+      <div>Header</div>
+      <div>
+        <Suspense fallback={<Skeleton />}>
+          <DataDisplay />
+        </Suspense>
+      </div>
+      <div>Footer</div>
+    </div>
+  )
+}
+
+async function DataDisplay() {
+  const data = await fetchData() // Only blocks this component
+  return <div>{data.content}</div>
+}
+```
+
+Sidebar, Header, and Footer render immediately. Only DataDisplay waits for data.
+
+**When NOT to use this pattern:**
+
+```tsx
+
+```
+
+**When NOT to use this pattern:**
+
+```tsx
+
+```
+
+---
+
+## 2. Bundle Size Optimization
+
+**Impact: CRITICAL**
+
+Reducing initial bundle size improves Time to Interactive and Largest Contentful Paint.
+
+### 2.1 Avoid Barrel File Imports
+
+Import directly from source files instead of barrel files to avoid loading thousands of unused modules. **Barrel files** are entry points that re-export multiple modules (e.g., `index.js` that does `export * from './module'`).
+
+Popular icon and component libraries can have **up to 10,000 re-exports** in their entry file. For many React packages, **it takes 200-800ms just to import them**, affecting both development speed and production cold starts.
+
+**Incorrect: imports entire library**
+
+```tsx
+import { Check, X, Menu } from 'lucide-react'
+// Loads 1,583 modules, takes ~2.8s extra in dev
+// Runtime cost: 200-800ms on every cold start
+
+import { Button, TextField } from '@mui/material'
+// Loads 2,225 modules, takes ~4.2s extra in dev
+```
+
+**Correct: imports only what you need**
+
+```tsx
+import Check from 'lucide-react/dist/esm/icons/check'
+import X from 'lucide-react/dist/esm/icons/x'
+import Menu from 'lucide-react/dist/esm/icons/menu'
+// Loads only 3 modules (~2KB vs ~1MB)
+
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+// Loads only what you use
+```
+
+**Alternative: Next.js 13.5+**
+
+```js
+// next.config.js - use optimizePackageImports
+module.exports = {
+  experimental: {
+    optimizePackageImports: ['lucide-react', '@mui/material']
+  }
+}
+
+// Then you can keep the ergonomic barrel imports:
+import { Check, X, Menu } from 'lucide-react'
+// Automatically transformed to direct imports at build time
+```
+
+Direct imports provide 15-70% faster dev boot, 28% faster builds, 40% faster cold starts, and significantly faster HMR.
+
+Libraries commonly affected: `lucide-react`, `@mui/material`, `@mui/icons-material`, `@tabler/icons-react`, `react-icons`, `@headlessui/react`, `@radix-ui/react-*`, `lodash`, `ramda`, `date-fns`, `rxjs`, `react-use`.
+
+Reference: [https://vercel.com/blog/how-we-optimized-package-imports-in-next-js](https://vercel.com/blog/how-we-optimized-package-imports-in-next-js)
+
+### 2.2 Conditional Module Loading
+
+Load large data or modules only when a feature is activated.
+
+**Example: lazy-load animation frames**
+
+```tsx
+function AnimationPlayer({ enabled }: { enabled: boolean }) {
+  const [frames, setFrames] = useState<Frame[] | null>(null)
+
+  useEffect(() => {
+    if (enabled && !frames && typeof window !== 'undefined') {
+      import('./animation-frames.js')
+        .then(mod => setFrames(mod.frames))
+        .catch(() => setEnabled(false))
+    }
+  }, [enabled, frames])
+
+  if (!frames) return <Skeleton />
+  return <Canvas frames={frames} />
+}
+```
+
+The `typeof window !== 'undefined'` check prevents bundling this module for SSR, optimizing server bundle size and build speed.
+
+### 2.3 Defer Non-Critical Third-Party Libraries
+
+Analytics, logging, and error tracking don't block user interaction. Load them after hydration.
+
+**Incorrect: blocks initial bundle**
+
+```tsx
+import { Analytics } from '@vercel/analytics/react'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <Analytics />
+      </body>
+    </html>
+  )
+}
+```
+
+**Correct: loads after hydration**
+
+```tsx
+import dynamic from 'next/dynamic'
+
+const Analytics = dynamic(
+  () => import('@vercel/analytics/react').then(m => m.Analytics),
+  { ssr: false }
+)
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <Analytics />
+      </body>
+    </html>
+  )
+}
+```
+
+### 2.4 Dynamic Imports for Heavy Components
+
+Use `next/dynamic` to lazy-load large components not needed on initial render.
+
+**Incorrect: Monaco bundles with main chunk ~300KB**
+
+```tsx
+import { MonacoEditor } from './monaco-editor'
+
+function CodePanel({ code }: { code: string }) {
+  return <MonacoEditor value={code} />
+}
+```
+
+**Correct: Monaco loads on demand**
+
+```tsx
+import dynamic from 'next/dynamic'
+
+const MonacoEditor = dynamic(
+  () => import('./monaco-editor').then(m => m.MonacoEditor),
+  { ssr: false }
+)
+
+function CodePanel({ code }: { code: string }) {
+  return <MonacoEditor value={code} />
+}
+```
+
+### 2.5 Preload Based on User Intent
+
+Preload heavy bundles before they're needed to reduce perceived latency.
+
+**Example: preload on hover/focus**
+
+```tsx
+function EditorButton({ onClick }: { onClick: () => void }) {
+  const preload = () => {
+    if (typeof window !== 'undefined') {
+      void import('./monaco-editor')
+    }
+  }
+
+  return (
+    <button
+      onMouseEnter={preload}
+      onFocus={preload}
+      onClick={onClick}
+    >
+      Open Editor
+    </button>
+  )
+}
+```
+
+**Example: preload when feature flag is enabled**
+
+```tsx
+function FlagsProvider({ children, flags }: Props) {
+  useEffect(() => {
+    if (flags.editorEnabled && typeof window !== 'undefined') {
+      void import('./monaco-editor').then(mod => mod.init())
+    }
+  }, [flags.editorEnabled])
+
+  return <FlagsContext.Provider value={flags}>
+    {children}
+  </FlagsContext.Provider>
+}
+```
+
+The `typeof window !== 'undefined'` check prevents bundling preloaded modules for SSR, optimizing server bundle size and build speed.
+
+---
+
+## 3. Server-Side Performance
+
+**Impact: HIGH**
+
+Optimizing server-side rendering and data fetching eliminates server-side waterfalls and reduces response times.
+
+### 3.1 Cross-Request LRU Caching
+
+`React.cache()` only works within one request. For data shared across sequential requests (user clicks button A then button B), use an LRU cache.
+
+**Implementation:**
+
+```typescript
+import { LRUCache } from 'lru-cache'
+
+const cache = new LRUCache<string, any>({
+  max: 1000,
+  ttl: 5 * 60 * 1000  // 5 minutes
+})
+
+export async function getUser(id: string) {
+  const cached = cache.get(id)
+  if (cached) return cached
+
+  const user = await db.user.findUnique({ where: { id } })
+  cache.set(id, user)
+  return user
+}
+
+// Request 1: DB query, result cached
+// Request 2: cache hit, no DB query
+```
+
+Use when sequential user actions hit multiple endpoints needing the same data within seconds. In serverless, consider Redis for cross-process caching.
+
+Reference: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache)
+
+### 3.2 Minimize Serialization at RSC Boundaries
+
+The React Server/Client boundary serializes all object properties. Only pass fields that the client actually uses.
+
+**Incorrect: serializes all 50 fields**
+
+```tsx
+async function Page() {
+  const user = await fetchUser()  // 50 fields
+  return <Profile user={user} />
+}
+
+'use client'
+function Profile({ user }: { user: User }) {
+  return <div>{user.name}</div>  // uses 1 field
+}
+```
+
+**Correct: serializes only 1 field**
+
+```tsx
+async function Page() {
+  const user = await fetchUser()
+  return <Profile name={user.name} />
+}
+
+'use client'
+function Profile({ name }: { name: string }) {
+  return <div>{name}</div>
+}
+```
+
+### 3.3 Parallel Data Fetching with Component Composition
+
+React Server Components execute sequentially within a tree. Restructure with composition to parallelize data fetching.
+
+**Incorrect: Sidebar waits for Page's fetch to complete**
+
+```tsx
+export default async function Page() {
+  const header = await fetchHeader()
+  return (
+    <div>
+      <div>{header}</div>
+      <Sidebar />
+    </div>
+  )
+}
+
+async function Sidebar() {
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
+}
+```
+
+**Correct: both fetch simultaneously**
+
+```tsx
+async function Header() {
+  const data = await fetchHeader()
+  return <div>{data}</div>
+}
+
+async function Sidebar() {
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <Header />
+      <Sidebar />
+    </div>
+  )
+}
+```
+
+**Alternative with children prop:**
+
+```tsx
+async function Layout({ children }: { children: ReactNode }) {
+  const header = await fetchHeader()
+  return (
+    <div>
+      <div>{header}</div>
+      {children}
+    </div>
+  )
+}
+
+async function Sidebar() {
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
+}
+
+export default function Page() {
+  return (
+    <Layout>
+      <Sidebar />
+    </Layout>
+  )
+}
+```
+
+### 3.4 Per-Request Deduplication with React.cache()
+
+Use `React.cache()` for server-side request deduplication. Authentication and database queries benefit most.
+
+**Usage:**
+
+```typescript
+import { cache } from 'react'
+
+export const getCurrentUser = cache(async () => {
+  const session = await auth()
+  if (!session?.user?.id) return null
+  return await db.user.findUnique({
+    where: { id: session.user.id }
+  })
+})
+```
+
+Within a single request, multiple calls to `getCurrentUser()` execute the query only once.
+
+---
+
+## 4. Client-Side Data Fetching
+
+**Impact: MEDIUM-HIGH**
+
+Automatic deduplication and efficient data fetching patterns reduce redundant network requests.
+
+### 4.1 Deduplicate Global Event Listeners
+
+Use `useSWRSubscription()` to share global event listeners across component instances.
+
+**Incorrect: N instances = N listeners**
+
+```tsx
+function useKeyboardShortcut(key: string, callback: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey && e.key === key) {
+        callback()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [key, callback])
+}
+```
+
+When using the `useKeyboardShortcut` hook multiple times, each instance will register a new listener.
+
+**Correct: N instances = 1 listener**
+
+```tsx
+import useSWRSubscription from 'swr/subscription'
+
+// Module-level Map to track callbacks per key
+const keyCallbacks = new Map<string, Set<() => void>>()
+
+function useKeyboardShortcut(key: string, callback: () => void) {
+  // Register this callback in the Map
+  useEffect(() => {
+    if (!keyCallbacks.has(key)) {
+      keyCallbacks.set(key, new Set())
+    }
+    keyCallbacks.get(key)!.add(callback)
+
+    return () => {
+      const set = keyCallbacks.get(key)
+      if (set) {
+        set.delete(callback)
+        if (set.size === 0) {
+          keyCallbacks.delete(key)
+        }
+      }
+    }
+  }, [key, callback])
+
+  useSWRSubscription('global-keydown', () => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey && keyCallbacks.has(e.key)) {
+        keyCallbacks.get(e.key)!.forEach(cb => cb())
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }
+}
+
+function Profile() {
+  // Multiple shortcuts will share the same listener
+  useKeyboardShortcut('p', () => { /* ... */ }) 
+  useKeyboardShortcut('k', () => { /* ... */ })
+  // ...
+}
+```
+
+### 4.2 Use SWR for Automatic Deduplication
+
+SWR enables request deduplication, caching, and revalidation across component instances.
+
+**Incorrect: no deduplication, each instance fetches**
+
+```tsx
+function UserList() {
+  const [users, setUsers] = useState([])
+  useEffect(() => {
+    fetch('/api/users')
+      .then(r => r.json())
+      .then(setUsers)
+  }, [])
+}
+```
+
+**Correct: multiple instances share one request**
+
+```tsx
+import useSWR from 'swr'
+
+function UserList() {
+  const { data: users } = useSWR('/api/users', fetcher)
+}
+```
+
+**For immutable data:**
+
+```tsx
+import { useImmutableSWR } from '@/lib/swr'
+
+function StaticContent() {
+  const { data } = useImmutableSWR('/api/config', fetcher)
+}
+```
+
+**For mutations:**
+
+```tsx
+import { useSWRMutation } from 'swr/mutation'
+
+function UpdateButton() {
+  const { trigger } = useSWRMutation('/api/user', updateUser)
+  return <button onClick={() => trigger()}>Update</button>
+}
+```
+
+Reference: [https://swr.vercel.app](https://swr.vercel.app)
+
+---
+
+## 5. Re-render Optimization
+
+**Impact: MEDIUM**
+
+Reducing unnecessary re-renders minimizes wasted computation and improves UI responsiveness.
+
+### 5.1 Defer State Reads to Usage Point
+
+Don't subscribe to dynamic state (searchParams, localStorage) if you only read it inside callbacks.
+
+**Incorrect: subscribes to all searchParams changes**
+
+```tsx
+function ShareButton({ chatId }: { chatId: string }) {
+  const searchParams = useSearchParams()
+
+  const handleShare = () => {
+    const ref = searchParams.get('ref')
+    shareChat(chatId, { ref })
+  }
+
+  return <button onClick={handleShare}>Share</button>
+}
+```
+
+**Correct: reads on demand, no subscription**
+
+```tsx
+function ShareButton({ chatId }: { chatId: string }) {
+  const handleShare = () => {
+    const params = new URLSearchParams(window.location.search)
+    const ref = params.get('ref')
+    shareChat(chatId, { ref })
+  }
+
+  return <button onClick={handleShare}>Share</button>
+}
+```
+
+### 5.2 Extract to Memoized Components
+
+Extract expensive work into memoized components to enable early returns before computation.
+
+**Incorrect: computes avatar even when loading**
+
+```tsx
+function Profile({ user, loading }: Props) {
+  const avatar = useMemo(() => {
+    const id = computeAvatarId(user)
+    return <Avatar id={id} />
+  }, [user])
+
+  if (loading) return <Skeleton />
+  return <div>{avatar}</div>
+}
+```
+
+**Correct: skips computation when loading**
+
+```tsx
+const UserAvatar = memo(function UserAvatar({ user }: { user: User }) {
+  const id = useMemo(() => computeAvatarId(user), [user])
+  return <Avatar id={id} />
+})
+
+function Profile({ user, loading }: Props) {
+  if (loading) return <Skeleton />
+  return (
+    <div>
+      <UserAvatar user={user} />
+    </div>
+  )
+}
+```
+
+### 5.3 Narrow Effect Dependencies
+
+Specify primitive dependencies instead of objects to minimize effect re-runs.
+
+**Incorrect: re-runs on any user field change**
+
+```tsx
+useEffect(() => {
+  console.log(user.id)
+}, [user])
+```
+
+**Correct: re-runs only when id changes**
+
+```tsx
+useEffect(() => {
+  console.log(user.id)
+}, [user.id])
+```
+
+**For derived state, compute outside effect:**
+
+```tsx
+// Incorrect: runs on width=767, 766, 765...
+useEffect(() => {
+  if (width < 768) {
+    enableMobileMode()
+  }
+}, [width])
+
+// Correct: runs only on boolean transition
+const isMobile = width < 768
+useEffect(() => {
+  if (isMobile) {
+    enableMobileMode()
+  }
+}, [isMobile])
+```
+
+### 5.4 Subscribe to Derived State
+
+Subscribe to derived boolean state instead of continuous values to reduce re-render frequency.
+
+**Incorrect: re-renders on every pixel change**
+
+```tsx
+function Sidebar() {
+  const width = useWindowWidth()  // updates continuously
+  const isMobile = width < 768
+  return <nav className={isMobile ? 'mobile' : 'desktop'}>
+}
+```
+
+**Correct: re-renders only when boolean changes**
+
+```tsx
+function Sidebar() {
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  return <nav className={isMobile ? 'mobile' : 'desktop'}>
+}
+```
+
+### 5.5 Use Lazy State Initialization
+
+Pass a function to `useState` for expensive initial values. Without the function form, the initializer runs on every render even though the value is only used once.
+
+**Incorrect: runs on every render**
+
+```tsx
+function FilteredList({ items }: { items: Item[] }) {
+  // buildSearchIndex() runs on EVERY render, even after initialization
+  const [searchIndex, setSearchIndex] = useState(buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
+  // When query changes, buildSearchIndex runs again unnecessarily
+  return <SearchResults index={searchIndex} query={query} />
+}
+
+function UserProfile() {
+  // JSON.parse runs on every render
+  const [settings, setSettings] = useState(
+    JSON.parse(localStorage.getItem('settings') || '{}')
+  )
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
+}
+```
+
+**Correct: runs only once**
+
+```tsx
+function FilteredList({ items }: { items: Item[] }) {
+  // buildSearchIndex() runs ONLY on initial render
+  const [searchIndex, setSearchIndex] = useState(() => buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
+  return <SearchResults index={searchIndex} query={query} />
+}
+
+function UserProfile() {
+  // JSON.parse runs only on initial render
+  const [settings, setSettings] = useState(() => {
+    const stored = localStorage.getItem('settings')
+    return stored ? JSON.parse(stored) : {}
+  })
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
+}
+```
+
+Use lazy initialization when computing initial values from localStorage/sessionStorage, building data structures (indexes, maps), reading from the DOM, or performing heavy transformations.
+
+For simple primitives (`useState(0)`), direct references (`useState(props.value)`), or cheap literals (`useState({})`), the function form is unnecessary.
+
+### 5.6 Use Transitions for Non-Urgent Updates
+
+Mark frequent, non-urgent state updates as transitions to maintain UI responsiveness.
+
+**Incorrect: blocks UI on every scroll**
+
+```tsx
+function ScrollTracker() {
+  const [scrollY, setScrollY] = useState(0)
+  useEffect(() => {
+    const handler = () => setScrollY(window.scrollY)
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
+}
+```
+
+**Correct: non-blocking updates**
+
+```tsx
+import { startTransition } from 'react'
+
+function ScrollTracker() {
+  const [scrollY, setScrollY] = useState(0)
+  useEffect(() => {
+    const handler = () => {
+      startTransition(() => setScrollY(window.scrollY))
+    }
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
+}
+```
+
+---
+
+## 6. Rendering Performance
+
+**Impact: MEDIUM**
+
+Optimizing the rendering process reduces the work the browser needs to do.
+
+### 6.1 CSS content-visibility for Long Lists
+
+Apply `content-visibility: auto` to defer off-screen rendering.
+
+**CSS:**
+
+```css
+.message-item {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 80px;
+}
+```
+
+**Example:**
+
+```tsx
+function MessageList({ messages }: { messages: Message[] }) {
+  return (
+    <div className="overflow-y-auto h-screen">
+      {messages.map(msg => (
+        <div key={msg.id} className="message-item">
+          <Avatar user={msg.author} />
+          <div>{msg.content}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+For 1000 messages, browser skips layout/paint for ~990 off-screen items (10× faster initial render).
+
+### 6.2 Hoist Static JSX Elements
+
+Extract static JSX outside components to avoid re-creation.
+
+**Incorrect: recreates element every render**
+
+```tsx
+function LoadingSkeleton() {
+  return <div className="animate-pulse h-20 bg-gray-200" />
+}
+
+function Container() {
+  return (
+    <div>
+      {loading && <LoadingSkeleton />}
+    </div>
+  )
+}
+```
+
+**Correct: reuses same element**
+
+```tsx
+const loadingSkeleton = (
+  <div className="animate-pulse h-20 bg-gray-200" />
+)
+
+function Container() {
+  return (
+    <div>
+      {loading && loadingSkeleton}
+    </div>
+  )
+}
+```
+
+This is especially helpful for large and static SVG nodes, which can be expensive to recreate on every render.
+
+### 6.3 Optimize SVG Precision
+
+Reduce SVG coordinate precision to decrease file size. The optimal precision depends on the viewBox size, but in general reducing precision should be considered.
+
+**Incorrect: excessive precision**
+
+```svg
+<path d="M 10.293847 20.847362 L 30.938472 40.192837" />
+```
+
+**Correct: 1 decimal place**
+
+```svg
+<path d="M 10.3 20.8 L 30.9 40.2" />
+```
+
+**Automate with SVGO:**
+
+```bash
+npx svgo --precision=1 --multipass icon.svg
+```
+
+### 6.4 Use Activity Component for Show/Hide
+
+Use React's `<Activity>` to preserve state/DOM for expensive components that frequently toggle visibility.
+
+**Usage:**
+
+```tsx
+import { Activity } from 'react'
+
+function Dropdown({ isOpen }: Props) {
+  return (
+    <Activity mode={isOpen ? 'visible' : 'hidden'}>
+      <ExpensiveMenu />
+    </Activity>
+  )
+}
+```
+
+Avoids expensive re-renders and state loss.
+
+### 6.5 Use Explicit Conditional Rendering
+
+Use explicit ternary operators (`? :`) instead of `&&` for conditional rendering when the condition can be `0`, `NaN`, or other falsy values that render.
+
+**Incorrect: renders "0" when count is 0**
+
+```tsx
+function Badge({ count }: { count: number }) {
+  return (
+    <div>
+      {count && <span className="badge">{count}</span>}
+    </div>
+  )
+}
+
+// When count = 0, renders: <div>0</div>
+// When count = 5, renders: <div><span class="badge">5</span></div>
+```
+
+**Correct: renders nothing when count is 0**
+
+```tsx
+function Badge({ count }: { count: number }) {
+  return (
+    <div>
+      {count > 0 ? <span className="badge">{count}</span> : null}
+    </div>
+  )
+}
+
+// When count = 0, renders: <div></div>
+// When count = 5, renders: <div><span class="badge">5</span></div>
+```
+
+---
+
+## 7. JavaScript Performance
+
+**Impact: LOW-MEDIUM**
+
+Micro-optimizations for hot paths can add up to meaningful improvements.
+
+### 7.1 Build Index Maps for Repeated Lookups
+
+Multiple `.find()` calls by the same key should use a Map.
+
+**Incorrect (O(n) per lookup):**
+
+```typescript
+function processOrders(orders: Order[], users: User[]) {
+  return orders.map(order => ({
+    ...order,
+    user: users.find(u => u.id === order.userId)
+  }))
+}
+```
+
+**Correct (O(1) per lookup):**
+
+```typescript
+function processOrders(orders: Order[], users: User[]) {
+  const userById = new Map(users.map(u => [u.id, u]))
+
+  return orders.map(order => ({
+    ...order,
+    user: userById.get(order.userId)
+  }))
+}
+```
+
+Build map once (O(n)), then all lookups are O(1).
+
+For 1000 orders × 1000 users: 1M ops → 2K ops.
+
+### 7.2 Cache Property Access in Loops
+
+Cache object property lookups in hot paths.
+
+**Incorrect: 3 lookups × N iterations**
+
+```typescript
+for (let i = 0; i < arr.length; i++) {
+  process(obj.config.settings.value)
+}
+```
+
+**Correct: 1 lookup total**
+
+```typescript
+const value = obj.config.settings.value
+const len = arr.length
+for (let i = 0; i < len; i++) {
+  process(value)
+}
+```
+
+### 7.3 Cache Repeated Function Calls
+
+Use a module-level Map to cache function results when the same function is called repeatedly with the same inputs during render.
+
+**Incorrect: redundant computation**
+
+```typescript
+function ProjectList({ projects }: { projects: Project[] }) {
+  return (
+    <div>
+      {projects.map(project => {
+        // slugify() called 100+ times for same project names
+        const slug = slugify(project.name)
+        
+        return <ProjectCard key={project.id} slug={slug} />
+      })}
+    </div>
+  )
+}
+```
+
+**Correct: cached results**
+
+```typescript
+// Module-level cache
+const cachedSlugify = new Map<string, any>()
+
+function cachedSlugify(text: string): string {
+  if (cachedSlugify.has(text)) {
+    return cachedSlugify.get(text)
+  }
+  const result = slugify(text)
+  cachedSlugify.set(text, result)
+  return result
+}
+
+function ProjectList({ projects }: { projects: Project[] }) {
+  return (
+    <div>
+      {projects.map(project => {
+        // Computed only once per unique project name
+        const slug = cachedSlugify(project.name)
+        
+        return <ProjectCard key={project.id} slug={slug} />
+      })}
+    </div>
+  )
+}
+```
+
+**Simpler pattern for single-value functions:**
+
+```typescript
+let isLoggedInCache: boolean | null = null
+
+function isLoggedIn(): boolean {
+  if (isLoggedInCache !== null) {
+    return isLoggedInCache
+  }
+  
+  isLoggedInCache = document.cookie.includes('auth=')
+  return isLoggedInCache
+}
+
+// Clear cache when auth changes
+function onAuthChange() {
+  isLoggedInCache = null
+}
+```
+
+Use a Map (not a hook) so it works everywhere: utilities, event handlers, not just React components.
+
+Reference: [https://vercel.com/blog/how-we-made-the-vercel-dashboard-twice-as-fast](https://vercel.com/blog/how-we-made-the-vercel-dashboard-twice-as-fast)
+
+### 7.4 Cache Storage API Calls
+
+`localStorage`, `sessionStorage`, and `document.cookie` are synchronous and expensive. Cache reads in memory.
+
+**Incorrect: reads storage on every call**
+
+```typescript
+function getTheme() {
+  return localStorage.getItem('theme') ?? 'light'
+}
+// Called 10 times = 10 storage reads
+```
+
+**Correct: Map cache**
+
+```typescript
+const storageCache = new Map<string, string | null>()
+
+function getLocalStorage(key: string) {
+  if (!storageCache.has(key)) {
+    storageCache.set(key, localStorage.getItem(key))
+  }
+  return storageCache.get(key)
+}
+
+function setLocalStorage(key: string, value: string) {
+  localStorage.setItem(key, value)
+  storageCache.set(key, value)  // keep cache in sync
+}
+```
+
+Use a Map (not a hook) so it works everywhere: utilities, event handlers, not just React components.
+
+**Cookie caching:**
+
+```typescript
+window.addEventListener('storage', (e) => {
+  if (e.key) storageCache.delete(e.key)
+})
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    storageCache.clear()
+  }
+})
+```
+
+**Cookie caching:**
+
+```typescript
+window.addEventListener('storage', (e) => {
+  if (e.key) storageCache.delete(e.key)
+})
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    storageCache.clear()
+  }
+})
+```
+
+### 7.5 Combine Multiple Array Iterations
+
+Multiple `.filter()` or `.map()` calls iterate the array multiple times. Combine into one loop.
+
+**Incorrect: 3 iterations**
+
+```typescript
+const admins = users.filter(u => u.isAdmin)
+const testers = users.filter(u => u.isTester)
+const inactive = users.filter(u => !u.isActive)
+```
+
+**Correct: 1 iteration**
+
+```typescript
+const admins: User[] = []
+const testers: User[] = []
+const inactive: User[] = []
+
+for (const user of users) {
+  if (user.isAdmin) admins.push(user)
+  if (user.isTester) testers.push(user)
+  if (!user.isActive) inactive.push(user)
+}
+```
+
+### 7.6 Early Return from Functions
+
+Return early when result is determined to skip unnecessary processing.
+
+**Incorrect: processes all items even after finding answer**
+
+```typescript
+function validateUsers(users: User[]) {
+  let hasError = false
+  let errorMessage = ''
+  
+  for (const user of users) {
+    if (!user.email) {
+      hasError = true
+      errorMessage = 'Email required'
+    }
+    if (!user.name) {
+      hasError = true
+      errorMessage = 'Name required'
+    }
+    // Continues checking all users even after error found
+  }
+  
+  return hasError ? { valid: false, error: errorMessage } : { valid: true }
+}
+```
+
+**Correct: returns immediately on first error**
+
+```typescript
+function validateUsers(users: User[]) {
+  for (const user of users) {
+    if (!user.email) {
+      return { valid: false, error: 'Email required' }
+    }
+    if (!user.name) {
+      return { valid: false, error: 'Name required' }
+    }
+  }
+  
+  return { valid: true }
+}
+```
+
+### 7.7 Hoist RegExp Creation
+
+Don't create RegExp inside render. Hoist to module scope or memoize with `useMemo()`.
+
+**Incorrect: new RegExp every render**
+
+```tsx
+function Highlighter({ text, query }: Props) {
+  const regex = new RegExp(`(${query})`, 'gi')
+  const parts = text.split(regex)
+  return <>{parts.map((part, i) => ...)}</>
+}
+```
+
+**Correct: memoize or hoist**
+
+```typescript
+const regex = /foo/g
+regex.test('foo')  // true, lastIndex = 3
+regex.test('foo')  // false, lastIndex = 0
+```
+
+**Correct: memoize or hoist**
+
+```typescript
+const regex = /foo/g
+regex.test('foo')  // true, lastIndex = 3
+regex.test('foo')  // false, lastIndex = 0
+```
+
+### 7.8 Use Set/Map for O(1) Lookups
+
+Convert arrays to Set/Map for repeated membership checks.
+
+**Incorrect (O(n) per check):**
+
+```typescript
+const allowedIds = ['a', 'b', 'c', ...]
+items.filter(item => allowedIds.includes(item.id))
+```
+
+**Correct (O(1) per check):**
+
+```typescript
+const allowedIds = new Set(['a', 'b', 'c', ...])
+items.filter(item => allowedIds.has(item.id))
+```
+
+---
+
+## 8. Advanced Patterns
+
+**Impact: LOW**
+
+Advanced patterns for specific cases that require careful implementation.
+
+### 8.1 Store Event Handlers in Refs
+
+Store callbacks in refs when used in effects that shouldn't re-subscribe on callback changes.
+
+**Incorrect: re-subscribes on every render**
+
+```tsx
+function useWindowEvent(event: string, handler: () => void) {
+  useEffect(() => {
+    window.addEventListener(event, handler)
+    return () => window.removeEventListener(event, handler)
+  }, [event, handler])
+}
+```
+
+**Correct: stable subscription**
+
+```tsx
+function useWindowEvent(event: string, handler: () => void) {
+  const handlerRef = useRef(handler)
+  useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    const listener = () => handlerRef.current()
+    window.addEventListener(event, listener)
+    return () => window.removeEventListener(event, listener)
+  }, [event])
+}
+```
+
+### 8.2 useLatest for Stable Callback Refs
+
+Access latest values in callbacks without adding them to dependency arrays. Prevents effect re-runs while avoiding stale closures.
+
+**Implementation:**
+
+```typescript
+function useLatest<T>(value: T) {
+  const ref = useRef(value)
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref
+}
+```
+
+**Incorrect: effect re-runs on every callback change**
+
+```tsx
+function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    const timeout = setTimeout(() => onSearch(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query, onSearch])
+}
+```
+
+**Correct: stable effect, fresh callback**
+
+```tsx
+function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
+  const [query, setQuery] = useState('')
+  const onSearchRef = useLatest(onSearch)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => onSearchRef.current(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query])
+}
+```
+
+---
+
+## References
+
+1. [https://react.dev](https://react.dev)
+2. [https://nextjs.org](https://nextjs.org)
+3. [https://swr.vercel.app](https://swr.vercel.app)
+4. [https://github.com/shuding/better-all](https://github.com/shuding/better-all)
+5. [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache)

--- a/devtools/skills/react-best-practices/references/rules/_sections.md
+++ b/devtools/skills/react-best-practices/references/rules/_sections.md
@@ -1,0 +1,46 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Eliminating Waterfalls (async)
+
+**Impact:** CRITICAL  
+**Description:** Waterfalls are the #1 performance killer. Each sequential await adds full network latency. Eliminating them yields the largest gains.
+
+## 2. Bundle Size Optimization (bundle)
+
+**Impact:** CRITICAL  
+**Description:** Reducing initial bundle size improves Time to Interactive and Largest Contentful Paint.
+
+## 3. Server-Side Performance (server)
+
+**Impact:** HIGH  
+**Description:** Optimizing server-side rendering and data fetching eliminates server-side waterfalls and reduces response times.
+
+## 4. Client-Side Data Fetching (client)
+
+**Impact:** MEDIUM-HIGH  
+**Description:** Automatic deduplication and efficient data fetching patterns reduce redundant network requests.
+
+## 5. Re-render Optimization (rerender)
+
+**Impact:** MEDIUM  
+**Description:** Reducing unnecessary re-renders minimizes wasted computation and improves UI responsiveness.
+
+## 6. Rendering Performance (rendering)
+
+**Impact:** MEDIUM  
+**Description:** Optimizing the rendering process reduces the work the browser needs to do.
+
+## 7. JavaScript Performance (js)
+
+**Impact:** LOW-MEDIUM  
+**Description:** Micro-optimizations for hot paths can add up to meaningful improvements.
+
+## 8. Advanced Patterns (advanced)
+
+**Impact:** LOW  
+**Description:** Advanced patterns for specific cases that require careful implementation.

--- a/devtools/skills/react-best-practices/references/rules/_template.md
+++ b/devtools/skills/react-best-practices/references/rules/_template.md
@@ -1,0 +1,28 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+impactDescription: Optional description of impact (e.g., "20-50% improvement")
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM (optional impact description)**
+
+Brief explanation of the rule and why it matters. This should be clear and concise, explaining the performance implications.
+
+**Incorrect (description of what's wrong):**
+
+```typescript
+// Bad code example here
+const bad = example()
+```
+
+**Correct (description of what's right):**
+
+```typescript
+// Good code example here
+const good = example()
+```
+
+Reference: [Link to documentation or resource](https://example.com)

--- a/devtools/skills/react-best-practices/references/rules/advanced-event-handler-refs.md
+++ b/devtools/skills/react-best-practices/references/rules/advanced-event-handler-refs.md
@@ -1,0 +1,38 @@
+---
+title: Store Event Handlers in Refs
+impact: LOW
+impactDescription: stable subscriptions
+tags: advanced, hooks, refs, event-handlers, optimization
+---
+
+## Store Event Handlers in Refs
+
+Store callbacks in refs when used in effects that shouldn't re-subscribe on callback changes.
+
+**Incorrect (re-subscribes on every render):**
+
+```tsx
+function useWindowEvent(event: string, handler: () => void) {
+  useEffect(() => {
+    window.addEventListener(event, handler)
+    return () => window.removeEventListener(event, handler)
+  }, [event, handler])
+}
+```
+
+**Correct (stable subscription):**
+
+```tsx
+function useWindowEvent(event: string, handler: () => void) {
+  const handlerRef = useRef(handler)
+  useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    const listener = () => handlerRef.current()
+    window.addEventListener(event, listener)
+    return () => window.removeEventListener(event, listener)
+  }, [event])
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/advanced-use-latest.md
+++ b/devtools/skills/react-best-practices/references/rules/advanced-use-latest.md
@@ -1,0 +1,49 @@
+---
+title: useLatest for Stable Callback Refs
+impact: LOW
+impactDescription: prevents effect re-runs
+tags: advanced, hooks, useLatest, refs, optimization
+---
+
+## useLatest for Stable Callback Refs
+
+Access latest values in callbacks without adding them to dependency arrays. Prevents effect re-runs while avoiding stale closures.
+
+**Implementation:**
+
+```typescript
+function useLatest<T>(value: T) {
+  const ref = useRef(value)
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref
+}
+```
+
+**Incorrect (effect re-runs on every callback change):**
+
+```tsx
+function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    const timeout = setTimeout(() => onSearch(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query, onSearch])
+}
+```
+
+**Correct (stable effect, fresh callback):**
+
+```tsx
+function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
+  const [query, setQuery] = useState('')
+  const onSearchRef = useLatest(onSearch)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => onSearchRef.current(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query])
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/async-api-routes.md
+++ b/devtools/skills/react-best-practices/references/rules/async-api-routes.md
@@ -1,0 +1,38 @@
+---
+title: Prevent Waterfall Chains in API Routes
+impact: CRITICAL
+impactDescription: 2-10× improvement
+tags: api-routes, server-actions, waterfalls, parallelization
+---
+
+## Prevent Waterfall Chains in API Routes
+
+In API routes and Server Actions, start independent operations immediately, even if you don't await them yet.
+
+**Incorrect (config waits for auth, data waits for both):**
+
+```typescript
+export async function GET(request: Request) {
+  const session = await auth()
+  const config = await fetchConfig()
+  const data = await fetchData(session.user.id)
+  return Response.json({ data, config })
+}
+```
+
+**Correct (auth and config start immediately):**
+
+```typescript
+export async function GET(request: Request) {
+  const sessionPromise = auth()
+  const configPromise = fetchConfig()
+  const session = await sessionPromise
+  const [config, data] = await Promise.all([
+    configPromise,
+    fetchData(session.user.id)
+  ])
+  return Response.json({ data, config })
+}
+```
+
+For operations with more complex dependency chains, use `better-all` to automatically maximize parallelism (see Dependency-Based Parallelization).

--- a/devtools/skills/react-best-practices/references/rules/async-defer-await.md
+++ b/devtools/skills/react-best-practices/references/rules/async-defer-await.md
@@ -1,0 +1,80 @@
+---
+title: Defer Await Until Needed
+impact: HIGH
+impactDescription: avoids blocking unused code paths
+tags: async, await, conditional, optimization
+---
+
+## Defer Await Until Needed
+
+Move `await` operations into the branches where they're actually used to avoid blocking code paths that don't need them.
+
+**Incorrect (blocks both branches):**
+
+```typescript
+async function handleRequest(userId: string, skipProcessing: boolean) {
+  const userData = await fetchUserData(userId)
+  
+  if (skipProcessing) {
+    // Returns immediately but still waited for userData
+    return { skipped: true }
+  }
+  
+  // Only this branch uses userData
+  return processUserData(userData)
+}
+```
+
+**Correct (only blocks when needed):**
+
+```typescript
+async function handleRequest(userId: string, skipProcessing: boolean) {
+  if (skipProcessing) {
+    // Returns immediately without waiting
+    return { skipped: true }
+  }
+  
+  // Fetch only when needed
+  const userData = await fetchUserData(userId)
+  return processUserData(userData)
+}
+```
+
+**Another example (early return optimization):**
+
+```typescript
+// Incorrect: always fetches permissions
+async function updateResource(resourceId: string, userId: string) {
+  const permissions = await fetchPermissions(userId)
+  const resource = await getResource(resourceId)
+  
+  if (!resource) {
+    return { error: 'Not found' }
+  }
+  
+  if (!permissions.canEdit) {
+    return { error: 'Forbidden' }
+  }
+  
+  return await updateResourceData(resource, permissions)
+}
+
+// Correct: fetches only when needed
+async function updateResource(resourceId: string, userId: string) {
+  const resource = await getResource(resourceId)
+  
+  if (!resource) {
+    return { error: 'Not found' }
+  }
+  
+  const permissions = await fetchPermissions(userId)
+  
+  if (!permissions.canEdit) {
+    return { error: 'Forbidden' }
+  }
+  
+  return await updateResourceData(resource, permissions)
+}
+```
+
+This optimization is especially valuable when the skipped branch is frequently taken, or when the deferred operation is expensive.

--- a/devtools/skills/react-best-practices/references/rules/async-dependencies.md
+++ b/devtools/skills/react-best-practices/references/rules/async-dependencies.md
@@ -1,0 +1,36 @@
+---
+title: Dependency-Based Parallelization
+impact: CRITICAL
+impactDescription: 2-10× improvement
+tags: async, parallelization, dependencies, better-all
+---
+
+## Dependency-Based Parallelization
+
+For operations with partial dependencies, use `better-all` to maximize parallelism. It automatically starts each task at the earliest possible moment.
+
+**Incorrect (profile waits for config unnecessarily):**
+
+```typescript
+const [user, config] = await Promise.all([
+  fetchUser(),
+  fetchConfig()
+])
+const profile = await fetchProfile(user.id)
+```
+
+**Correct (config and profile run in parallel):**
+
+```typescript
+import { all } from 'better-all'
+
+const { user, config, profile } = await all({
+  async user() { return fetchUser() },
+  async config() { return fetchConfig() },
+  async profile() {
+    return fetchProfile((await this.$.user).id)
+  }
+})
+```
+
+Reference: [https://github.com/shuding/better-all](https://github.com/shuding/better-all)

--- a/devtools/skills/react-best-practices/references/rules/async-parallel.md
+++ b/devtools/skills/react-best-practices/references/rules/async-parallel.md
@@ -1,0 +1,28 @@
+---
+title: Promise.all() for Independent Operations
+impact: CRITICAL
+impactDescription: 2-10× improvement
+tags: async, parallelization, promises, waterfalls
+---
+
+## Promise.all() for Independent Operations
+
+When async operations have no interdependencies, execute them concurrently using `Promise.all()`.
+
+**Incorrect (sequential execution, 3 round trips):**
+
+```typescript
+const user = await fetchUser()
+const posts = await fetchPosts()
+const comments = await fetchComments()
+```
+
+**Correct (parallel execution, 1 round trip):**
+
+```typescript
+const [user, posts, comments] = await Promise.all([
+  fetchUser(),
+  fetchPosts(),
+  fetchComments()
+])
+```

--- a/devtools/skills/react-best-practices/references/rules/async-suspense-boundaries.md
+++ b/devtools/skills/react-best-practices/references/rules/async-suspense-boundaries.md
@@ -1,0 +1,66 @@
+---
+title: Strategic Suspense Boundaries
+impact: HIGH
+impactDescription: faster initial paint
+tags: async, suspense, streaming, layout-shift
+---
+
+## Strategic Suspense Boundaries
+
+Instead of awaiting data in async components before returning JSX, use Suspense boundaries to show the wrapper UI faster while data loads.
+
+**Incorrect (wrapper blocked by data fetching):**
+
+```tsx
+async function Page() {
+  const data = await fetchData() // Blocks entire page
+  
+  return (
+    <div>
+      <div>Sidebar</div>
+      <div>Header</div>
+      <div>
+        <DataDisplay data={data} />
+      </div>
+      <div>Footer</div>
+    </div>
+  )
+}
+```
+
+The entire layout waits for data even though only the middle section needs it.
+
+**Correct (wrapper shows immediately, data streams in):**
+
+```tsx
+function Page() {
+  return (
+    <div>
+      <div>Sidebar</div>
+      <div>Header</div>
+      <div>
+        <Suspense fallback={<Skeleton />}>
+          <DataDisplay />
+        </Suspense>
+      </div>
+      <div>Footer</div>
+    </div>
+  )
+}
+
+async function DataDisplay() {
+  const data = await fetchData() // Only blocks this component
+  return <div>{data.content}</div>
+}
+```
+
+Sidebar, Header, and Footer render immediately. Only DataDisplay waits for data.
+
+**When NOT to use this pattern:**
+
+- Critical data needed for layout decisions (affects positioning)
+- SEO-critical content above the fold
+- Small, fast queries where suspense overhead isn't worth it
+- When you want to avoid layout shift (loading → content jump)
+
+**Trade-off:** Faster initial paint vs potential layout shift. Choose based on your UX priorities.

--- a/devtools/skills/react-best-practices/references/rules/bundle-barrel-imports.md
+++ b/devtools/skills/react-best-practices/references/rules/bundle-barrel-imports.md
@@ -1,0 +1,59 @@
+---
+title: Avoid Barrel File Imports
+impact: CRITICAL
+impactDescription: 200-800ms import cost, slow builds
+tags: bundle, imports, tree-shaking, barrel-files, performance
+---
+
+## Avoid Barrel File Imports
+
+Import directly from source files instead of barrel files to avoid loading thousands of unused modules. **Barrel files** are entry points that re-export multiple modules (e.g., `index.js` that does `export * from './module'`).
+
+Popular icon and component libraries can have **up to 10,000 re-exports** in their entry file. For many React packages, **it takes 200-800ms just to import them**, affecting both development speed and production cold starts.
+
+**Why tree-shaking doesn't help:** When a library is marked as external (not bundled), the bundler can't optimize it. If you bundle it to enable tree-shaking, builds become substantially slower analyzing the entire module graph.
+
+**Incorrect (imports entire library):**
+
+```tsx
+import { Check, X, Menu } from 'lucide-react'
+// Loads 1,583 modules, takes ~2.8s extra in dev
+// Runtime cost: 200-800ms on every cold start
+
+import { Button, TextField } from '@mui/material'
+// Loads 2,225 modules, takes ~4.2s extra in dev
+```
+
+**Correct (imports only what you need):**
+
+```tsx
+import Check from 'lucide-react/dist/esm/icons/check'
+import X from 'lucide-react/dist/esm/icons/x'
+import Menu from 'lucide-react/dist/esm/icons/menu'
+// Loads only 3 modules (~2KB vs ~1MB)
+
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+// Loads only what you use
+```
+
+**Alternative (Next.js 13.5+):**
+
+```js
+// next.config.js - use optimizePackageImports
+module.exports = {
+  experimental: {
+    optimizePackageImports: ['lucide-react', '@mui/material']
+  }
+}
+
+// Then you can keep the ergonomic barrel imports:
+import { Check, X, Menu } from 'lucide-react'
+// Automatically transformed to direct imports at build time
+```
+
+Direct imports provide 15-70% faster dev boot, 28% faster builds, 40% faster cold starts, and significantly faster HMR.
+
+Libraries commonly affected: `lucide-react`, `@mui/material`, `@mui/icons-material`, `@tabler/icons-react`, `react-icons`, `@headlessui/react`, `@radix-ui/react-*`, `lodash`, `ramda`, `date-fns`, `rxjs`, `react-use`.
+
+Reference: [How we optimized package imports in Next.js](https://vercel.com/blog/how-we-optimized-package-imports-in-next-js)

--- a/devtools/skills/react-best-practices/references/rules/bundle-conditional.md
+++ b/devtools/skills/react-best-practices/references/rules/bundle-conditional.md
@@ -1,0 +1,31 @@
+---
+title: Conditional Module Loading
+impact: CRITICAL
+impactDescription: loads large data only when needed
+tags: bundle, conditional-loading, lazy-loading
+---
+
+## Conditional Module Loading
+
+Load large data or modules only when a feature is activated.
+
+**Example (lazy-load animation frames):**
+
+```tsx
+function AnimationPlayer({ enabled }: { enabled: boolean }) {
+  const [frames, setFrames] = useState<Frame[] | null>(null)
+
+  useEffect(() => {
+    if (enabled && !frames && typeof window !== 'undefined') {
+      import('./animation-frames.js')
+        .then(mod => setFrames(mod.frames))
+        .catch(() => setEnabled(false))
+    }
+  }, [enabled, frames])
+
+  if (!frames) return <Skeleton />
+  return <Canvas frames={frames} />
+}
+```
+
+The `typeof window !== 'undefined'` check prevents bundling this module for SSR, optimizing server bundle size and build speed.

--- a/devtools/skills/react-best-practices/references/rules/bundle-defer-third-party.md
+++ b/devtools/skills/react-best-practices/references/rules/bundle-defer-third-party.md
@@ -1,0 +1,49 @@
+---
+title: Defer Non-Critical Third-Party Libraries
+impact: CRITICAL
+impactDescription: loads after hydration
+tags: bundle, third-party, analytics, defer
+---
+
+## Defer Non-Critical Third-Party Libraries
+
+Analytics, logging, and error tracking don't block user interaction. Load them after hydration.
+
+**Incorrect (blocks initial bundle):**
+
+```tsx
+import { Analytics } from '@vercel/analytics/react'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <Analytics />
+      </body>
+    </html>
+  )
+}
+```
+
+**Correct (loads after hydration):**
+
+```tsx
+import dynamic from 'next/dynamic'
+
+const Analytics = dynamic(
+  () => import('@vercel/analytics/react').then(m => m.Analytics),
+  { ssr: false }
+)
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <Analytics />
+      </body>
+    </html>
+  )
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/bundle-dynamic-imports.md
+++ b/devtools/skills/react-best-practices/references/rules/bundle-dynamic-imports.md
@@ -1,0 +1,35 @@
+---
+title: Dynamic Imports for Heavy Components
+impact: CRITICAL
+impactDescription: directly affects TTI and LCP
+tags: bundle, dynamic-import, code-splitting, next-dynamic
+---
+
+## Dynamic Imports for Heavy Components
+
+Use `next/dynamic` to lazy-load large components not needed on initial render.
+
+**Incorrect (Monaco bundles with main chunk ~300KB):**
+
+```tsx
+import { MonacoEditor } from './monaco-editor'
+
+function CodePanel({ code }: { code: string }) {
+  return <MonacoEditor value={code} />
+}
+```
+
+**Correct (Monaco loads on demand):**
+
+```tsx
+import dynamic from 'next/dynamic'
+
+const MonacoEditor = dynamic(
+  () => import('./monaco-editor').then(m => m.MonacoEditor),
+  { ssr: false }
+)
+
+function CodePanel({ code }: { code: string }) {
+  return <MonacoEditor value={code} />
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/bundle-preload.md
+++ b/devtools/skills/react-best-practices/references/rules/bundle-preload.md
@@ -1,0 +1,50 @@
+---
+title: Preload Based on User Intent
+impact: CRITICAL
+impactDescription: reduces perceived latency
+tags: bundle, preload, user-intent, hover
+---
+
+## Preload Based on User Intent
+
+Preload heavy bundles before they're needed to reduce perceived latency.
+
+**Example (preload on hover/focus):**
+
+```tsx
+function EditorButton({ onClick }: { onClick: () => void }) {
+  const preload = () => {
+    if (typeof window !== 'undefined') {
+      void import('./monaco-editor')
+    }
+  }
+
+  return (
+    <button
+      onMouseEnter={preload}
+      onFocus={preload}
+      onClick={onClick}
+    >
+      Open Editor
+    </button>
+  )
+}
+```
+
+**Example (preload when feature flag is enabled):**
+
+```tsx
+function FlagsProvider({ children, flags }: Props) {
+  useEffect(() => {
+    if (flags.editorEnabled && typeof window !== 'undefined') {
+      void import('./monaco-editor').then(mod => mod.init())
+    }
+  }, [flags.editorEnabled])
+
+  return <FlagsContext.Provider value={flags}>
+    {children}
+  </FlagsContext.Provider>
+}
+```
+
+The `typeof window !== 'undefined'` check prevents bundling preloaded modules for SSR, optimizing server bundle size and build speed.

--- a/devtools/skills/react-best-practices/references/rules/client-event-listeners.md
+++ b/devtools/skills/react-best-practices/references/rules/client-event-listeners.md
@@ -1,0 +1,74 @@
+---
+title: Deduplicate Global Event Listeners
+impact: MEDIUM-HIGH
+impactDescription: single listener for N components
+tags: client, swr, event-listeners, subscription
+---
+
+## Deduplicate Global Event Listeners
+
+Use `useSWRSubscription()` to share global event listeners across component instances.
+
+**Incorrect (N instances = N listeners):**
+
+```tsx
+function useKeyboardShortcut(key: string, callback: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey && e.key === key) {
+        callback()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [key, callback])
+}
+```
+
+When using the `useKeyboardShortcut` hook multiple times, each instance will register a new listener.
+
+**Correct (N instances = 1 listener):**
+
+```tsx
+import useSWRSubscription from 'swr/subscription'
+
+// Module-level Map to track callbacks per key
+const keyCallbacks = new Map<string, Set<() => void>>()
+
+function useKeyboardShortcut(key: string, callback: () => void) {
+  // Register this callback in the Map
+  useEffect(() => {
+    if (!keyCallbacks.has(key)) {
+      keyCallbacks.set(key, new Set())
+    }
+    keyCallbacks.get(key)!.add(callback)
+
+    return () => {
+      const set = keyCallbacks.get(key)
+      if (set) {
+        set.delete(callback)
+        if (set.size === 0) {
+          keyCallbacks.delete(key)
+        }
+      }
+    }
+  }, [key, callback])
+
+  useSWRSubscription('global-keydown', () => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey && keyCallbacks.has(e.key)) {
+        keyCallbacks.get(e.key)!.forEach(cb => cb())
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }
+}
+
+function Profile() {
+  // Multiple shortcuts will share the same listener
+  useKeyboardShortcut('p', () => { /* ... */ }) 
+  useKeyboardShortcut('k', () => { /* ... */ })
+  // ...
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/client-swr-dedup.md
+++ b/devtools/skills/react-best-practices/references/rules/client-swr-dedup.md
@@ -1,0 +1,56 @@
+---
+title: Use SWR for Automatic Deduplication
+impact: MEDIUM-HIGH
+impactDescription: automatic deduplication
+tags: client, swr, deduplication, data-fetching
+---
+
+## Use SWR for Automatic Deduplication
+
+SWR enables request deduplication, caching, and revalidation across component instances.
+
+**Incorrect (no deduplication, each instance fetches):**
+
+```tsx
+function UserList() {
+  const [users, setUsers] = useState([])
+  useEffect(() => {
+    fetch('/api/users')
+      .then(r => r.json())
+      .then(setUsers)
+  }, [])
+}
+```
+
+**Correct (multiple instances share one request):**
+
+```tsx
+import useSWR from 'swr'
+
+function UserList() {
+  const { data: users } = useSWR('/api/users', fetcher)
+}
+```
+
+**For immutable data:**
+
+```tsx
+import { useImmutableSWR } from '@/lib/swr'
+
+function StaticContent() {
+  const { data } = useImmutableSWR('/api/config', fetcher)
+}
+```
+
+**For mutations:**
+
+```tsx
+import { useSWRMutation } from 'swr/mutation'
+
+function UpdateButton() {
+  const { trigger } = useSWRMutation('/api/user', updateUser)
+  return <button onClick={() => trigger()}>Update</button>
+}
+```
+
+Reference: [https://swr.vercel.app](https://swr.vercel.app)

--- a/devtools/skills/react-best-practices/references/rules/js-cache-function-results.md
+++ b/devtools/skills/react-best-practices/references/rules/js-cache-function-results.md
@@ -1,0 +1,80 @@
+---
+title: Cache Repeated Function Calls
+impact: MEDIUM-HIGH
+impactDescription: avoid redundant computation
+tags: javascript, cache, memoization, performance
+---
+
+## Cache Repeated Function Calls
+
+Use a module-level Map to cache function results when the same function is called repeatedly with the same inputs during render.
+
+**Incorrect (redundant computation):**
+
+```typescript
+function ProjectList({ projects }: { projects: Project[] }) {
+  return (
+    <div>
+      {projects.map(project => {
+        // slugify() called 100+ times for same project names
+        const slug = slugify(project.name)
+        
+        return <ProjectCard key={project.id} slug={slug} />
+      })}
+    </div>
+  )
+}
+```
+
+**Correct (cached results):**
+
+```typescript
+// Module-level cache
+const cachedSlugify = new Map<string, any>()
+
+function cachedSlugify(text: string): string {
+  if (cachedSlugify.has(text)) {
+    return cachedSlugify.get(text)
+  }
+  const result = slugify(text)
+  cachedSlugify.set(text, result)
+  return result
+}
+
+function ProjectList({ projects }: { projects: Project[] }) {
+  return (
+    <div>
+      {projects.map(project => {
+        // Computed only once per unique project name
+        const slug = cachedSlugify(project.name)
+        
+        return <ProjectCard key={project.id} slug={slug} />
+      })}
+    </div>
+  )
+}
+```
+
+**Simpler pattern for single-value functions:**
+
+```typescript
+let isLoggedInCache: boolean | null = null
+
+function isLoggedIn(): boolean {
+  if (isLoggedInCache !== null) {
+    return isLoggedInCache
+  }
+  
+  isLoggedInCache = document.cookie.includes('auth=')
+  return isLoggedInCache
+}
+
+// Clear cache when auth changes
+function onAuthChange() {
+  isLoggedInCache = null
+}
+```
+
+Use a Map (not a hook) so it works everywhere: utilities, event handlers, not just React components.
+
+Reference: [How we made the Vercel Dashboard twice as fast](https://vercel.com/blog/how-we-made-the-vercel-dashboard-twice-as-fast)

--- a/devtools/skills/react-best-practices/references/rules/js-cache-property-access.md
+++ b/devtools/skills/react-best-practices/references/rules/js-cache-property-access.md
@@ -1,0 +1,28 @@
+---
+title: Cache Property Access in Loops
+impact: LOW-MEDIUM
+impactDescription: reduces lookups
+tags: javascript, loops, optimization, caching
+---
+
+## Cache Property Access in Loops
+
+Cache object property lookups in hot paths.
+
+**Incorrect (3 lookups × N iterations):**
+
+```typescript
+for (let i = 0; i < arr.length; i++) {
+  process(obj.config.settings.value)
+}
+```
+
+**Correct (1 lookup total):**
+
+```typescript
+const value = obj.config.settings.value
+const len = arr.length
+for (let i = 0; i < len; i++) {
+  process(value)
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/js-cache-storage.md
+++ b/devtools/skills/react-best-practices/references/rules/js-cache-storage.md
@@ -1,0 +1,68 @@
+---
+title: Cache Storage API Calls
+impact: LOW-MEDIUM
+impactDescription: reduces expensive I/O
+tags: javascript, localStorage, storage, caching, performance
+---
+
+## Cache Storage API Calls
+
+`localStorage`, `sessionStorage`, and `document.cookie` are synchronous and expensive. Cache reads in memory.
+
+**Incorrect (reads storage on every call):**
+
+```typescript
+function getTheme() {
+  return localStorage.getItem('theme') ?? 'light'
+}
+// Called 10 times = 10 storage reads
+```
+
+**Correct (Map cache):**
+
+```typescript
+const storageCache = new Map<string, string | null>()
+
+function getLocalStorage(key: string) {
+  if (!storageCache.has(key)) {
+    storageCache.set(key, localStorage.getItem(key))
+  }
+  return storageCache.get(key)
+}
+
+function setLocalStorage(key: string, value: string) {
+  localStorage.setItem(key, value)
+  storageCache.set(key, value)  // keep cache in sync
+}
+```
+
+Use a Map (not a hook) so it works everywhere: utilities, event handlers, not just React components.
+
+**Cookie caching:**
+
+```typescript
+let cookieCache: Record<string, string> | null = null
+
+function getCookie(name: string) {
+  if (!cookieCache) {
+    cookieCache = Object.fromEntries(
+      document.cookie.split('; ').map(c => c.split('='))
+    )
+  }
+  return cookieCache[name]
+}
+```
+
+**Important:** If storage can change externally (another tab, server-set cookies), invalidate cache:
+
+```typescript
+window.addEventListener('storage', (e) => {
+  if (e.key) storageCache.delete(e.key)
+})
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    storageCache.clear()
+  }
+})
+```

--- a/devtools/skills/react-best-practices/references/rules/js-combine-iterations.md
+++ b/devtools/skills/react-best-practices/references/rules/js-combine-iterations.md
@@ -1,0 +1,32 @@
+---
+title: Combine Multiple Array Iterations
+impact: LOW-MEDIUM
+impactDescription: reduces iterations
+tags: javascript, arrays, loops, performance
+---
+
+## Combine Multiple Array Iterations
+
+Multiple `.filter()` or `.map()` calls iterate the array multiple times. Combine into one loop.
+
+**Incorrect (3 iterations):**
+
+```typescript
+const admins = users.filter(u => u.isAdmin)
+const testers = users.filter(u => u.isTester)
+const inactive = users.filter(u => !u.isActive)
+```
+
+**Correct (1 iteration):**
+
+```typescript
+const admins: User[] = []
+const testers: User[] = []
+const inactive: User[] = []
+
+for (const user of users) {
+  if (user.isAdmin) admins.push(user)
+  if (user.isTester) testers.push(user)
+  if (!user.isActive) inactive.push(user)
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/js-early-exit.md
+++ b/devtools/skills/react-best-practices/references/rules/js-early-exit.md
@@ -1,0 +1,50 @@
+---
+title: Early Return from Functions
+impact: LOW-MEDIUM
+impactDescription: avoids unnecessary computation
+tags: javascript, functions, optimization, early-return
+---
+
+## Early Return from Functions
+
+Return early when result is determined to skip unnecessary processing.
+
+**Incorrect (processes all items even after finding answer):**
+
+```typescript
+function validateUsers(users: User[]) {
+  let hasError = false
+  let errorMessage = ''
+  
+  for (const user of users) {
+    if (!user.email) {
+      hasError = true
+      errorMessage = 'Email required'
+    }
+    if (!user.name) {
+      hasError = true
+      errorMessage = 'Name required'
+    }
+    // Continues checking all users even after error found
+  }
+  
+  return hasError ? { valid: false, error: errorMessage } : { valid: true }
+}
+```
+
+**Correct (returns immediately on first error):**
+
+```typescript
+function validateUsers(users: User[]) {
+  for (const user of users) {
+    if (!user.email) {
+      return { valid: false, error: 'Email required' }
+    }
+    if (!user.name) {
+      return { valid: false, error: 'Name required' }
+    }
+  }
+  
+  return { valid: true }
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/js-hoist-regexp.md
+++ b/devtools/skills/react-best-practices/references/rules/js-hoist-regexp.md
@@ -1,0 +1,43 @@
+---
+title: Hoist RegExp Creation
+impact: LOW-MEDIUM
+impactDescription: avoids recreation
+tags: javascript, regexp, optimization, memoization
+---
+
+## Hoist RegExp Creation
+
+Don't create RegExp inside render. Hoist to module scope or memoize with `useMemo()`.
+
+**Incorrect (new RegExp every render):**
+
+```tsx
+function Highlighter({ text, query }: Props) {
+  const regex = new RegExp(`(${query})`, 'gi')
+  const parts = text.split(regex)
+  return <>{parts.map((part, i) => ...)}</>
+}
+```
+
+**Correct (memoize or hoist):**
+
+```tsx
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function Highlighter({ text, query }: Props) {
+  const regex = useMemo(
+    () => new RegExp(`(${escapeRegex(query)})`, 'gi'),
+    [query]
+  )
+  const parts = text.split(regex)
+  return <>{parts.map((part, i) => ...)}</>
+}
+```
+
+**Warning:** Global regex (`/g`) has mutable `lastIndex` state:
+
+```typescript
+const regex = /foo/g
+regex.test('foo')  // true, lastIndex = 3
+regex.test('foo')  // false, lastIndex = 0
+```

--- a/devtools/skills/react-best-practices/references/rules/js-index-maps.md
+++ b/devtools/skills/react-best-practices/references/rules/js-index-maps.md
@@ -1,0 +1,37 @@
+---
+title: Build Index Maps for Repeated Lookups
+impact: LOW-MEDIUM
+impactDescription: 1M ops to 2K ops
+tags: javascript, map, indexing, optimization, performance
+---
+
+## Build Index Maps for Repeated Lookups
+
+Multiple `.find()` calls by the same key should use a Map.
+
+**Incorrect (O(n) per lookup):**
+
+```typescript
+function processOrders(orders: Order[], users: User[]) {
+  return orders.map(order => ({
+    ...order,
+    user: users.find(u => u.id === order.userId)
+  }))
+}
+```
+
+**Correct (O(1) per lookup):**
+
+```typescript
+function processOrders(orders: Order[], users: User[]) {
+  const userById = new Map(users.map(u => [u.id, u]))
+
+  return orders.map(order => ({
+    ...order,
+    user: userById.get(order.userId)
+  }))
+}
+```
+
+Build map once (O(n)), then all lookups are O(1).
+For 1000 orders × 1000 users: 1M ops → 2K ops.

--- a/devtools/skills/react-best-practices/references/rules/js-set-map-lookups.md
+++ b/devtools/skills/react-best-practices/references/rules/js-set-map-lookups.md
@@ -1,0 +1,24 @@
+---
+title: Use Set/Map for O(1) Lookups
+impact: LOW-MEDIUM
+impactDescription: O(n) to O(1)
+tags: javascript, set, map, data-structures, performance
+---
+
+## Use Set/Map for O(1) Lookups
+
+Convert arrays to Set/Map for repeated membership checks.
+
+**Incorrect (O(n) per check):**
+
+```typescript
+const allowedIds = ['a', 'b', 'c', ...]
+items.filter(item => allowedIds.includes(item.id))
+```
+
+**Correct (O(1) per check):**
+
+```typescript
+const allowedIds = new Set(['a', 'b', 'c', ...])
+items.filter(item => allowedIds.has(item.id))
+```

--- a/devtools/skills/react-best-practices/references/rules/rendering-activity.md
+++ b/devtools/skills/react-best-practices/references/rules/rendering-activity.md
@@ -1,0 +1,26 @@
+---
+title: Use Activity Component for Show/Hide
+impact: MEDIUM
+impactDescription: preserves state/DOM
+tags: rendering, activity, visibility, state-preservation
+---
+
+## Use Activity Component for Show/Hide
+
+Use React's `<Activity>` to preserve state/DOM for expensive components that frequently toggle visibility.
+
+**Usage:**
+
+```tsx
+import { Activity } from 'react'
+
+function Dropdown({ isOpen }: Props) {
+  return (
+    <Activity mode={isOpen ? 'visible' : 'hidden'}>
+      <ExpensiveMenu />
+    </Activity>
+  )
+}
+```
+
+Avoids expensive re-renders and state loss.

--- a/devtools/skills/react-best-practices/references/rules/rendering-conditional-render.md
+++ b/devtools/skills/react-best-practices/references/rules/rendering-conditional-render.md
@@ -1,0 +1,40 @@
+---
+title: Use Explicit Conditional Rendering
+impact: MEDIUM
+impactDescription: prevents rendering 0 or NaN
+tags: rendering, conditional, jsx, falsy-values
+---
+
+## Use Explicit Conditional Rendering
+
+Use explicit ternary operators (`? :`) instead of `&&` for conditional rendering when the condition can be `0`, `NaN`, or other falsy values that render.
+
+**Incorrect (renders "0" when count is 0):**
+
+```tsx
+function Badge({ count }: { count: number }) {
+  return (
+    <div>
+      {count && <span className="badge">{count}</span>}
+    </div>
+  )
+}
+
+// When count = 0, renders: <div>0</div>
+// When count = 5, renders: <div><span class="badge">5</span></div>
+```
+
+**Correct (renders nothing when count is 0):**
+
+```tsx
+function Badge({ count }: { count: number }) {
+  return (
+    <div>
+      {count > 0 ? <span className="badge">{count}</span> : null}
+    </div>
+  )
+}
+
+// When count = 0, renders: <div></div>
+// When count = 5, renders: <div><span class="badge">5</span></div>
+```

--- a/devtools/skills/react-best-practices/references/rules/rendering-content-visibility.md
+++ b/devtools/skills/react-best-practices/references/rules/rendering-content-visibility.md
@@ -1,0 +1,38 @@
+---
+title: CSS content-visibility for Long Lists
+impact: MEDIUM
+impactDescription: 10× faster initial render
+tags: rendering, css, content-visibility, long-lists
+---
+
+## CSS content-visibility for Long Lists
+
+Apply `content-visibility: auto` to defer off-screen rendering.
+
+**CSS:**
+
+```css
+.message-item {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 80px;
+}
+```
+
+**Example:**
+
+```tsx
+function MessageList({ messages }: { messages: Message[] }) {
+  return (
+    <div className="overflow-y-auto h-screen">
+      {messages.map(msg => (
+        <div key={msg.id} className="message-item">
+          <Avatar user={msg.author} />
+          <div>{msg.content}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+For 1000 messages, browser skips layout/paint for ~990 off-screen items (10× faster initial render).

--- a/devtools/skills/react-best-practices/references/rules/rendering-hoist-jsx.md
+++ b/devtools/skills/react-best-practices/references/rules/rendering-hoist-jsx.md
@@ -1,0 +1,44 @@
+---
+title: Hoist Static JSX Elements
+impact: MEDIUM
+impactDescription: avoids re-creation
+tags: rendering, jsx, static, optimization
+---
+
+## Hoist Static JSX Elements
+
+Extract static JSX outside components to avoid re-creation.
+
+**Incorrect (recreates element every render):**
+
+```tsx
+function LoadingSkeleton() {
+  return <div className="animate-pulse h-20 bg-gray-200" />
+}
+
+function Container() {
+  return (
+    <div>
+      {loading && <LoadingSkeleton />}
+    </div>
+  )
+}
+```
+
+**Correct (reuses same element):**
+
+```tsx
+const loadingSkeleton = (
+  <div className="animate-pulse h-20 bg-gray-200" />
+)
+
+function Container() {
+  return (
+    <div>
+      {loading && loadingSkeleton}
+    </div>
+  )
+}
+```
+
+This is especially helpful for large and static SVG nodes, which can be expensive to recreate on every render.

--- a/devtools/skills/react-best-practices/references/rules/rendering-svg-precision.md
+++ b/devtools/skills/react-best-practices/references/rules/rendering-svg-precision.md
@@ -1,0 +1,28 @@
+---
+title: Optimize SVG Precision
+impact: MEDIUM
+impactDescription: reduces file size
+tags: rendering, svg, optimization, svgo
+---
+
+## Optimize SVG Precision
+
+Reduce SVG coordinate precision to decrease file size. The optimal precision depends on the viewBox size, but in general reducing precision should be considered.
+
+**Incorrect (excessive precision):**
+
+```svg
+<path d="M 10.293847 20.847362 L 30.938472 40.192837" />
+```
+
+**Correct (1 decimal place):**
+
+```svg
+<path d="M 10.3 20.8 L 30.9 40.2" />
+```
+
+**Automate with SVGO:**
+
+```bash
+npx svgo --precision=1 --multipass icon.svg
+```

--- a/devtools/skills/react-best-practices/references/rules/rerender-defer-reads.md
+++ b/devtools/skills/react-best-practices/references/rules/rerender-defer-reads.md
@@ -1,0 +1,39 @@
+---
+title: Defer State Reads to Usage Point
+impact: MEDIUM
+impactDescription: avoids unnecessary subscriptions
+tags: rerender, searchParams, localStorage, optimization
+---
+
+## Defer State Reads to Usage Point
+
+Don't subscribe to dynamic state (searchParams, localStorage) if you only read it inside callbacks.
+
+**Incorrect (subscribes to all searchParams changes):**
+
+```tsx
+function ShareButton({ chatId }: { chatId: string }) {
+  const searchParams = useSearchParams()
+
+  const handleShare = () => {
+    const ref = searchParams.get('ref')
+    shareChat(chatId, { ref })
+  }
+
+  return <button onClick={handleShare}>Share</button>
+}
+```
+
+**Correct (reads on demand, no subscription):**
+
+```tsx
+function ShareButton({ chatId }: { chatId: string }) {
+  const handleShare = () => {
+    const params = new URLSearchParams(window.location.search)
+    const ref = params.get('ref')
+    shareChat(chatId, { ref })
+  }
+
+  return <button onClick={handleShare}>Share</button>
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/rerender-dependencies.md
+++ b/devtools/skills/react-best-practices/references/rules/rerender-dependencies.md
@@ -1,0 +1,45 @@
+---
+title: Narrow Effect Dependencies
+impact: MEDIUM
+impactDescription: minimizes effect re-runs
+tags: rerender, useEffect, dependencies, optimization
+---
+
+## Narrow Effect Dependencies
+
+Specify primitive dependencies instead of objects to minimize effect re-runs.
+
+**Incorrect (re-runs on any user field change):**
+
+```tsx
+useEffect(() => {
+  console.log(user.id)
+}, [user])
+```
+
+**Correct (re-runs only when id changes):**
+
+```tsx
+useEffect(() => {
+  console.log(user.id)
+}, [user.id])
+```
+
+**For derived state, compute outside effect:**
+
+```tsx
+// Incorrect: runs on width=767, 766, 765...
+useEffect(() => {
+  if (width < 768) {
+    enableMobileMode()
+  }
+}, [width])
+
+// Correct: runs only on boolean transition
+const isMobile = width < 768
+useEffect(() => {
+  if (isMobile) {
+    enableMobileMode()
+  }
+}, [isMobile])
+```

--- a/devtools/skills/react-best-practices/references/rules/rerender-derived-state.md
+++ b/devtools/skills/react-best-practices/references/rules/rerender-derived-state.md
@@ -1,0 +1,29 @@
+---
+title: Subscribe to Derived State
+impact: MEDIUM
+impactDescription: reduces re-render frequency
+tags: rerender, derived-state, media-query, optimization
+---
+
+## Subscribe to Derived State
+
+Subscribe to derived boolean state instead of continuous values to reduce re-render frequency.
+
+**Incorrect (re-renders on every pixel change):**
+
+```tsx
+function Sidebar() {
+  const width = useWindowWidth()  // updates continuously
+  const isMobile = width < 768
+  return <nav className={isMobile ? 'mobile' : 'desktop'}>
+}
+```
+
+**Correct (re-renders only when boolean changes):**
+
+```tsx
+function Sidebar() {
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  return <nav className={isMobile ? 'mobile' : 'desktop'}>
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/rerender-lazy-state-init.md
+++ b/devtools/skills/react-best-practices/references/rules/rerender-lazy-state-init.md
@@ -1,0 +1,58 @@
+---
+title: Use Lazy State Initialization
+impact: MEDIUM
+impactDescription: wasted computation on every render
+tags: react, hooks, useState, performance, initialization
+---
+
+## Use Lazy State Initialization
+
+Pass a function to `useState` for expensive initial values. Without the function form, the initializer runs on every render even though the value is only used once.
+
+**Incorrect (runs on every render):**
+
+```tsx
+function FilteredList({ items }: { items: Item[] }) {
+  // buildSearchIndex() runs on EVERY render, even after initialization
+  const [searchIndex, setSearchIndex] = useState(buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
+  // When query changes, buildSearchIndex runs again unnecessarily
+  return <SearchResults index={searchIndex} query={query} />
+}
+
+function UserProfile() {
+  // JSON.parse runs on every render
+  const [settings, setSettings] = useState(
+    JSON.parse(localStorage.getItem('settings') || '{}')
+  )
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
+}
+```
+
+**Correct (runs only once):**
+
+```tsx
+function FilteredList({ items }: { items: Item[] }) {
+  // buildSearchIndex() runs ONLY on initial render
+  const [searchIndex, setSearchIndex] = useState(() => buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
+  return <SearchResults index={searchIndex} query={query} />
+}
+
+function UserProfile() {
+  // JSON.parse runs only on initial render
+  const [settings, setSettings] = useState(() => {
+    const stored = localStorage.getItem('settings')
+    return stored ? JSON.parse(stored) : {}
+  })
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
+}
+```
+
+Use lazy initialization when computing initial values from localStorage/sessionStorage, building data structures (indexes, maps), reading from the DOM, or performing heavy transformations.
+
+For simple primitives (`useState(0)`), direct references (`useState(props.value)`), or cheap literals (`useState({})`), the function form is unnecessary.

--- a/devtools/skills/react-best-practices/references/rules/rerender-memo.md
+++ b/devtools/skills/react-best-practices/references/rules/rerender-memo.md
@@ -1,0 +1,42 @@
+---
+title: Extract to Memoized Components
+impact: MEDIUM
+impactDescription: enables early returns
+tags: rerender, memo, useMemo, optimization
+---
+
+## Extract to Memoized Components
+
+Extract expensive work into memoized components to enable early returns before computation.
+
+**Incorrect (computes avatar even when loading):**
+
+```tsx
+function Profile({ user, loading }: Props) {
+  const avatar = useMemo(() => {
+    const id = computeAvatarId(user)
+    return <Avatar id={id} />
+  }, [user])
+
+  if (loading) return <Skeleton />
+  return <div>{avatar}</div>
+}
+```
+
+**Correct (skips computation when loading):**
+
+```tsx
+const UserAvatar = memo(function UserAvatar({ user }: { user: User }) {
+  const id = useMemo(() => computeAvatarId(user), [user])
+  return <Avatar id={id} />
+})
+
+function Profile({ user, loading }: Props) {
+  if (loading) return <Skeleton />
+  return (
+    <div>
+      <UserAvatar user={user} />
+    </div>
+  )
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/rerender-transitions.md
+++ b/devtools/skills/react-best-practices/references/rules/rerender-transitions.md
@@ -1,0 +1,40 @@
+---
+title: Use Transitions for Non-Urgent Updates
+impact: MEDIUM
+impactDescription: maintains UI responsiveness
+tags: rerender, transitions, startTransition, performance
+---
+
+## Use Transitions for Non-Urgent Updates
+
+Mark frequent, non-urgent state updates as transitions to maintain UI responsiveness.
+
+**Incorrect (blocks UI on every scroll):**
+
+```tsx
+function ScrollTracker() {
+  const [scrollY, setScrollY] = useState(0)
+  useEffect(() => {
+    const handler = () => setScrollY(window.scrollY)
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
+}
+```
+
+**Correct (non-blocking updates):**
+
+```tsx
+import { startTransition } from 'react'
+
+function ScrollTracker() {
+  const [scrollY, setScrollY] = useState(0)
+  useEffect(() => {
+    const handler = () => {
+      startTransition(() => setScrollY(window.scrollY))
+    }
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/server-cache-lru.md
+++ b/devtools/skills/react-best-practices/references/rules/server-cache-lru.md
@@ -1,0 +1,37 @@
+---
+title: Cross-Request LRU Caching
+impact: HIGH
+impactDescription: caches across requests
+tags: server, cache, lru, cross-request
+---
+
+## Cross-Request LRU Caching
+
+`React.cache()` only works within one request. For data shared across sequential requests (user clicks button A then button B), use an LRU cache.
+
+**Implementation:**
+
+```typescript
+import { LRUCache } from 'lru-cache'
+
+const cache = new LRUCache<string, any>({
+  max: 1000,
+  ttl: 5 * 60 * 1000  // 5 minutes
+})
+
+export async function getUser(id: string) {
+  const cached = cache.get(id)
+  if (cached) return cached
+
+  const user = await db.user.findUnique({ where: { id } })
+  cache.set(id, user)
+  return user
+}
+
+// Request 1: DB query, result cached
+// Request 2: cache hit, no DB query
+```
+
+Use when sequential user actions hit multiple endpoints needing the same data within seconds. In serverless, consider Redis for cross-process caching.
+
+Reference: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache)

--- a/devtools/skills/react-best-practices/references/rules/server-cache-react.md
+++ b/devtools/skills/react-best-practices/references/rules/server-cache-react.md
@@ -1,0 +1,26 @@
+---
+title: Per-Request Deduplication with React.cache()
+impact: HIGH
+impactDescription: deduplicates within request
+tags: server, cache, react-cache, deduplication
+---
+
+## Per-Request Deduplication with React.cache()
+
+Use `React.cache()` for server-side request deduplication. Authentication and database queries benefit most.
+
+**Usage:**
+
+```typescript
+import { cache } from 'react'
+
+export const getCurrentUser = cache(async () => {
+  const session = await auth()
+  if (!session?.user?.id) return null
+  return await db.user.findUnique({
+    where: { id: session.user.id }
+  })
+})
+```
+
+Within a single request, multiple calls to `getCurrentUser()` execute the query only once.

--- a/devtools/skills/react-best-practices/references/rules/server-parallel-fetching.md
+++ b/devtools/skills/react-best-practices/references/rules/server-parallel-fetching.md
@@ -1,0 +1,79 @@
+---
+title: Parallel Data Fetching with Component Composition
+impact: HIGH
+impactDescription: eliminates server-side waterfalls
+tags: server, rsc, parallel-fetching, composition
+---
+
+## Parallel Data Fetching with Component Composition
+
+React Server Components execute sequentially within a tree. Restructure with composition to parallelize data fetching.
+
+**Incorrect (Sidebar waits for Page's fetch to complete):**
+
+```tsx
+export default async function Page() {
+  const header = await fetchHeader()
+  return (
+    <div>
+      <div>{header}</div>
+      <Sidebar />
+    </div>
+  )
+}
+
+async function Sidebar() {
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
+}
+```
+
+**Correct (both fetch simultaneously):**
+
+```tsx
+async function Header() {
+  const data = await fetchHeader()
+  return <div>{data}</div>
+}
+
+async function Sidebar() {
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <Header />
+      <Sidebar />
+    </div>
+  )
+}
+```
+
+**Alternative with children prop:**
+
+```tsx
+async function Layout({ children }: { children: ReactNode }) {
+  const header = await fetchHeader()
+  return (
+    <div>
+      <div>{header}</div>
+      {children}
+    </div>
+  )
+}
+
+async function Sidebar() {
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
+}
+
+export default function Page() {
+  return (
+    <Layout>
+      <Sidebar />
+    </Layout>
+  )
+}
+```

--- a/devtools/skills/react-best-practices/references/rules/server-serialization.md
+++ b/devtools/skills/react-best-practices/references/rules/server-serialization.md
@@ -1,0 +1,38 @@
+---
+title: Minimize Serialization at RSC Boundaries
+impact: HIGH
+impactDescription: reduces data transfer size
+tags: server, rsc, serialization, props
+---
+
+## Minimize Serialization at RSC Boundaries
+
+The React Server/Client boundary serializes all object properties. Only pass fields that the client actually uses.
+
+**Incorrect (serializes all 50 fields):**
+
+```tsx
+async function Page() {
+  const user = await fetchUser()  // 50 fields
+  return <Profile user={user} />
+}
+
+'use client'
+function Profile({ user }: { user: User }) {
+  return <div>{user.name}</div>  // uses 1 field
+}
+```
+
+**Correct (serializes only 1 field):**
+
+```tsx
+async function Page() {
+  const user = await fetchUser()
+  return <Profile name={user.name} />
+}
+
+'use client'
+function Profile({ name }: { name: string }) {
+  return <div>{name}</div>
+}
+```

--- a/devtools/skills/react/SKILL.md
+++ b/devtools/skills/react/SKILL.md
@@ -163,6 +163,23 @@ export function MyComponent({
 
 </component_pattern>
 
+<related_skills>
+
+**Performance optimization:** Load via `Skill({ skill: "devtools:react-best-practices" })` when:
+
+- Optimizing React/Next.js bundle size
+- Eliminating data fetching waterfalls
+- Improving re-render performance
+- Using Suspense, `React.cache()`, or transitions
+
+**UI design audit:** Load via `Skill({ skill: "devtools:vercel-design-guidelines" })` when:
+
+- Reviewing UI for accessibility issues
+- Checking design compliance against best practices
+- Auditing interactions, animations, and layout
+
+</related_skills>
+
 <success_criteria>
 
 - [ ] Context7 docs fetched before implementation

--- a/devtools/skills/shadcn/SKILL.md
+++ b/devtools/skills/shadcn/SKILL.md
@@ -309,6 +309,22 @@ className={cn("base-class", isActive && "active")}
 </pitfall>
 </anti_patterns>
 
+<related_skills>
+
+**Design guidelines:** Load via `Skill({ skill: "devtools:vercel-design-guidelines" })` when:
+
+- Auditing UI for accessibility compliance
+- Checking interactions, animations, and form design
+- Reviewing copywriting and content patterns
+
+**Design system:** Load via `Skill({ skill: "devtools:design-principles" })` when:
+
+- Setting up design direction and color foundations
+- Establishing spacing, typography, and depth strategies
+- Building consistent card layouts and navigation
+
+</related_skills>
+
 <success_criteria>
 
 - [ ] shadcn MCP server used for component discovery/installation

--- a/devtools/skills/tanstack-start/SKILL.md
+++ b/devtools/skills/tanstack-start/SKILL.md
@@ -241,6 +241,21 @@ src/
 - Catch-all: `[...].tsx`
   </constraints>
 
+<related_skills>
+
+**React performance:** Load via `Skill({ skill: "devtools:react-best-practices" })` when:
+
+- Optimizing data loading and eliminating waterfalls
+- Implementing efficient Suspense boundaries
+- Reducing re-renders and bundle size
+
+**TanStack Query:** Load via `Skill({ skill: "devtools:react" })` for TanStack Query patterns when:
+
+- Setting up query client and cache configuration
+- Implementing mutations and optimistic updates
+
+</related_skills>
+
 <success_criteria>
 
 - [ ] Context7 docs fetched for current API

--- a/devtools/skills/vercel-design-guidelines/SKILL.md
+++ b/devtools/skills/vercel-design-guidelines/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: vercel-design-guidelines
+description: Check web interfaces against Vercel's design guidelines. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", "check my site against best practices", or "apply Vercel design guidelines".
+---
+
+# Vercel Design Guidelines
+
+Review web interfaces against Vercel's comprehensive design guidelines and propose fixes.
+
+## How It Works
+
+1. Read the user's code (components, CSS, HTML)
+2. Check against Vercel design guidelines (interactions, animations, layout, content, forms, performance, design, copywriting)
+3. Report violations with specific line references
+4. Propose concrete fixes with code examples
+
+## Usage
+
+When a user asks to review their UI or check against design guidelines:
+
+1. Fetch the live guidelines from `https://vercel.com/design/guidelines`
+2. Read the relevant source files (components, styles, HTML)
+3. Analyze the code against each applicable guideline category
+4. Report findings grouped by category with severity
+
+**Guidelines URL:** https://vercel.com/design/guidelines
+
+Always fetch fresh guidelines to ensure you're checking against the latest standards.
+
+## Audit Categories
+
+- **Interactions**: Keyboard accessibility, focus management, hit targets, loading states, URL persistence
+- **Animations**: Reduced motion, GPU acceleration, easing, interruptibility
+- **Layout**: Optical adjustment, alignment, responsive testing, safe areas
+- **Content**: Inline help, skeletons, empty states, typography, accessibility
+- **Forms**: Labels, validation, autocomplete, error handling, submit behavior
+- **Performance**: Re-renders, layout thrashing, virtualization, preloading
+- **Design**: Shadows, borders, radii, contrast, color accessibility
+- **Copywriting**: Active voice, title case, clarity, error messaging
+
+## Output Format
+
+Present findings as:
+
+```
+## {Category} Issues
+
+### {Severity}: {Guideline Name}
+**File:** `path/to/file.tsx:42`
+**Issue:** {Description of the violation}
+**Guideline:** {Brief guideline reference}
+**Fix:**
+```{language}
+{Proposed code fix}
+```
+```
+
+Severity levels:
+- **Critical**: Accessibility violations, broken functionality
+- **Warning**: UX issues, performance concerns
+- **Suggestion**: Polish, best practices
+
+## Example Review
+
+```
+## Interactions Issues
+
+### Critical: Keyboard Accessibility
+**File:** `components/Modal.tsx:28`
+**Issue:** Modal lacks focus trap - keyboard users can tab outside
+**Guideline:** Implement focus traps per WAI-ARIA patterns
+**Fix:**
+```tsx
+// Add focus trap using @radix-ui/react-focus-guards or similar
+import { FocusScope } from '@radix-ui/react-focus-scope';
+
+<FocusScope trapped>
+  <ModalContent>{children}</ModalContent>
+</FocusScope>
+```
+
+### Warning: Loading State Duration
+**File:** `components/Button.tsx:15`
+**Issue:** No minimum loading duration - causes flicker on fast responses
+**Guideline:** Add 150-300ms delay and 300-500ms minimum visibility
+**Fix:**
+```tsx
+const [isLoading, setIsLoading] = useState(false);
+const minimumLoadingTime = 300;
+
+async function handleClick() {
+  setIsLoading(true);
+  const start = Date.now();
+  await action();
+  const elapsed = Date.now() - start;
+  if (elapsed < minimumLoadingTime) {
+    await new Promise(r => setTimeout(r, minimumLoadingTime - elapsed));
+  }
+  setIsLoading(false);
+}
+```
+```
+
+## Quick Checklist
+
+For rapid reviews, check these high-impact items first:
+
+- [ ] All interactive elements keyboard accessible
+- [ ] Visible focus rings on focusable elements
+- [ ] Hit targets ≥24px (44px on mobile)
+- [ ] Form inputs have associated labels
+- [ ] Loading states don't flicker
+- [ ] `prefers-reduced-motion` respected
+- [ ] No `transition: all`
+- [ ] Errors show how to fix, not just what's wrong
+- [ ] Color contrast meets APCA standards
+- [ ] No zoom disabled
+
+## Present Results to User
+
+After reviewing:
+
+```
+# Design Guidelines Audit
+
+Reviewed {N} files against Vercel design guidelines.
+
+## Summary
+- Critical: {N} issues
+- Warning: {N} issues
+- Suggestions: {N} items
+
+{Detailed findings by category}
+
+## Recommended Priority
+1. {First critical fix}
+2. {Second critical fix}
+...
+```


### PR DESCRIPTION
## Summary

Add two new skills for React/Next.js performance optimization and UI/UX design audits. Integrate these skills throughout the codebase to incentivize their use by orchestrator commands and worker agents.

**New skills:**
- `devtools:react-best-practices` - Performance patterns, bundle optimization, data fetching
- `devtools:vercel-design-guidelines` - UI/UX audit, accessibility, interaction patterns

## Integrations

### 1. Worker Preambles (30 skills total)
Expanded skill loading sections in orchestrator commands with ALL 30 skills organized by domain:

**crew:plan.md** - Research phase worker preamble
- 8 Frontend skills
- 2 Design skills
- 3 Testing skills
- 6 Backend/API skills
- 3 Blockchain skills
- 4 DevOps skills
- 4 Crew skills

**crew:work.md** - Implementation phase worker preamble + review agents
- Same 30 skills in tabular format for easy reference
- Updated all review agents to load relevant skills
- Added dedicated UI/UX Review agent (Phase 5)

### 2. Related Skills Sections
Added `<related_skills>` sections to 7 skills with proper Skill() format:
- `devtools:react` → references react-best-practices, vercel-design-guidelines
- `devtools:design-principles` → references react-best-practices, vercel-design-guidelines
- `devtools:shadcn` → references vercel-design-guidelines, design-principles
- `devtools:radix` → references vercel-design-guidelines, design-principles
- `devtools:motion` → references vercel-design-guidelines, design-principles
- `devtools:tanstack-start` → references react-best-practices
- `devtools:playwright` → references vercel-design-guidelines, design-principles

### 3. Pre-Tool Hooks
Added skill suggestion hooks for Next.js workflows:
- `devtools/scripts/hooks/pre-tool/suggest-skill.sh` - Suggest react-best-practices for Next.js builds and component creation
- `crew/scripts/hooks/pre-tool/suggest-skill.sh` - Same triggers for crew commands

### 4. Documentation
Updated `CLAUDE.md` with mandatory Skill() reference format to ensure all skill mentions use executable format.

## Changes

- **56 files modified** with skill integrations
- **2 files added** - New skills with comprehensive documentation
- **Version bumps**: crew 3.13.0 → 3.14.0, devtools 1.22.0 → 1.23.0

## Test Plan

- [ ] Verify all 30 skills are listed in crew:plan worker preamble
- [ ] Verify all 30 skills are listed in crew:work worker preamble
- [ ] Check that pre-tool hooks trigger for Next.js commands
- [ ] Verify Skill() format references work with /crew:plan and /crew:work
- [ ] Confirm new skills load correctly via Skill() tool


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two devtools skills for React/Next.js performance and Vercel design audits, and integrates them into crew commands, related skills, and pre-tool hooks to guide usage. Standardizes Skill() references in docs and bumps plugin versions.

- **New Features**
  - New skills: devtools:react-best-practices and devtools:vercel-design-guidelines.
  - Expanded crew:plan and crew:work preambles to load 30 skills; added a UI/UX Review agent.
  - Linked <related_skills> across react, design-principles, shadcn, radix, motion, tanstack-start, and playwright.
  - Pre-tool hooks suggest react-best-practices for Next.js builds and component generation.
  - CLAUDE.md updated with mandatory Skill({ skill: "..." }) reference format.

- **Dependencies**
  - crew: 3.13.0 → 3.14.0
  - devtools: 1.22.0 → 1.23.0

<sup>Written for commit aaf11258805e32be89caa71772656fcc88803454. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

