### PR TITLE
feat(devtools): add PR auto-update on push

### DIFF
--- a/devtools/.claude-plugin/plugin.json
+++ b/devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devtools",
   "description": "Modern development tools for React, APIs, blockchain, databases, and testing. MCP-first skills with Context7 integration for up-to-date documentation.",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "author": {
     "name": "SettleMint",
     "email": "support@settlemint.com"

--- a/devtools/commands/pr-update.md
+++ b/devtools/commands/pr-update.md
@@ -1,0 +1,19 @@
+---
+description: Update PR title and body from commits
+argument-hint: [PR number, defaults to current branch PR]
+allowed-tools: Bash(git:*,gh:*)
+---
+
+Update PR title and body to match current commits.
+
+## Current State
+- Branch: !`git branch --show-current`
+- PR: !`gh pr view --json number,title -q '"\(.number): \(.title)"' 2>/dev/null || echo "No PR"`
+
+## Instructions
+
+Load Skill({ skill: "devtools:git" })
+
+Then read and follow `workflows/pr-update.md`.
+
+User message: $ARGUMENTS

--- a/devtools/skills/git/SKILL.md
+++ b/devtools/skills/git/SKILL.md
@@ -35,6 +35,10 @@ triggers:
   - "resolve comment"
   - "pr feedback"
   - "conventional commit"
+  - "update pr"
+  - "sync pr"
+  - "refresh pr"
+  - "pr sync"
 ---
 
 <objective>
@@ -56,6 +60,7 @@ Route git tasks to the appropriate workflow. Handles commits, branches, PRs, pus
 | Create commit | `workflows/commit.md` | `/commit` |
 | Create branch | `workflows/branch-create.md` | `/branch` |
 | Create PR | `workflows/pr-create.md` | `/pr` |
+| Update PR | `workflows/pr-update.md` | `/pr-update` |
 | Push to remote | `workflows/push.md` | `/push` |
 | Sync with main | `workflows/sync.md` | `/sync` |
 | Fix PR reviews | `workflows/pr-fix-reviews.md` | `/fix-pr-reviews` |
@@ -69,6 +74,7 @@ Route git tasks to the appropriate workflow. Handles commits, branches, PRs, pus
 - "commit changes" / "save work" → Read `workflows/commit.md`
 - "create branch" / "new feature" → Read `workflows/branch-create.md`
 - "create PR" / "submit for review" → Read `workflows/pr-create.md`
+- "update pr" / "sync pr" / "refresh pr" → Read `workflows/pr-update.md`
 - "push" / "upload commits" → Read `workflows/push.md`
 - "sync" / "merge main" / "rebase" → Read `workflows/sync.md`
 - "fix pr" / "address review" / "resolve comments" → Read `workflows/pr-fix-reviews.md`

--- a/devtools/skills/git/workflows/pr-update.md
+++ b/devtools/skills/git/workflows/pr-update.md
@@ -1,0 +1,172 @@
+---
+name: pr-update
+description: Update PR title and body from commits
+---
+
+<context>
+!`${SKILL_ROOT}/scripts/context.sh pr`
+</context>
+
+<objective>
+Update existing PR title and body to reflect all commits. Automatically called after push.
+</objective>
+
+<workflow>
+
+## Step 1: Validate PR
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null)
+```
+
+If no PR found → exit with message "No PR for current branch. Use /pr to create one."
+
+## Step 2: Gather Context
+
+```bash
+# Get base branch
+BASE=$(gh pr view --json baseRefName -q '.baseRefName')
+
+# Get all commit messages since divergence
+git log origin/${BASE}..HEAD --pretty=format:"%s"
+
+# Get commit count
+COMMIT_COUNT=$(git rev-list origin/${BASE}..HEAD --count)
+
+# Check for plan files
+ls .claude/plans/*.md 2>/dev/null
+```
+
+## Step 3: Generate Title
+
+**Rules:**
+
+- Single commit → use commit message verbatim
+- Multiple commits → `type(scope): summary` with most significant type
+
+**Type priority (most → least significant):**
+
+1. `feat` - new features
+2. `fix` - bug fixes
+3. `refactor` - code restructuring
+4. `docs` - documentation
+5. `chore` - maintenance
+
+**Example:**
+
+```
+# Single commit
+"feat(api): add user authentication"
+
+# Multiple commits (2 feat, 1 fix, 1 docs)
+"feat(api): user authentication and rate limiting"
+```
+
+## Step 4: Generate Body
+
+**Select template based on primary commit type:**
+
+| Commit Type | Template |
+|-------------|----------|
+| feat | `templates/pr-feature.md` |
+| fix | `templates/pr-fix.md` |
+| refactor, docs, chore, test | `templates/pr-refactor.md` |
+| other | `templates/pr-body.md` |
+
+**Gather content for placeholders:**
+
+```bash
+# Summary from commits
+git log origin/${BASE}..HEAD --oneline
+
+# Diff stats
+git diff --stat origin/${BASE}
+
+# Plan file content (if exists)
+PLAN=$(ls -t .claude/plans/*.md 2>/dev/null | head -1)
+```
+
+**Extract from plan file (if exists):**
+
+- `MOTIVATION` - from problem/motivation section
+- `DESIGN_DECISIONS` - from approach/considerations section
+- `TEST_PLAN` - from test criteria section
+
+**Fill template placeholders and remove HTML comments.**
+
+## Step 5: Update PR
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number')
+
+# Update title
+gh pr edit $PR_NUM --title "type(scope): description"
+
+# Update body (use HEREDOC for proper formatting)
+gh pr edit $PR_NUM --body "$(cat <<'EOF'
+## Summary
+
+...filled content...
+
+## Why
+
+...filled content...
+EOF
+)"
+```
+
+</workflow>
+
+<commands>
+
+```bash
+# Check if PR exists
+gh pr view --json number -q '.number' 2>/dev/null
+
+# Get base branch
+gh pr view --json baseRefName -q '.baseRefName'
+
+# Get commits since base
+git log origin/main..HEAD --pretty=format:"%s"
+git log origin/main..HEAD --oneline
+
+# Get diff stats
+git diff --stat origin/main
+
+# Update PR title
+gh pr edit $PR_NUM --title "feat(scope): description"
+
+# Update PR body
+gh pr edit $PR_NUM --body "$(cat <<'EOF'
+## Summary
+...
+EOF
+)"
+```
+
+</commands>
+
+<constraints>
+
+**Banned:**
+
+- Updating PR on main/master branch
+- Empty or generic titles like "Update" or "Changes"
+- Removing existing PR description entirely
+
+**Required:**
+
+- Conventional commit format for title
+- Template-based body generation
+- Preserve any manually added sections at end of body
+
+</constraints>
+
+<success_criteria>
+
+- [ ] PR exists for current branch
+- [ ] Title reflects primary commit type and scope
+- [ ] Body generated from appropriate template
+- [ ] Plan context included (if plan file exists)
+
+</success_criteria>

--- a/devtools/skills/git/workflows/push.md
+++ b/devtools/skills/git/workflows/push.md
@@ -81,11 +81,29 @@ In multi-Claude environments:
 
 </constraints>
 
+<pr_update>
+
+## Step 5: Update PR (if exists)
+
+After successful push, check if a PR exists and update it:
+
+```bash
+# Check if PR exists for current branch
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null)
+```
+
+If PR exists → read and follow `workflows/pr-update.md` to sync title/body with commits.
+
+If no PR → skip (user can create one with `/pr`).
+
+</pr_update>
+
 <success_criteria>
 
 - [ ] QA passed (if context showed "Stale")
 - [ ] Not pushing to protected branch
 - [ ] Using `-u` flag for new branches
 - [ ] Using `--force-with-lease` (not `--force`) if rebased
+- [ ] PR updated (if exists)
 
 </success_criteria>


### PR DESCRIPTION
# User description
## Summary

Add functionality to automatically update PR title and body after every push, reflecting all commits. This brings back the behavior from the old crew plugin where pushing would sync the PR state with the current commits.

## Why

The old `crew` plugin had functionality where pushing commits would automatically update the PR title and description to reflect all commits. This was removed during the consolidation into `devtools`. Users relied on this to keep PRs accurate as work progressed.

## Design decisions

- **Automatic on push**: PR update triggers automatically after every successful push (like old crew plugin behavior)
- **Standalone command available**: Users can also manually run `/pr-update` to refresh PR at any time
- **Template-based body generation**: Uses same template selection logic as pr-create (feat/fix/refactor templates)
- **Graceful handling**: If no PR exists, push proceeds normally without error

## What changed

- `devtools/skills/git/workflows/pr-update.md` - New workflow for updating PR title/body
- `devtools/skills/git/workflows/push.md` - Added Step 5 to trigger pr-update after push
- `devtools/skills/git/SKILL.md` - Added routing, triggers, and decision tree entry
- `devtools/commands/pr-update.md` - New `/pr-update` command
- `devtools/.claude-plugin/plugin.json` - Version 1.43.0 → 1.44.0

## How to test

1. On a branch with existing PR:
   - Run `/push` → verify PR title/body updated
   - Run `/pr-update` → verify PR title/body updated
2. On a branch without PR:
   - Run `/push` → verify it pushes without error
   - Run `/pr-update` → verify graceful exit message
3. Test with different commit types (feat, fix, refactor) to verify template selection

## Checklist

- [x] Self-reviewed the diff
- [ ] Added or updated tests
- [x] Ran `bun run ci` locally (no ci script configured)
- [x] No console.log or debug code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements an automated workflow to synchronize Pull Request titles and descriptions with the latest commits after every push. Introduces the <code>/pr-update</code> command and integrates it into the standard push process to ensure PR metadata remains accurate and template-aligned.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/149?tool=ast&topic=PR+Update+Logic>PR Update Logic</a>
        </td><td>Defines the logic for generating PR titles and bodies based on commit history and predefined templates, including a new <code>/pr-update</code> command.<details><summary>Modified files (3)</summary><ul><li>devtools/.claude-plugin/plugin.json</li>
<li>devtools/commands/pr-update.md</li>
<li>devtools/skills/git/workflows/pr-update.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>chore-setup-remove-una...</td><td>January 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/149?tool=ast&topic=Workflow+Integration>Workflow Integration</a>
        </td><td>Integrates the PR update workflow into the existing git skill routing and the standard push sequence.<details><summary>Modified files (2)</summary><ul><li>devtools/skills/git/SKILL.md</li>
<li>devtools/skills/git/workflows/push.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>chore-setup-remove-una...</td><td>January 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/149?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically syncs PR titles and bodies with the latest commits after each push. Adds a manual /pr-update command and template-based generation for clear, consistent PRs.

- **New Features**
  - Auto-update runs after a successful push; skips cleanly if no PR exists.
  - New pr-update workflow and /pr-update command for manual sync.
  - Title follows conventional commits; body uses templates (feat, fix, refactor) and includes plan context when available.
  - Updated git skill routing/triggers; push workflow now calls pr-update.

<sup>Written for commit bb242fc5dcec90d15d092883a8e4b2d39d3ac073. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

