### PR TITLE
feat(flow): add commands for fix-pr-reviews and init-enhanced

### DIFF
--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.22.0",
+  "version": "1.24.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/commands/fix-pr-reviews.md
+++ b/flow/commands/fix-pr-reviews.md
@@ -1,0 +1,18 @@
+---
+description: Fix all unresolved PR review comments and CI failures
+argument-hint: [PR number, defaults to current branch PR]
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Glob, Grep
+---
+
+Fix all unresolved PR review comments and CI failures following the fix-pr-reviews skill guidelines.
+
+## Current State
+- Branch: !`git branch --show-current`
+- Status: !`git status --short`
+- PR: !`gh pr view --json number,url,title 2>/dev/null | jq -r '"\(.number): \(.title)"' || echo "No PR found"`
+
+## Instructions
+
+Load Skill({ skill: "flow:fix-pr-reviews" })
+
+PR number: $ARGUMENTS

--- a/flow/commands/init.md
+++ b/flow/commands/init.md
@@ -1,0 +1,18 @@
+---
+description: Deep codebase analysis with progressive disclosure docs
+argument-hint: [--incremental for updates only]
+allowed-tools: Bash(git:*), Read, Write, Edit, Glob, Grep, Task
+---
+
+Generate modular documentation in `.claude/docs/` following the init-enhanced skill guidelines.
+
+## Current State
+- Branch: !`git branch --show-current`
+- Docs exist: !`test -d .claude/docs && echo "yes" || echo "no"`
+- Meta: !`cat .claude/docs/.meta.json 2>/dev/null | jq -r '.generated // "none"' || echo "none"`
+
+## Instructions
+
+Load Skill({ skill: "flow:init-enhanced" })
+
+Arguments: $ARGUMENTS


### PR DESCRIPTION
# User description
Add command files for flow plugin skills following the devtools pattern. Creates flow/commands/fix-pr-reviews.md and flow/commands/init.md that load the respective skills.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduces new command definitions for the flow plugin to automate PR review fixes and codebase initialization. Updates the plugin version to 1.24.0 to reflect these additions to the workflow automation suite.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>Auto-generate-session-...</td><td>January 16, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/146?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two Flow commands that load the fix-pr-reviews and init-enhanced skills and show current repo state (branch, status, PR/docs) before running. Streamlines PR cleanup and docs generation; bumps plugin version to 1.24.0.

<sup>Written for commit 49739b457e30bf19847d4870248a4225d12619ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

