### PR TITLE
Auto-generate session learnings and capture corrections

### DIFF
--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/hooks/hooks.json
+++ b/flow/hooks/hooks.json
@@ -55,6 +55,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/user-prompt-submit/analyze-intent.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/user-prompt-submit/capture-correction.sh"
           }
         ]
       }

--- a/flow/scripts/hooks/lib/common.sh
+++ b/flow/scripts/hooks/lib/common.sh
@@ -32,89 +32,90 @@ COLOR_ERROR="\033[31m" # Red
 # --- Logging Functions ---
 
 # Initialize logging (call after setting SCRIPT_NAME)
+# Note: Per-hook directories are created lazily on first log write
 log_init() {
-	mkdir -p "$FLOW_LOG_DIR" 2>/dev/null || true
-	# Create per-hook log directory if SCRIPT_NAME is set
-	if [[ -n "$SCRIPT_NAME" && "$SCRIPT_NAME" != "unknown" ]]; then
-		mkdir -p "$FLOW_LOG_DIR/hooks/$SCRIPT_NAME" 2>/dev/null || true
-	fi
+  mkdir -p "$FLOW_LOG_DIR" 2>/dev/null || true
+  # Per-hook directories now created lazily in _log() to avoid empty folders
 }
 
 # Get current ISO 8601 timestamp
 _timestamp() {
-	date -u +"%Y-%m-%dT%H:%M:%SZ"
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
 # Get today's date for log file rotation
 _today() {
-	date -u +"%Y-%m-%d"
+  date -u +"%Y-%m-%d"
 }
 
 # Core log function
 # Usage: _log LEVEL "message" [key=value ...]
 _log() {
-	local level=$1
-	shift
-	local message=$1
-	shift
+  local level=$1
+  shift
+  local message=$1
+  shift
 
-	local color=""
-	local prefix=""
+  local color=""
+  local prefix=""
 
-	case $level in
-	DEBUG)
-		[[ $FLOW_LOG_LEVEL -gt $LOG_DEBUG ]] && return
-		color=$COLOR_DEBUG
-		prefix="DEBUG"
-		;;
-	INFO)
-		[[ $FLOW_LOG_LEVEL -gt $LOG_INFO ]] && return
-		color=$COLOR_INFO
-		prefix="INFO"
-		;;
-	WARN)
-		[[ $FLOW_LOG_LEVEL -gt $LOG_WARN ]] && return
-		color=$COLOR_WARN
-		prefix="WARN"
-		;;
-	ERROR)
-		color=$COLOR_ERROR
-		prefix="ERROR"
-		;;
-	*)
-		prefix="INFO"
-		color=$COLOR_INFO
-		;;
-	esac
+  case $level in
+    DEBUG)
+      [[ $FLOW_LOG_LEVEL -gt $LOG_DEBUG ]] && return
+      color=$COLOR_DEBUG
+      prefix="DEBUG"
+      ;;
+    INFO)
+      [[ $FLOW_LOG_LEVEL -gt $LOG_INFO ]] && return
+      color=$COLOR_INFO
+      prefix="INFO"
+      ;;
+    WARN)
+      [[ $FLOW_LOG_LEVEL -gt $LOG_WARN ]] && return
+      color=$COLOR_WARN
+      prefix="WARN"
+      ;;
+    ERROR)
+      color=$COLOR_ERROR
+      prefix="ERROR"
+      ;;
+    *)
+      prefix="INFO"
+      color=$COLOR_INFO
+      ;;
+  esac
 
-	local timestamp
-	timestamp=$(_timestamp)
+  local timestamp
+  timestamp=$(_timestamp)
 
-	# Build log entry with key=value pairs
-	local log_entry="[$timestamp] $prefix script=$SCRIPT_NAME"
-	if [[ -n "$message" ]]; then
-		log_entry="$log_entry $message"
-	fi
-	# Append any additional key=value pairs
-	while [[ $# -gt 0 ]]; do
-		log_entry="$log_entry $1"
-		shift
-	done
+  # Build log entry with key=value pairs
+  local log_entry="[$timestamp] $prefix script=$SCRIPT_NAME"
+  if [[ -n "$message" ]]; then
+    log_entry="$log_entry $message"
+  fi
+  # Append any additional key=value pairs
+  while [[ $# -gt 0 ]]; do
+    log_entry="$log_entry $1"
+    shift
+  done
 
-	# Write to combined log file
-	echo "$log_entry" >>"$FLOW_LOG_FILE" 2>/dev/null || true
+  # Write to combined log file
+  echo "$log_entry" >>"$FLOW_LOG_FILE" 2>/dev/null || true
 
-	# Write to per-hook daily log file
-	if [[ -n "$SCRIPT_NAME" && "$SCRIPT_NAME" != "unknown" ]]; then
-		local hook_log
-		hook_log="$FLOW_LOG_DIR/hooks/$SCRIPT_NAME/$(_today).log"
-		echo "$log_entry" >>"$hook_log" 2>/dev/null || true
-	fi
+  # Write to per-hook daily log file (lazy directory creation)
+  if [[ -n "$SCRIPT_NAME" && "$SCRIPT_NAME" != "unknown" ]]; then
+    local hook_dir="$FLOW_LOG_DIR/hooks/$SCRIPT_NAME"
+    local hook_log
+    hook_log="$hook_dir/$(_today).log"
+    # Create directory only when we have something to write
+    mkdir -p "$hook_dir" 2>/dev/null || true
+    echo "$log_entry" >>"$hook_log" 2>/dev/null || true
+  fi
 
-	# Also output to stderr with colors (for terminal visibility during debugging)
-	if [[ "${FLOW_LOG_STDERR:-}" == "1" ]]; then
-		echo -e "${color}[Flow:${prefix}:${SCRIPT_NAME}]${COLOR_RESET} $message $*" >&2
-	fi
+  # Also output to stderr with colors (for terminal visibility during debugging)
+  if [[ "${FLOW_LOG_STDERR:-}" == "1" ]]; then
+    echo -e "${color}[Flow:${prefix}:${SCRIPT_NAME}]${COLOR_RESET} $message $*" >&2
+  fi
 }
 
 # Convenience functions
@@ -126,48 +127,48 @@ log_error() { _log ERROR "$@"; }
 # Structured event logging (matches enhance-agent.sh pattern)
 # Usage: log_event STATUS "key=value" ...
 log_event() {
-	local status=$1
-	shift
-	_log INFO "event=$status" "$@"
+  local status=$1
+  shift
+  _log INFO "event=$status" "$@"
 }
 
 # --- Utility Functions ---
 
 # Check if a command exists
 has_command() {
-	command -v "$1" &>/dev/null
+  command -v "$1" &>/dev/null
 }
 
 # Safe JSON extraction with jq (returns empty string on failure)
 json_get() {
-	local input=$1
-	local path=$2
-	echo "$input" | jq -r "$path // \"\"" 2>/dev/null || echo ""
+  local input=$1
+  local path=$2
+  echo "$input" | jq -r "$path // \"\"" 2>/dev/null || echo ""
 }
 
 # Get session ID (for deduplication markers)
 get_session_id() {
-	echo "${CLAUDE_SESSION_ID:-$$}"
+  echo "${CLAUDE_SESSION_ID:-$$}"
 }
 
 # Check if a session marker exists (for once-per-session hints)
 session_marker_exists() {
-	local marker_name=$1
-	local session_id
-	session_id=$(get_session_id)
-	local marker_file="$PROJECT_DIR/.claude/flow/hooks/.${marker_name}-${session_id}"
-	[[ -f "$marker_file" ]]
+  local marker_name=$1
+  local session_id
+  session_id=$(get_session_id)
+  local marker_file="$PROJECT_DIR/.claude/flow/hooks/.${marker_name}-${session_id}"
+  [[ -f "$marker_file" ]]
 }
 
 # Create a session marker
 create_session_marker() {
-	local marker_name=$1
-	local session_id
-	session_id=$(get_session_id)
-	local marker_dir="$PROJECT_DIR/.claude/flow/hooks"
-	local marker_file="$marker_dir/.${marker_name}-${session_id}"
-	mkdir -p "$marker_dir" 2>/dev/null || true
-	touch "$marker_file" 2>/dev/null || true
+  local marker_name=$1
+  local session_id
+  session_id=$(get_session_id)
+  local marker_dir="$PROJECT_DIR/.claude/flow/hooks"
+  local marker_file="$marker_dir/.${marker_name}-${session_id}"
+  mkdir -p "$marker_dir" 2>/dev/null || true
+  touch "$marker_file" 2>/dev/null || true
 }
 
 # --- Skill Activation Logging ---
@@ -177,47 +178,47 @@ create_session_marker() {
 SKILL_ACTIVATION_LOG="$PROJECT_DIR/.claude/flow/skill-activations.jsonl"
 
 log_skill_activation() {
-	local skill="$1"
-	local trigger="$2"
-	local prompt="$3"
-	local source="$4"
-	shift 4
+  local skill="$1"
+  local trigger="$2"
+  local prompt="$3"
+  local source="$4"
+  shift 4
 
-	# Collect extra key=value args into JSON object
-	local extra_json="{}"
-	while [[ $# -gt 0 ]]; do
-		local kv="$1"
-		local key="${kv%%=*}"
-		local value="${kv#*=}"
-		extra_json=$(echo "$extra_json" | jq --arg k "$key" --arg v "$value" '. + {($k): $v}' 2>/dev/null || echo "$extra_json")
-		shift
-	done
+  # Collect extra key=value args into JSON object
+  local extra_json="{}"
+  while [[ $# -gt 0 ]]; do
+    local kv="$1"
+    local key="${kv%%=*}"
+    local value="${kv#*=}"
+    extra_json=$(echo "$extra_json" | jq --arg k "$key" --arg v "$value" '. + {($k): $v}' 2>/dev/null || echo "$extra_json")
+    shift
+  done
 
-	# Truncate prompt to 200 chars for storage efficiency
-	local prompt_excerpt="${prompt:0:200}"
-	[[ ${#prompt} -gt 200 ]] && prompt_excerpt="${prompt_excerpt}..."
+  # Truncate prompt to 200 chars for storage efficiency
+  local prompt_excerpt="${prompt:0:200}"
+  [[ ${#prompt} -gt 200 ]] && prompt_excerpt="${prompt_excerpt}..."
 
-	local timestamp
-	timestamp=$(_timestamp)
+  local timestamp
+  timestamp=$(_timestamp)
 
-	local session_id
-	session_id=$(get_session_id)
+  local session_id
+  session_id=$(get_session_id)
 
-	local branch
-	branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
-	# Build JSON entry with extra metadata
-	local entry
-	entry=$(jq -n \
-		--arg ts "$timestamp" \
-		--arg session "$session_id" \
-		--arg branch "$branch" \
-		--arg skill "$skill" \
-		--arg trigger "$trigger" \
-		--arg prompt "$prompt_excerpt" \
-		--arg source "$source" \
-		--argjson extra "$extra_json" \
-		'{
+  # Build JSON entry with extra metadata
+  local entry
+  entry=$(jq -n \
+    --arg ts "$timestamp" \
+    --arg session "$session_id" \
+    --arg branch "$branch" \
+    --arg skill "$skill" \
+    --arg trigger "$trigger" \
+    --arg prompt "$prompt_excerpt" \
+    --arg source "$source" \
+    --argjson extra "$extra_json" \
+    '{
 			timestamp: $ts,
 			session_id: $session,
 			branch: $branch,
@@ -228,10 +229,57 @@ log_skill_activation() {
 			metadata: $extra
 		}' 2>/dev/null)
 
-	# Append to JSONL file
-	mkdir -p "$(dirname "$SKILL_ACTIVATION_LOG")" 2>/dev/null || true
-	echo "$entry" >>"$SKILL_ACTIVATION_LOG" 2>/dev/null || true
+  # Append to JSONL file
+  mkdir -p "$(dirname "$SKILL_ACTIVATION_LOG")" 2>/dev/null || true
+  echo "$entry" >>"$SKILL_ACTIVATION_LOG" 2>/dev/null || true
 
-	# Also log to standard flow log for immediate visibility
-	log_info "event=SKILL_ACTIVATED" "skill=$skill" "trigger=$trigger" "source=$source"
+  # Also log to standard flow log for immediate visibility
+  log_info "event=SKILL_ACTIVATED" "skill=$skill" "trigger=$trigger" "source=$source"
+}
+
+# --- Correction Logging ---
+# Logs user corrections/direction changes for learning extraction
+# Usage: log_correction "detected_pattern" "full_prompt"
+
+CORRECTION_LOG="$PROJECT_DIR/.claude/flow/corrections.jsonl"
+
+log_correction() {
+  local pattern="$1"
+  local prompt="$2"
+
+  # Truncate prompt to 500 chars for storage efficiency
+  local prompt_excerpt="${prompt:0:500}"
+  [[ ${#prompt} -gt 500 ]] && prompt_excerpt="${prompt_excerpt}..."
+
+  local timestamp
+  timestamp=$(_timestamp)
+
+  local session_id
+  session_id=$(get_session_id)
+
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+  # Build JSON entry
+  local entry
+  entry=$(jq -n \
+    --arg ts "$timestamp" \
+    --arg session "$session_id" \
+    --arg branch "$branch" \
+    --arg pattern "$pattern" \
+    --arg prompt "$prompt_excerpt" \
+    '{
+			timestamp: $ts,
+			session_id: $session,
+			branch: $branch,
+			correction_pattern: $pattern,
+			prompt_excerpt: $prompt
+		}' 2>/dev/null)
+
+  # Append to JSONL file
+  mkdir -p "$(dirname "$CORRECTION_LOG")" 2>/dev/null || true
+  echo "$entry" >>"$CORRECTION_LOG" 2>/dev/null || true
+
+  # Also log to standard flow log for immediate visibility
+  log_info "event=CORRECTION_DETECTED" "pattern=$pattern"
 }

--- a/flow/scripts/hooks/user-prompt-submit/capture-correction.sh
+++ b/flow/scripts/hooks/user-prompt-submit/capture-correction.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Capture user correction patterns for learning extraction
+# Runs on: UserPromptSubmit
+# Silent auto-logging - captures direction changes without interrupting flow
+
+# Hooks must never fail
+set +e
+
+# --- Logging setup ---
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME="capture-correction"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+log_init
+
+# Read prompt from stdin
+PROMPT_DATA=$(cat)
+PROMPT=$(echo "$PROMPT_DATA" | jq -r '.prompt // ""' 2>/dev/null || echo "")
+
+# Skip empty prompts
+if [[ -z "$PROMPT" ]]; then
+  exit 0
+fi
+
+# Convert to lowercase for pattern matching
+PROMPT_LOWER="${PROMPT,,}"
+
+# Correction patterns - signals user is redirecting Claude
+# These indicate a change in direction that should be captured as a learning
+CORRECTION_PATTERNS=(
+  # Direct negations
+  "^no[,.]"
+  "^no "
+  "^nope"
+  "^wrong"
+  "^that's not"
+  "^that is not"
+  "^not what i"
+  "^not like that"
+  # Redirection signals
+  "actually[,]"
+  "instead[,]"
+  "different approach"
+  "different way"
+  "try something else"
+  "let's try"
+  "let me clarify"
+  "what i meant"
+  "i meant"
+  "i want you to"
+  # Cancellation signals
+  "stop doing"
+  "don't do that"
+  "don't continue"
+  "scratch that"
+  "forget that"
+  "never mind"
+  "nevermind"
+  "cancel that"
+  # Explicit corrections
+  "you should have"
+  "you were supposed"
+  "that was wrong"
+  "not correct"
+  "incorrect"
+)
+
+# Check for correction patterns
+DETECTED_PATTERN=""
+for pattern in "${CORRECTION_PATTERNS[@]}"; do
+  if [[ "$PROMPT_LOWER" =~ $pattern ]]; then
+    DETECTED_PATTERN="$pattern"
+    break
+  fi
+done
+
+# If no correction detected, exit silently
+if [[ -z "$DETECTED_PATTERN" ]]; then
+  exit 0
+fi
+
+# Log the correction
+log_correction "$DETECTED_PATTERN" "$PROMPT"
+
+exit 0


### PR DESCRIPTION
# User description
## Summary

This PR adds automatic session learning extraction and user correction tracking to the flow plugin. Instead of prompting Claude to write learnings, the retrospective now auto-generates structured markdown files based on logged corrections and errors. A new capture-correction hook silently tracks user direction changes without interrupting workflow.

## Changes

- Add `capture-correction.sh` hook to detect and log user correction patterns
- New `log_correction()` function in common.sh for structured correction tracking
- Session retrospective now auto-generates learnings markdown from logs
- Skip trivial sessions with minimal activity
- Reformat shell scripts for consistency (2-space indents)
- Bump flow plugin to v1.22.0

## Test Plan

- Verify capture-correction hook detects common correction patterns without noise
- Check session-retrospective generates accurate learnings files at session end
- Ensure trivial sessions are skipped (no corrections/errors, few skills)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Automates the generation of session learning reports by tracking user correction patterns and session activity through a new hook and structured logging. Replaces the manual retrospective prompt with an auto-generated markdown summary that captures direction changes, errors, and skill usage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/145?tool=ast&topic=Correction+Tracking>Correction Tracking</a>
        </td><td>Introduces <code>capture-correction.sh</code> and <code>log_correction</code> to identify and store user redirection patterns from prompts, while updating <code>common.sh</code> with lazy directory creation for more efficient logging.<details><summary>Modified files (3)</summary><ul><li>flow/hooks/hooks.json</li>
<li>flow/scripts/hooks/lib/common.sh</li>
<li>flow/scripts/hooks/user-prompt-submit/capture-correction.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>fix-feedback-141</td><td>January 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/145?tool=ast&topic=Auto-Retrospective>Auto-Retrospective</a>
        </td><td>Updates <code>session-retrospective.sh</code> to automatically generate markdown reports from session logs, including logic to skip trivial sessions and provide actionable insights based on detected patterns.<details><summary>Modified files (2)</summary><ul><li>flow/.claude-plugin/plugin.json</li>
<li>flow/scripts/hooks/stop/session-retrospective.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>feat-devtools-add-git-...</td><td>January 15, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/145?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-generates session learnings from logs and silently captures user corrections to improve retrospectives with no extra prompts. The stop hook now writes a structured markdown file and skips trivial sessions.

- **New Features**
  - Auto-generate learnings markdown at session end using corrections, errors, and skill activation logs.
  - Add capture-correction hook on UserPromptSubmit to log direction changes without interrupting the flow.
  - New log_correction() in common.sh writes structured entries to corrections.jsonl.
  - Skip trivial sessions (no corrections/errors and few skills).

- **Refactors**
  - Switched session-retrospective to log-driven generation and added a brief end-of-session summary.
  - Centralized logging updates (lazy per-hook log directories) and standardized scripts to 2-space indents.
  - Hook wiring added in hooks.json; plugin version bumped to v1.22.0.

<sup>Written for commit 91a04b5d7faaedd7e3eb808076eda51c554392e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

