### PR TITLE
fix(flow): use POSIX-compatible lowercase conversion in capture-correction hook

### DIFF
--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/scripts/hooks/user-prompt-submit/capture-correction.sh
+++ b/flow/scripts/hooks/user-prompt-submit/capture-correction.sh
@@ -22,8 +22,8 @@ if [[ -z "$PROMPT" ]]; then
   exit 0
 fi
 
-# Convert to lowercase for pattern matching
-PROMPT_LOWER="${PROMPT,,}"
+# Convert to lowercase for pattern matching (POSIX-compatible)
+PROMPT_LOWER=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]')
 
 # Correction patterns - signals user is redirecting Claude
 # These indicate a change in direction that should be captured as a learning


### PR DESCRIPTION
# User description
## Summary

Fixes UserPromptSubmit hook error when using slash commands like `/devtools:commit`.

## Root cause

The `capture-correction.sh` script used `${PROMPT,,}` (Bash 4+ syntax) for lowercase string conversion. This syntax fails on older Bash versions or when the script runs in a different shell environment, causing the hook to error out.

## The fix

Replaced `${PROMPT,,}` with `$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]')` which is POSIX-compatible and works across all shell environments. This matches the approach already used in `analyze-intent.sh`.

## How to reproduce (before)

1. Run `/devtools:commit` or any slash command
2. Observe "UserPromptSubmit hook error" message

## How to verify (after)

1. Run `/devtools:commit` or any slash command
2. No hook error should appear
3. Command executes normally

## Risk assessment

**Low** - This is a straightforward syntax change that makes the script more portable. The functionality remains identical, just using a POSIX-compatible method.

## Checklist

- [x] Identified root cause (not just symptoms)
- [x] Verified fix with manual testing
- [x] Checked for similar issues in other scripts (analyze-intent.sh already uses the correct approach)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>UserPromptSubmit</code> hook to use POSIX-compatible string conversion and increments the plugin version to 1.25.1. Ensures that slash commands like <code>/devtools:commit</code> execute without errors across different shell environments by replacing Bash-specific syntax with <code>tr</code>.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/148?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the UserPromptSubmit hook error when running slash commands by switching to POSIX-compatible lowercase conversion in capture-correction.sh. This makes the hook reliable across different shells and older Bash versions.

- **Bug Fixes**
  - Replaced Bash-specific `${PROMPT,,}` with `tr '[:upper:]' '[:lower:]'` for lowercase conversion.
  - Bumped plugin version to 1.25.1.

<sup>Written for commit 0615508ae92bb3044c4ae6492b420ce499563029. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

