### PR TITLE
feat(flow): detect plan mode and make skill loading mandatory

### DIFF
--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Hook-based agent enhancement and workflow automation for Claude Code. Enhances native Explore, Plan, and General-purpose agents with Rule of Five convergence patterns.",
-  "version": "1.27.3",
+  "version": "1.28.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"


### PR DESCRIPTION
# User description
## Summary

Enhances the analyze-intent hook to detect Claude Code's plan mode via the `permission_mode` field in hook input JSON, automatically injecting `flow:enhance:plan` skill. Also changes skill suggestions from passive hints to mandatory directives.

## Why

When users enter plan mode (`/plan`), the `flow:enhance:plan` skill should automatically load to provide the Rule of Five convergence patterns. Previously, the hook only matched skills based on prompt text, missing the mode context. Additionally, skill suggestions were too passive - Claude often didn't follow them.

## Design decisions

- **Read `permission_mode` from hook JSON**: Claude Code provides this field with values like "default", "plan", "acceptEdits", etc. This is the authoritative source for mode detection.
- **Front-load enhance:plan**: When in plan mode OR when troubleshooting is matched, prepend `flow:enhance:plan` to ensure structured approach.
- **Directive instead of suggestion**: Changed from `<flow-hint>Skills matched. Load:` to `<skill-load required="true">REQUIRED: Load these skills BEFORE responding`. Stronger language increases compliance.

## What changed

- `flow/scripts/hooks/user-prompt-submit/analyze-intent.sh`:
  - Read `permission_mode` from hook input JSON
  - Auto-inject `flow:enhance:plan` when `permission_mode == "plan"`
  - Auto-inject `flow:enhance:plan` when `devtools:troubleshooting` matches
  - Replace `<flow-hint>` with `<skill-load required="true">` directive
  - Remove unused `SCRIPT_NAME` variable
  - Formatting cleanup (shfmt)
- `flow/.claude-plugin/plugin.json`: Version bump 1.27.3 → 1.28.0

## How to test

1. In a project with flow plugin, enter plan mode: `/plan`
2. Submit a prompt about anything (e.g., "fix the login bug")
3. Verify `flow:enhance:plan` appears in the skill-load directive
4. Verify output uses `<skill-load required="true">` tag

## Checklist

- [x] Self-reviewed the diff
- [x] Ran shellcheck and shfmt
- [x] No debug code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the <code>analyze-intent.sh</code> hook to detect Claude Code's plan mode and automatically inject the <code>flow:enhance:plan</code> skill for structured convergence patterns. Updates the skill suggestion mechanism to a mandatory <code><skill-load></code> directive to ensure agent compliance with required tools.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/154?tool=ast&topic=Skill+Enforcement>Skill Enforcement</a>
        </td><td>Replaces the <code><flow-hint></code> tag with a mandatory <code><skill-load></code> directive to improve agent compliance and increments the version in <code>plugin.json</code>.<details><summary>Modified files (2)</summary><ul><li>flow/.claude-plugin/plugin.json</li>
<li>flow/scripts/hooks/user-prompt-submit/analyze-intent.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>feat-flow-include-enha...</td><td>January 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/154?tool=ast&topic=Intent+Detection>Intent Detection</a>
        </td><td>Updates <code>analyze-intent.sh</code> to extract <code>permission_mode</code> from input and conditionally inject the <code>flow:enhance:plan</code> skill during planning or troubleshooting phases.<details><summary>Modified files (1)</summary><ul><li>flow/scripts/hooks/user-prompt-submit/analyze-intent.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>refactor-consolidate-p...</td><td>January 15, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/154?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the analyze-intent hook detect plan mode via permission_mode and require explicit skill loading. This auto-loads flow:enhance:plan in plan mode or during troubleshooting so planning patterns consistently apply.

- **New Features**
  - Read permission_mode and inject flow:enhance:plan when mode is plan.
  - Also prepend flow:enhance:plan when devtools:troubleshooting matches.
  - Replace <flow-hint> with <skill-load required="true"> to force calling Skill() before responding.

- **Refactors**
  - Remove unused variable and apply shfmt cleanup; add logging.
  - Bump plugin version to 1.28.0.

<sup>Written for commit b5d46269ca349cc786412beeaf82cc3fd136fca2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

