### PR TITLE
docs(setup): add one-line bash installer and fix PyYAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ SettleMint development tools for Claude Code.
 
 ## Installation
 
+**One-line setup (recommended):**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/settlemint/agent-marketplace/main/setup.sh | bash
+```
+
+This installs all dependencies (jq, gh, shfmt, shellcheck, ast-grep), configures marketplaces, and installs the full plugin suite including Trail of Bits security plugins.
+
 **Interactive (inside Claude Code):**
 
 ```bash

--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/setup.sh
+++ b/setup.sh
@@ -307,10 +307,10 @@ echo ""
 
 echo "Python packages:"
 info "Installing PyYAML..."
-if pip3 install --quiet PyYAML; then
+if pip3 install --user --quiet PyYAML 2>/dev/null || pip3 install --quiet PyYAML 2>/dev/null; then
   success "PyYAML installed"
 else
-  warn "PyYAML install failed"
+  warn "PyYAML install failed (try: pip3 install --user PyYAML)"
 fi
 echo ""
 


### PR DESCRIPTION
Add curl-based installation method to README for quick setup of the agent marketplace. Fixes PEP 668 externally-managed Python environment issues on modern macOS.

- One-line bash installer via curl for initial setup
- Handle --user flag for pip in PEP 668 compliant systems
- Fallback to standard install if user install unavailable
- Update flow plugin version for documentation improvement

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a one-line curl installer and fixed PyYAML installation for PEP 668 environments to make setup fast and reliable on modern macOS.

- **New Features**
  - One-line installer via curl that installs jq, gh, shfmt, shellcheck, ast-grep, configures marketplaces, and sets up the full plugin suite (including Trail of Bits).

- **Bug Fixes**
  - PyYAML install now uses pip3 --user with a fallback to standard install, fixing failures in externally managed Python environments.

<sup>Written for commit cb61703297ce3741524c2e3dade82f64a57303ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

