### PR TITLE
fix(flow): use case-insensitive agent type matching in enhance-agent hook

### DIFF
--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/scripts/hooks/pre-tool/enhance-agent.sh
+++ b/flow/scripts/hooks/pre-tool/enhance-agent.sh
@@ -27,14 +27,17 @@ INPUT=$(cat)
 read -r TOOL_NAME SUBAGENT_TYPE < <(echo "$INPUT" | jq -r '[.tool_name // "", .tool_input.subagent_type // ""] | @tsv' 2>/dev/null)
 TASK_PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // ""' 2>/dev/null)
 
+# Convert to lowercase for comparison and path lookup (Claude uses "Explore", "Plan")
+SUBAGENT_TYPE=$(echo "$SUBAGENT_TYPE" | tr '[:upper:]' '[:lower:]')
+
 # Only process Task tool
 if [[ "$TOOL_NAME" != "Task" ]]; then
-	exit 0
+  exit 0
 fi
 
 # Skip if no subagent_type
 if [[ -z "$SUBAGENT_TYPE" ]]; then
-	exit 0
+  exit 0
 fi
 
 # --- Setup paths ---
@@ -48,10 +51,10 @@ source "$LIB_DIR/skill-matcher.sh"
 # --- Check if this is a target agent for flow enhancement ---
 IS_TARGET=false
 for agent in $TARGET_AGENTS; do
-	if [[ "$SUBAGENT_TYPE" == "$agent" ]]; then
-		IS_TARGET=true
-		break
-	fi
+  if [[ "$SUBAGENT_TYPE" == "$agent" ]]; then
+    IS_TARGET=true
+    break
+  fi
 done
 
 # --- Collect skills to inject ---
@@ -59,38 +62,38 @@ SKILLS_TO_INJECT=""
 
 # 1. Flow enhancement skill (for target agents)
 if [[ "$IS_TARGET" == "true" ]]; then
-	SKILL_PATH="$PLUGIN_ROOT/skills/enhance/$SUBAGENT_TYPE/SKILL.md"
-	SKILL_NAME="flow:enhance:$SUBAGENT_TYPE"
+  SKILL_PATH="$PLUGIN_ROOT/skills/enhance/$SUBAGENT_TYPE/SKILL.md"
+  SKILL_NAME="flow:enhance:$SUBAGENT_TYPE"
 
-	if [[ -f "$SKILL_PATH" ]]; then
-		SKILLS_TO_INJECT="$SKILL_NAME"
-		log_event "ENHANCE" "agent=$SUBAGENT_TYPE" "skill=$SKILL_NAME"
-		# Log activation for evaluation
-		log_skill_activation "$SKILL_NAME" "target_agent=$SUBAGENT_TYPE" "$TASK_PROMPT" "enhance-agent:flow"
-	else
-		log_event "SKIP" "agent=$SUBAGENT_TYPE" "skill=$SKILL_NAME" "reason=skill_missing"
-	fi
+  if [[ -f "$SKILL_PATH" ]]; then
+    SKILLS_TO_INJECT="$SKILL_NAME"
+    log_event "ENHANCE" "agent=$SUBAGENT_TYPE" "skill=$SKILL_NAME"
+    # Log activation for evaluation
+    log_skill_activation "$SKILL_NAME" "target_agent=$SUBAGENT_TYPE" "$TASK_PROMPT" "enhance-agent:flow"
+  else
+    log_event "SKIP" "agent=$SUBAGENT_TYPE" "skill=$SKILL_NAME" "reason=skill_missing"
+  fi
 fi
 
 # 2. Review enhancement (detected from prompt keywords)
 # Unlike target agents, review tasks don't have a dedicated subagent_type
 # We detect review context from prompt content and inject the skill
 if [[ -n "$TASK_PROMPT" ]]; then
-	REVIEW_PATTERN="(code.*review|review.*(pr|code|changes)|pr.*review|audit|compliance|bug.*detect|find.*(bug|issue)|security.*review|check.*code)"
-	PROMPT_LOWER="${TASK_PROMPT,,}"
-	if [[ "$PROMPT_LOWER" =~ $REVIEW_PATTERN ]]; then
-		REVIEW_SKILL_PATH="$PLUGIN_ROOT/skills/enhance/review/SKILL.md"
-		if [[ -f "$REVIEW_SKILL_PATH" ]]; then
-			if [[ -n "$SKILLS_TO_INJECT" ]]; then
-				SKILLS_TO_INJECT="$SKILLS_TO_INJECT flow:enhance:review"
-			else
-				SKILLS_TO_INJECT="flow:enhance:review"
-			fi
-			log_event "ENHANCE" "agent=$SUBAGENT_TYPE" "skill=flow:enhance:review" "reason=prompt_match"
-			# Log activation for evaluation
-			log_skill_activation "flow:enhance:review" "$REVIEW_PATTERN" "$TASK_PROMPT" "enhance-agent:review"
-		fi
-	fi
+  REVIEW_PATTERN="(code.*review|review.*(pr|code|changes)|pr.*review|audit|compliance|bug.*detect|find.*(bug|issue)|security.*review|check.*code)"
+  PROMPT_LOWER=$(echo "$TASK_PROMPT" | tr '[:upper:]' '[:lower:]')
+  if [[ "$PROMPT_LOWER" =~ $REVIEW_PATTERN ]]; then
+    REVIEW_SKILL_PATH="$PLUGIN_ROOT/skills/enhance/review/SKILL.md"
+    if [[ -f "$REVIEW_SKILL_PATH" ]]; then
+      if [[ -n "$SKILLS_TO_INJECT" ]]; then
+        SKILLS_TO_INJECT="$SKILLS_TO_INJECT flow:enhance:review"
+      else
+        SKILLS_TO_INJECT="flow:enhance:review"
+      fi
+      log_event "ENHANCE" "agent=$SUBAGENT_TYPE" "skill=flow:enhance:review" "reason=prompt_match"
+      # Log activation for evaluation
+      log_skill_activation "flow:enhance:review" "$REVIEW_PATTERN" "$TASK_PROMPT" "enhance-agent:review"
+    fi
+  fi
 fi
 
 # 3. PR awareness (when working on a branch with open PR)
@@ -98,54 +101,54 @@ fi
 # This provides passive context about unresolved comments during regular work
 HAS_PR=$(gh pr view --json number -q '.number' 2>/dev/null || true)
 if [[ -n "$HAS_PR" ]]; then
-	PR_AWARENESS_SKILL_PATH="$PLUGIN_ROOT/skills/enhance/pr-awareness/SKILL.md"
-	if [[ -f "$PR_AWARENESS_SKILL_PATH" ]]; then
-		if [[ -n "$SKILLS_TO_INJECT" ]]; then
-			SKILLS_TO_INJECT="$SKILLS_TO_INJECT flow:enhance:pr-awareness"
-		else
-			SKILLS_TO_INJECT="flow:enhance:pr-awareness"
-		fi
-		log_event "ENHANCE" "agent=$SUBAGENT_TYPE" "skill=flow:enhance:pr-awareness" "reason=pr_detected"
-		# Log activation for evaluation
-		log_skill_activation "flow:enhance:pr-awareness" "pr_detected=$HAS_PR" "$TASK_PROMPT" "enhance-agent:pr"
-	fi
+  PR_AWARENESS_SKILL_PATH="$PLUGIN_ROOT/skills/enhance/pr-awareness/SKILL.md"
+  if [[ -f "$PR_AWARENESS_SKILL_PATH" ]]; then
+    if [[ -n "$SKILLS_TO_INJECT" ]]; then
+      SKILLS_TO_INJECT="$SKILLS_TO_INJECT flow:enhance:pr-awareness"
+    else
+      SKILLS_TO_INJECT="flow:enhance:pr-awareness"
+    fi
+    log_event "ENHANCE" "agent=$SUBAGENT_TYPE" "skill=flow:enhance:pr-awareness" "reason=pr_detected"
+    # Log activation for evaluation
+    log_skill_activation "flow:enhance:pr-awareness" "pr_detected=$HAS_PR" "$TASK_PROMPT" "enhance-agent:pr"
+  fi
 fi
 
 # 4. Domain skills (matched from triggers in prompt, with activation logging)
 if [[ -n "$TASK_PROMPT" ]]; then
-	MATCHED_SKILLS=$(match_skills_from_triggers "$TASK_PROMPT" "$LIB_DIR" "log" "enhance-agent:domain")
+  MATCHED_SKILLS=$(match_skills_from_triggers "$TASK_PROMPT" "$LIB_DIR" "log" "enhance-agent:domain")
 
-	if [[ -n "$MATCHED_SKILLS" ]]; then
-		if [[ -n "$SKILLS_TO_INJECT" ]]; then
-			SKILLS_TO_INJECT="$SKILLS_TO_INJECT $MATCHED_SKILLS"
-		else
-			SKILLS_TO_INJECT="$MATCHED_SKILLS"
-		fi
-	fi
+  if [[ -n "$MATCHED_SKILLS" ]]; then
+    if [[ -n "$SKILLS_TO_INJECT" ]]; then
+      SKILLS_TO_INJECT="$SKILLS_TO_INJECT $MATCHED_SKILLS"
+    else
+      SKILLS_TO_INJECT="$MATCHED_SKILLS"
+    fi
+  fi
 fi
 
 # --- Exit if no skills to inject ---
 if [[ -z "$SKILLS_TO_INJECT" ]]; then
-	exit 0
+  exit 0
 fi
 
 # --- Output enhancement directive ---
 {
-	echo ""
-	echo "╔══════════════════════════════════════════════════════════════════╗"
-	echo "║ AGENT ENHANCEMENT DIRECTIVE                                      ║"
-	echo "╠══════════════════════════════════════════════════════════════════╣"
-	printf "║ Agent: %-57s║\n" "$SUBAGENT_TYPE"
-	echo "║                                                                  ║"
-	echo "║ ACTION: Modify your prompt parameter to prepend:                 ║"
-	echo "║                                                                  ║"
-	for skill in $SKILLS_TO_INJECT; do
-		printf "║   Skill({ skill: \"%s\" })%*s║\n" "$skill" $((37 - ${#skill})) ""
-	done
-	echo "║                                                                  ║"
-	echo "║ This ensures the agent has required domain knowledge.            ║"
-	echo "╚══════════════════════════════════════════════════════════════════╝"
-	echo ""
+  echo ""
+  echo "╔══════════════════════════════════════════════════════════════════╗"
+  echo "║ AGENT ENHANCEMENT DIRECTIVE                                      ║"
+  echo "╠══════════════════════════════════════════════════════════════════╣"
+  printf "║ Agent: %-57s║\n" "$SUBAGENT_TYPE"
+  echo "║                                                                  ║"
+  echo "║ ACTION: Modify your prompt parameter to prepend:                 ║"
+  echo "║                                                                  ║"
+  for skill in $SKILLS_TO_INJECT; do
+    printf "║   Skill({ skill: \"%s\" })%*s║\n" "$skill" $((37 - ${#skill})) ""
+  done
+  echo "║                                                                  ║"
+  echo "║ This ensures the agent has required domain knowledge.            ║"
+  echo "╚══════════════════════════════════════════════════════════════════╝"
+  echo ""
 }
 
 exit 0


### PR DESCRIPTION
## Summary

Fix enhance skills not loading for Explore and Plan agents due to case-sensitive string comparison.

## Root cause

The `enhance-agent.sh` hook compared `subagent_type` values case-sensitively. Claude Code passes capitalized values (`"Explore"`, `"Plan"`) but the hook expected lowercase (`"explore"`, `"plan"`), causing the comparison to fail silently.

**Affected lines:**
- Line 51: `if [[ "$SUBAGENT_TYPE" == "$agent" ]]; then` - comparison failed
- Line 62: `SKILL_PATH="$PLUGIN_ROOT/skills/enhance/$SUBAGENT_TYPE/SKILL.md"` - path lookup failed (no `Explore/` directory)

## The fix

Convert `SUBAGENT_TYPE` to lowercase immediately after extraction using POSIX-compatible `tr`:
```bash
SUBAGENT_TYPE=$(echo "$SUBAGENT_TYPE" | tr '[:upper:]' '[:lower:]')
```

Also fixed a bash-specific `${,,}` syntax on line 83 to use `tr` for POSIX compatibility.

## How to reproduce (before)

1. Spawn a Task agent with `subagent_type: "Plan"` or `"Explore"`
2. Observe that `flow:enhance:plan` or `flow:enhance:explore` skills are NOT loaded
3. The enhancement directive box never appears for these agents

## How to verify (after)

```bash
TEST="Plan"
RESULT=$(echo "$TEST" | tr '[:upper:]' '[:lower:]')
echo "$RESULT"  # Should output: plan
```

When spawning Plan/Explore agents, the enhancement directive should now appear.

## Risk assessment

**Low** - The change only affects string comparison logic. Uses POSIX-compatible `tr` which is already used elsewhere in the codebase. No functional behavior changes other than fixing the broken skill loading.

## Checklist

- [x] Identified root cause (not just symptoms)
- [ ] Added test to prevent regression
- [x] Ran shellcheck locally
- [x] Checked for similar bugs elsewhere (fixed both occurrences)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing enhance skills for Explore and Plan by normalizing subagent_type to lowercase in the enhance-agent hook, restoring correct matching and skill loading.

- **Bug Fixes**
  - Compare agent type case-insensitively by lowercasing with tr.
  - Fix skill path lookup by using the normalized type.
  - Replace bash-specific ${,,} with POSIX-compatible tr.
  - Bump plugin version to 1.26.1.

<sup>Written for commit c49fe5ad33fa182c2ebfa113c07bbc0e5274174a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

