### PR TITLE
feat(flow): include enhance skills in trigger cache and broaden triggers

### DIFF
--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.26.2",
+  "version": "1.27.3",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/skills/enhance/explore/SKILL.md
+++ b/flow/skills/enhance/explore/SKILL.md
@@ -5,6 +5,13 @@ license: MIT
 triggers:
   - "enhance.*explore"
   - "explore.*enhancement"
+  - "explore.*codebase"
+  - "search.*codebase"
+  - "find.*in.*code"
+  - "understand.*code"
+  - "investigate"
+  - "research.*code"
+  - "look.*into"
 ---
 
 <objective>

--- a/flow/skills/enhance/general-purpose/SKILL.md
+++ b/flow/skills/enhance/general-purpose/SKILL.md
@@ -2,11 +2,23 @@
 name: flow:enhance:general-purpose
 description: Enhances the general-purpose agent with Rule of Five convergence. Enforces 30-second reality check, evidence-based completion, and explicit convergence signals.
 license: MIT
-# NOTE: This skill exceeds 300 lines. Consider extracting parallel_work_patterns
-# and worker_preamble_template to references/ subdirectory for leaner core.
 triggers:
   - "enhance.*general"
   - "general.*enhancement"
+  - "implement"
+  - "build"
+  - "create"
+  - "make.*component"
+  - "make.*function"
+  - "add.*feature"
+  - "add.*function"
+  - "add.*method"
+  - "develop"
+  - "code.*this"
+  - "write.*code"
+  - "refactor"
+  - "plan.*file"
+  - "\\.claude/plans"
 ---
 
 <objective>

--- a/flow/skills/enhance/plan/SKILL.md
+++ b/flow/skills/enhance/plan/SKILL.md
@@ -5,6 +5,18 @@ license: MIT
 triggers:
   - "enhance.*plan"
   - "plan.*enhancement"
+  - "planning"
+  - "create.*plan"
+  - "make.*plan"
+  - "write.*plan"
+  - "design.*plan"
+  - "implementation.*plan"
+  - "plan.*implementation"
+  - "plan.*approach"
+  - "step.*by.*step"
+  - "plan mode"
+  - "plan.*file"
+  - "\\.claude/plans"
 ---
 
 <objective>

--- a/flow/skills/enhance/pr-awareness/SKILL.md
+++ b/flow/skills/enhance/pr-awareness/SKILL.md
@@ -7,6 +7,8 @@ triggers:
   - "review.*comment"
   - "address.*feedback"
   - "fix.*comment"
+  - "resolve.*thread"
+  - "pr.*feedback"
 ---
 
 <objective>

--- a/flow/skills/enhance/review/SKILL.md
+++ b/flow/skills/enhance/review/SKILL.md
@@ -2,8 +2,6 @@
 name: flow:enhance:review
 description: Enhances review agents with high-signal filtering and validation protocols. Enforces evidence-based findings, confidence scoring, and five-pass convergence.
 license: MIT
-# NOTE: This skill exceeds 300 lines. Consider extracting codex_quality_review
-# and tdd_verification to references/ subdirectory for leaner core.
 triggers:
   - "code.*review"
   - "review.*pr"
@@ -16,6 +14,7 @@ triggers:
   - "find.*issue"
   - "security.*review"
   - "check.*code"
+  - "quality.*check"
 ---
 
 <objective>


### PR DESCRIPTION
# User description
## Summary

This PR improves the skill trigger system by including enhance skills in the cache and broadening trigger patterns. The skill trigger cache grows from 23 to 40 skills, and enhance skills now load automatically when users work on planning, building, or exploring tasks.

## Why

Previously, enhance skills (`flow:enhance:plan`, `flow:enhance:explore`, `flow:enhance:general-purpose`, `flow:enhance:review`, `flow:enhance:pr-awareness`) were excluded from the trigger cache by design. This meant they only loaded when spawned agents were created, not for the main conversation. Users had to manually load these skills or have very specific prompts.

Additionally, 12 devtools skills using JSON array format for triggers (`triggers: [...]`) weren't being parsed, leaving them out of the cache.

## Design decisions

- **Include enhance skills**: Removed the `/enhance/` exclusion from `scan-skill-triggers.sh` since these skills have valuable content that should trigger based on user prompts
- **JSON array parsing**: Added support for both YAML list and JSON array trigger formats to ensure all skills are cached
- **Broader triggers**: Added common task-related patterns to enhance skills so they load during typical development workflows

## What changed

- `flow/scripts/hooks/lib/scan-skill-triggers.sh`: Removed enhance exclusion, added JSON array parsing
- `flow/skills/enhance/plan/SKILL.md`: Added triggers for "planning", "plan file", ".claude/plans"
- `flow/skills/enhance/explore/SKILL.md`: Added triggers for "investigate", "research", "look into"
- `flow/skills/enhance/general-purpose/SKILL.md`: Added triggers for "build", "create", "refactor"
- `flow/skills/enhance/review/SKILL.md`: Added "quality check" trigger
- `flow/skills/enhance/pr-awareness/SKILL.md`: Added "resolve thread", "pr feedback"
- Removed NOTE comments from skill frontmatters

## How to test

1. Clear the trigger cache: `rm -f .claude/flow/cache/skill-triggers.txt`
2. Regenerate cache and verify count: should show ~40 skills
3. Send prompt "this planning session" → should suggest `flow:enhance:plan`
4. Send prompt "build me a component" → should suggest `flow:enhance:general-purpose`

## Checklist

- [x] Self-reviewed the diff
- [x] Ran shellcheck and shfmt on modified shell scripts
- [x] Tested cache regeneration

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the skill trigger system by modifying the <code>scan-skill-triggers.sh</code> script to include 'enhance' skills and parse JSON array trigger formats, thereby broadening the activation patterns for core skills to ensure they automatically load during typical development workflows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/153?tool=ast&topic=Skill+Trigger+System>Skill Trigger System</a>
        </td><td>Refine the skill trigger scanning mechanism in <code>scan-skill-triggers.sh</code> to include previously excluded 'enhance' skills and add robust parsing for JSON array formatted triggers, alongside expanding the trigger patterns in various <code>SKILL.md</code> files to improve automatic skill loading for common development tasks.<details><summary>Modified files (6)</summary><ul><li>flow/scripts/hooks/lib/scan-skill-triggers.sh</li>
<li>flow/skills/enhance/explore/SKILL.md</li>
<li>flow/skills/enhance/general-purpose/SKILL.md</li>
<li>flow/skills/enhance/plan/SKILL.md</li>
<li>flow/skills/enhance/pr-awareness/SKILL.md</li>
<li>flow/skills/enhance/review/SKILL.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>fix-flow-make-skill-tr...</td><td>January 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/153?tool=ast&topic=Plugin+Version+Update>Plugin Version Update</a>
        </td><td>Update the plugin version in <code>plugin.json</code> to reflect the new capabilities and release cycle.<details><summary>Modified files (1)</summary><ul><li>flow/.claude-plugin/plugin.json</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>fix-flow-make-skill-tr...</td><td>January 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/153?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Includes enhance skills in the trigger cache and broadens trigger patterns so enhancers auto-load during planning, building, exploring, reviewing, and PR workflows. Cache grows from 23 to ~40 skills, and trigger parsing now supports JSON arrays.

- **New Features**
  - Include enhance/ skills in trigger scanning (removed exclusion).
  - Parse triggers from YAML lists and JSON arrays to capture previously skipped skills.
  - Broaden triggers for plan, explore, general-purpose, review, and PR-awareness to match common prompts.
  - Bump plugin version to 1.27.3.

- **Migration**
  - Regenerate the trigger cache to pick up changes.

<sup>Written for commit ccf408310a1d4ba1f8dab952338e3f71d2294f2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

