### PR TITLE
feat(hooks): enforce CI before task completion

### DIFF
--- a/devtools/.claude-plugin/plugin.json
+++ b/devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devtools",
   "description": "Modern development tools for React, APIs, blockchain, databases, and testing. MCP-first skills with Context7 integration for up-to-date documentation.",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "author": {
     "name": "SettleMint",
     "email": "support@settlemint.com"

--- a/devtools/hooks/hooks.json
+++ b/devtools/hooks/hooks.json
@@ -22,6 +22,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/suggest-skill.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/ci-gate.sh"
           }
         ]
       }

--- a/devtools/scripts/hooks/pre-tool/ci-gate.sh
+++ b/devtools/scripts/hooks/pre-tool/ci-gate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# CI gate for git push/commit operations
+# Warns (non-blocking) when CI is stale and code changes are being pushed
+
+set +e
+
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME="ci-gate"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+log_init
+
+is_truthy() {
+  case "${1:-}" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+QUIET="${CLAUDE_QUIET:-${DEVTOOLS_QUIET:-}}"
+
+# Allow opt-out
+if is_truthy "$QUIET"; then
+  exit 0
+fi
+
+# Read tool input
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# Only check git push and git commit commands
+if [[ "$COMMAND" != *"git push"* ]] && [[ "$COMMAND" != *"git commit"* ]]; then
+  exit 0
+fi
+
+# --- Paths ---
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+QA_FILE="$PROJECT_DIR/.claude/state/qa-timestamp"
+
+# --- Session deduplication (warn only once per session) ---
+SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
+MARKER_DIR="$PROJECT_DIR/.claude/devtools/hooks"
+MARKER="$MARKER_DIR/.ci-gate-warned-${SESSION_ID}"
+
+if [[ -f "$MARKER" ]]; then
+  exit 0
+fi
+
+# --- Check if changes include code files ---
+CODE_PATTERNS='\.(ts|tsx|js|jsx|py|go|rs|java|c|cpp|h|hpp|rb|php|swift|kt)$'
+DOCS_ONLY=true
+
+# For commits, check staged files
+if [[ "$COMMAND" == *"git commit"* ]]; then
+  if git -C "$PROJECT_DIR" diff --cached --name-only 2>/dev/null | grep -qE "$CODE_PATTERNS"; then
+    DOCS_ONLY=false
+  fi
+fi
+
+# For pushes, check commits ahead of remote
+if [[ "$COMMAND" == *"git push"* ]]; then
+  BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "HEAD")
+  if git -C "$PROJECT_DIR" log "origin/${BRANCH}..HEAD" --name-only --oneline 2>/dev/null | grep -qE "$CODE_PATTERNS"; then
+    DOCS_ONLY=false
+  fi
+fi
+
+# Skip warning for docs-only changes
+if [[ "$DOCS_ONLY" == "true" ]]; then
+  log_info "event=CI_GATE_SKIP" "reason=docs_only"
+  exit 0
+fi
+
+# --- Check CI freshness ---
+if [[ ! -f "$QA_FILE" ]]; then
+  log_warn "event=CI_GATE_WARN" "reason=no_qa_file"
+  mkdir -p "$MARKER_DIR" 2>/dev/null
+  touch "$MARKER" 2>/dev/null
+  jq -n '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "message": "CI status: Unknown - no .claude/state/qa-timestamp found. Run `bun run ci` to verify code health before pushing."
+    }
+  }'
+  exit 0
+fi
+
+LAST_QA=$(cat "$QA_FILE")
+NOW=$(date +%s)
+AGE=$((NOW - LAST_QA))
+
+if [[ $AGE -gt 300 ]]; then
+  log_warn "event=CI_GATE_WARN" "reason=stale" "age=${AGE}s"
+  mkdir -p "$MARKER_DIR" 2>/dev/null
+  touch "$MARKER" 2>/dev/null
+  jq -n --arg age "${AGE}s" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "message": ("CI status: Stale (" + $age + " ago). Run `bun run ci` before pushing code changes. Skip for docs/config only.")
+    }
+  }'
+fi
+
+exit 0

--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/hooks/hooks.json
+++ b/flow/hooks/hooks.json
@@ -69,6 +69,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/stop/session-retrospective.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/stop/ci-freshness-check.sh"
           }
         ]
       }

--- a/flow/scripts/hooks/stop/ci-freshness-check.sh
+++ b/flow/scripts/hooks/stop/ci-freshness-check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# CI freshness check at session end
+# Warns if CI is stale and code changes were made
+
+set +e
+
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME="ci-freshness-check"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+log_init
+
+# Read event data
+EVENT_DATA=$(cat)
+
+# Skip for subagents
+AGENT_TYPE=$(echo "$EVENT_DATA" | jq -r '.agent_type // "main"' 2>/dev/null || echo "main")
+if [[ "$AGENT_TYPE" != "main" ]]; then
+  exit 0
+fi
+
+# --- Paths ---
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+QA_FILE="$PROJECT_DIR/.claude/state/qa-timestamp"
+
+# --- Check for code changes in this session ---
+HAS_CODE_CHANGES=false
+CODE_PATTERNS='\.(ts|tsx|js|jsx|py|go|rs|java|c|cpp|h|hpp|rb|php|swift|kt)$'
+
+# Check staged/unstaged changes
+if git -C "$PROJECT_DIR" diff --name-only 2>/dev/null | grep -qE "$CODE_PATTERNS"; then
+  HAS_CODE_CHANGES=true
+fi
+if git -C "$PROJECT_DIR" diff --cached --name-only 2>/dev/null | grep -qE "$CODE_PATTERNS"; then
+  HAS_CODE_CHANGES=true
+fi
+
+# --- Check CI freshness ---
+CI_STATUS="unknown"
+CI_AGE=""
+
+if [[ -f "$QA_FILE" ]]; then
+  LAST_QA=$(cat "$QA_FILE")
+  NOW=$(date +%s)
+  AGE=$((NOW - LAST_QA))
+  CI_AGE="${AGE}s"
+
+  if [[ $AGE -lt 300 ]]; then
+    CI_STATUS="fresh"
+  else
+    CI_STATUS="stale"
+  fi
+else
+  CI_STATUS="missing"
+fi
+
+# --- Output based on status ---
+log_info "event=CI_CHECK" "status=$CI_STATUS" "age=$CI_AGE" "code_changes=$HAS_CODE_CHANGES"
+
+echo ""
+echo "<flow-ci-status>"
+
+case "$CI_STATUS" in
+  "fresh")
+    echo "CI: Fresh (${CI_AGE} ago) - ready to push"
+    ;;
+  "stale")
+    if [[ "$HAS_CODE_CHANGES" == "true" ]]; then
+      echo "CI: STALE (${CI_AGE} ago) - run \`bun run ci\` before pushing code changes"
+      echo "Update timestamp: mkdir -p .claude/state && date +%s > .claude/state/qa-timestamp"
+    else
+      echo "CI: Stale (${CI_AGE} ago) - no code changes detected, OK to skip"
+    fi
+    ;;
+  "missing")
+    if [[ "$HAS_CODE_CHANGES" == "true" ]]; then
+      echo "CI: No baseline - run \`bun run ci\` to establish CI health"
+    else
+      echo "CI: No baseline recorded"
+    fi
+    ;;
+esac
+
+echo "</flow-ci-status>"
+
+exit 0

--- a/flow/skills/enhance/general-purpose/SKILL.md
+++ b/flow/skills/enhance/general-purpose/SKILL.md
@@ -73,13 +73,14 @@ Before declaring completion, ask:
 
 **30-Second Reality Check (MANDATORY)**
 
-Before declaring ANY task complete, answer these 5 questions. If ANY answer is NO, the task is NOT complete:
+Before declaring ANY task complete, answer these 6 questions. If ANY answer is NO, the task is NOT complete:
 
 - [ ] Did I run/build the code?
 - [ ] Did I trigger the exact feature I changed?
 - [ ] Did I see the expected result with my own observation?
 - [ ] Did I check for error messages or warnings?
 - [ ] Would I bet $100 this works?
+- [ ] **Is CI fresh?** (for code changes, run `bun run ci` if stale)
 
 **Verification by task type:**
 
@@ -337,9 +338,10 @@ Before writing ANY implementation code:
 - [ ] Each pass documented its findings
 - [ ] Final output shows improvement from initial
 - [ ] Convergence explicitly declared
-- [ ] 30-second reality check passed (all 5 questions = YES)
+- [ ] 30-second reality check passed (all 6 questions = YES)
 - [ ] Evidence provided (command run, output observed)
 - [ ] No "should work" language - only observed facts
+- [ ] **CI is fresh** (for code changes - run `bun run ci` before pushing)
 
 </success_criteria>
 


### PR DESCRIPTION
# User description
## Summary

Add CI freshness enforcement hooks to ensure `bun run ci` is consistently run before tasks are considered done when the devtools/flow plugins are enabled in other projects.

## Why

When the plugins are enabled in consumer projects, `bun run ci` was not being consistently run before tasks were marked complete. This led to CI failures being discovered after push rather than during development.

## Design decisions

**Multi-pronged approach** for robust coverage:
1. **Stop Hook** - Session-end reminder catches tasks that skip CI
2. **PreToolUse Hook** - Warns on git push/commit with stale CI (action-time)
3. **Reality Check Enhancement** - Adds CI to the mandatory 6-question checklist

**Non-blocking warnings** - Hooks warn but don't block, allowing docs-only commits without friction.

**Session deduplication** - Warnings show once per session to avoid noise.

**Code-only triggers** - Both hooks detect code file patterns and skip for docs/config-only changes.

## What changed

**flow plugin (v1.26.0):**
- `flow/scripts/hooks/stop/ci-freshness-check.sh` - New Stop hook
- `flow/hooks/hooks.json` - Register ci-freshness-check
- `flow/skills/enhance/general-purpose/SKILL.md` - Add CI to reality check

**devtools plugin (v1.45.0):**
- `devtools/scripts/hooks/pre-tool/ci-gate.sh` - New PreToolUse hook
- `devtools/hooks/hooks.json` - Register ci-gate

## How to test

1. Install plugins in a test project with `bun run ci` defined
2. Edit a TypeScript file
3. End session → verify stale CI warning appears
4. Run `bun run ci && mkdir -p .claude/state && date +%s > .claude/state/qa-timestamp`
5. End session → verify fresh CI status
6. Try `git push` with stale CI → verify warning
7. Try `git push` after CI → no warning

## Checklist

- [x] Self-reviewed the diff
- [x] Shell scripts pass shellcheck (expected warnings only)
- [x] JSON files validated
- [x] No console.log or debug code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduces CI freshness enforcement hooks and documentation updates to ensure <code>bun run ci</code> is executed before task completion. These changes implement non-blocking warnings during session termination and git operations to prevent pushing stale code.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/150?tool=ast&topic=Process+Enforcement>Process Enforcement</a>
        </td><td>Update the mandatory reality check in <code>SKILL.md</code> to include CI freshness as a requirement for declaring tasks complete.<details><summary>Modified files (1)</summary><ul><li>flow/skills/enhance/general-purpose/SKILL.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>refactor-consolidate-p...</td><td>January 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/150?tool=ast&topic=Automated+CI+Hooks>Automated CI Hooks</a>
        </td><td>Implement <code>ci-gate.sh</code> and <code>ci-freshness-check.sh</code> to monitor CI status via <code>.claude/state/qa-timestamp</code> and warn users during git commands or session ends.<details><summary>Modified files (6)</summary><ul><li>devtools/.claude-plugin/plugin.json</li>
<li>devtools/hooks/hooks.json</li>
<li>devtools/scripts/hooks/pre-tool/ci-gate.sh</li>
<li>flow/.claude-plugin/plugin.json</li>
<li>flow/hooks/hooks.json</li>
<li>flow/scripts/hooks/stop/ci-freshness-check.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>feat-devtools-add-PR-a...</td><td>January 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/150?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces CI freshness before marking tasks done and before git push/commit, prompting developers to run `bun run ci` when stale. This reduces post-push CI failures in projects using the devtools/flow plugins.

- **New Features**
  - Stop hook (flow): end-of-session CI freshness check; warns only if code changes
  - PreToolUse hook (devtools): warns on `git commit`/`git push` when CI is stale
  - Non-blocking warnings, deduped per session; skips docs/config-only changes
  - CI freshness source: `.claude/state/qa-timestamp` with a 5-minute freshness window
  - Reality Check updated: “Is CI fresh?” added as the 6th mandatory question
  - Versions bumped: devtools 1.45.0, flow 1.26.0

<sup>Written for commit 475708661525b029e2947d389748216a8d834bcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

