### PR TITLE
feat(flow): enforce Rule of Five with commit gate

### DIFF
--- a/devtools/.claude-plugin/plugin.json
+++ b/devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devtools",
   "description": "Modern development tools for React, APIs, blockchain, databases, and testing. MCP-first skills with Context7 integration for up-to-date documentation.",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "author": {
     "name": "SettleMint",
     "email": "support@settlemint.com"

--- a/devtools/skills/rule-of-five/SKILL.md
+++ b/devtools/skills/rule-of-five/SKILL.md
@@ -80,12 +80,18 @@ Achieve higher quality through iterative refinement. Have agents review their ow
 <constraints>
 **Banned:** Single-pass outputs for complex work, skipping review phases, declaring convergence before 3 passes
 
-**Required:**
+**Required for code changes (ENFORCED):**
 
-- Minimum 3 passes for non-trivial work
+- Minimum 3 documented passes before committing
 - Each pass must broaden scope (code → architecture → existential)
-- Document findings from each pass
+- Document findings from each pass (even if "No findings")
+- Commits will be BLOCKED without documented review passes
+
+**Required for all work:**
+
+- Each pass must broaden scope (code → architecture → existential)
 - Declare convergence only when new findings approach zero
+- Exploration tasks are exempt from commit gates
   </constraints>
 
 <anti_patterns>

--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Router-based agent enhancement and workflow automation for Claude Code. Central router for Rule of Five patterns, domain skill routing, and coding rules.",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/hooks/hooks.json
+++ b/flow/hooks/hooks.json
@@ -37,6 +37,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/git-safety.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/commit-review-gate.sh"
           }
         ]
       }
@@ -51,6 +55,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/stop/todo-enforcer.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/stop/review-enforcer.sh"
           }
         ]
       }

--- a/flow/scripts/hooks/pre-tool/commit-review-gate.sh
+++ b/flow/scripts/hooks/pre-tool/commit-review-gate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Block git commit without documented review passes
+# Implements hybrid enforcement: block at commit gates
+#
+# Checks for:
+# - git commit commands
+# - Review pass documentation in transcript
+# - Blocks if fewer than 3 passes documented for code-change sessions
+#
+# Bypass: Include "--skip-review" in commit message for emergencies
+
+set +e
+
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME="commit-review-gate"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+log_init
+
+# Read tool input from stdin
+TOOL_INPUT=$(cat)
+COMMAND=$(echo "$TOOL_INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+TRANSCRIPT_PATH=$(echo "$TOOL_INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
+
+# Skip if no command
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# Skip if not a git commit command
+if [[ "$COMMAND" != *"git commit"* ]]; then
+  exit 0
+fi
+
+log_info "event=COMMIT_DETECTED" "command_preview=${COMMAND:0:50}..."
+
+# Check for bypass flag in commit message
+if [[ "$COMMAND" == *"--skip-review"* ]]; then
+  log_warn "event=REVIEW_BYPASS" "reason=skip_review_flag"
+  echo "Review check bypassed with --skip-review flag" >&2
+  exit 0
+fi
+
+# No transcript - allow (can't verify)
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+  log_warn "event=ALLOW_NO_TRANSCRIPT"
+  exit 0
+fi
+
+# --- Check for code changes (Edit/Write tool usage) ---
+CODE_CHANGE_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "tool_use" and (.name == "Edit" or .name == "Write"))] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+# No code changes in session - allow commit (might be committing external changes)
+if [[ "$CODE_CHANGE_COUNT" == "0" || "$CODE_CHANGE_COUNT" == "null" ]]; then
+  log_info "event=ALLOW" "reason=no_code_changes_in_session"
+  exit 0
+fi
+
+# --- Check for review pass documentation ---
+PASS_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "text") | .text // ""] |
+  join(" ") |
+  [match("(?i)(pass\\s*[1-5]|## pass|\\*\\*pass)"; "g")] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+log_info "event=REVIEW_CHECK" "pass_count=$PASS_COUNT" "code_changes=$CODE_CHANGE_COUNT"
+
+# --- Block if insufficient passes ---
+MIN_PASSES=3
+
+if [[ "$PASS_COUNT" -lt "$MIN_PASSES" ]]; then
+  log_warn "event=COMMIT_BLOCKED" "pass_count=$PASS_COUNT" "required=$MIN_PASSES"
+
+  REASON="Commit blocked: Rule of Five requires documented review passes.
+
+Code changes detected: $CODE_CHANGE_COUNT file(s)
+Review passes found: $PASS_COUNT (minimum $MIN_PASSES required)
+
+Before committing, document your review:
+  1. Pass 1: Standard review - bugs, edge cases, test coverage
+  2. Pass 2: Deep review - naming, duplication, error handling
+  3. Pass 3: Architecture review - patterns, dependencies, YAGNI
+
+Example output format:
+  ## Pass 1: Standard Review
+  - Finding: [issue] - Severity: P2
+  - Fix applied: [change]
+
+  ## Pass 2: Deep Review
+  - No new findings
+
+  ## Pass 3: Architecture Review
+  - Converged: All issues addressed
+
+Emergency bypass: Add '--skip-review' to commit message (use sparingly)"
+
+  jq -n --arg reason "$REASON" '{"decision": "block", "reason": $reason}'
+  exit 0
+fi
+
+log_info "event=COMMIT_ALLOWED" "pass_count=$PASS_COUNT"
+exit 0

--- a/flow/scripts/hooks/stop/review-enforcer.sh
+++ b/flow/scripts/hooks/stop/review-enforcer.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Stop hook: Warn if code changes made without documented review passes
+# Implements hybrid enforcement: warn during work, block at commit gates
+#
+# Checks for:
+# - Edit/Write tool usage (code change indicator)
+# - "Pass 1", "Pass 2", etc. in assistant messages (review pass documentation)
+# - Warns if fewer than 3 passes documented for code-change sessions
+#
+# Does NOT block - just warns. Blocking happens at commit time.
+
+set +e
+
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME="review-enforcer"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+log_init
+
+# Read hook input from stdin
+HOOK_INPUT=$(cat)
+
+# Parse hook input
+TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
+AGENT_TYPE=$(echo "$HOOK_INPUT" | jq -r '.agent_type // "main"' 2>/dev/null || echo "main")
+
+# Skip for subagents - they report to parent
+if [[ "$AGENT_TYPE" != "main" ]]; then
+  log_info "event=SKIP" "reason=subagent"
+  exit 0
+fi
+
+# No transcript - nothing to check
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+  log_info "event=SKIP" "reason=no_transcript"
+  exit 0
+fi
+
+# --- Check for code changes (Edit/Write tool usage) ---
+CODE_CHANGE_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "tool_use" and (.name == "Edit" or .name == "Write"))] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+if [[ "$CODE_CHANGE_COUNT" == "0" || "$CODE_CHANGE_COUNT" == "null" ]]; then
+  log_info "event=SKIP" "reason=no_code_changes"
+  exit 0
+fi
+
+log_info "event=CODE_CHANGES_DETECTED" "count=$CODE_CHANGE_COUNT"
+
+# --- Check for review pass documentation ---
+# Look for "Pass 1", "Pass 2", "Pass 3" etc. in assistant messages
+# Also check for alternative patterns like "## Pass 1" or "**Pass 1**"
+PASS_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "text") | .text // ""] |
+  join(" ") |
+  [match("(?i)(pass\\s*[1-5]|## pass|\\*\\*pass)"; "g")] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+# Also check for convergence indicators
+HAS_CONVERGENCE=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "text") | .text // ""] |
+  join(" ") |
+  test("(?i)(converg|findings|## review)"; "g")
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "false")
+
+log_info "event=REVIEW_CHECK" "pass_count=$PASS_COUNT" "has_convergence=$HAS_CONVERGENCE"
+
+# --- Determine warning level ---
+WARNING_LEVEL="none"
+WARNING_MSG=""
+
+if [[ "$PASS_COUNT" == "0" || "$PASS_COUNT" == "null" ]]; then
+  WARNING_LEVEL="high"
+  WARNING_MSG="Code changes made without documented review passes. Rule of Five requires minimum 3 passes for code changes."
+elif [[ "$PASS_COUNT" -lt 3 ]]; then
+  WARNING_LEVEL="medium"
+  WARNING_MSG="Only $PASS_COUNT review pass(es) documented. Rule of Five recommends minimum 3 passes for code changes."
+fi
+
+# --- Output warning if needed ---
+if [[ "$WARNING_LEVEL" != "none" ]]; then
+  log_warn "event=REVIEW_WARNING" "level=$WARNING_LEVEL" "passes=$PASS_COUNT" "code_changes=$CODE_CHANGE_COUNT"
+
+  echo ""
+  echo "<flow-review-warning>"
+  echo "Review passes: $PASS_COUNT (minimum 3 recommended)"
+  echo "Code changes: $CODE_CHANGE_COUNT file(s) modified"
+  echo ""
+  echo "$WARNING_MSG"
+  echo ""
+  echo "Before committing, document your review:"
+  echo "  - Pass 1: Standard review (bugs, edge cases)"
+  echo "  - Pass 2: Deep review (naming, duplication)"
+  echo "  - Pass 3: Architecture review (patterns, YAGNI)"
+  echo ""
+  echo "Note: Commits will be blocked without documented passes."
+  echo "</flow-review-warning>"
+else
+  log_info "event=REVIEW_OK" "passes=$PASS_COUNT"
+fi
+
+exit 0

--- a/flow/skills/enhance/SKILL.md
+++ b/flow/skills/enhance/SKILL.md
@@ -204,6 +204,12 @@ Apply 5-angle investigation. Cite file:line for findings.`
 - [ ] Would bet $100 this is correct
 - [ ] No "should work" language used
 
+**Before committing code changes (ENFORCED):**
+- [ ] Minimum 3 review passes documented (Pass 1, Pass 2, Pass 3)
+- [ ] Findings section present (even if empty: "No findings")
+- [ ] Convergence status stated
+- [ ] Commits will be BLOCKED without documented passes
+
 </quick_reference>
 
 <workflow_files>
@@ -231,6 +237,15 @@ Detailed patterns for each agent type:
 - **Sub-agent skill loading** - Agents need context to do quality work
 
 These aren't arbitrary rules - they're patterns that consistently produce better outcomes. Apply judgment; deviate when you have good reason.
+
+**TDD Reminder (recommended, not enforced):**
+
+When writing implementation code, consider test-driven development:
+- **RED**: Write a failing test first that defines expected behavior
+- **GREEN**: Write minimal code to make the test pass
+- **REFACTOR**: Improve code while keeping tests green
+
+TDD helps catch bugs early and documents intent. Load `devtools:tdd-typescript` for detailed patterns.
 
 </guidelines>
 


### PR DESCRIPTION
# User description
## Summary

Adds hybrid enforcement for Rule of Five methodology. A Stop hook warns when code changes are made without documented review passes, and a PreToolUse hook blocks git commits unless 3+ review passes are documented. Emergency bypass available with `--skip-review` flag.

## Why

Audit of 19 dalp sessions from today found **70% skip Rule of Five entirely**:
- dalp-sofia: 2/5 sessions compliant (40%)
- dalp-amarillo: 0/3 sessions compliant
- dalp-valencia: 0/5 sessions compliant

The philosophy "freedom enables quality" wasn't working - freedom without accountability led to skipped quality gates. Users became the quality gate instead of Claude self-reviewing.

## Design decisions

**Hybrid enforcement chosen over pure soft/hard approaches:**
- During work: Full freedom - warn only via Stop hook
- At commit gates: Block without documented passes
- Exploration sessions exempt (no Edit/Write = no enforcement)
- TDD remains a soft reminder (not enforced)

This preserves the trust-based philosophy while adding accountability at critical checkpoints.

## What changed

**New files:**
- `flow/scripts/hooks/stop/review-enforcer.sh` - Warns at session end if passes missing
- `flow/scripts/hooks/pre-tool/commit-review-gate.sh` - Blocks commits without review

**Modified files:**
- `flow/hooks/hooks.json` - Registered new hooks
- `flow/skills/enhance/SKILL.md` - Added completion checklist + TDD reminder
- `devtools/skills/rule-of-five/SKILL.md` - Strengthened requirements language

**Version bumps:**
- flow: 1.32.0 → 1.33.0
- devtools: 1.46.0 → 1.47.0

## How to test

1. Start a session, make code changes with Edit/Write
2. Try to commit without documenting passes → Should block with helpful message
3. Document 3+ passes with findings (Pass 1, Pass 2, Pass 3)
4. Commit again → Should succeed
5. Start exploration session (no code changes) → No enforcement
6. Use `--skip-review` in commit message → Should bypass (emergency use)

## Checklist

- [x] Self-reviewed the diff (Rule of Five: 3 passes)
- [x] No tests needed (hook scripts follow existing patterns)
- [x] No console.log or debug code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements a hybrid enforcement system for the Rule of Five methodology by introducing automated hooks that warn or block actions based on documented review passes. These components ensure accountability at critical commit gates while maintaining developer freedom during active work sessions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/158?tool=ast&topic=Skill+%26+Metadata>Skill & Metadata</a>
        </td><td>Updates <code>SKILL.md</code> files and plugin manifests to reflect the new mandatory review requirements and version increments.<details><summary>Modified files (4)</summary><ul><li>devtools/.claude-plugin/plugin.json</li>
<li>devtools/skills/rule-of-five/SKILL.md</li>
<li>flow/.claude-plugin/plugin.json</li>
<li>flow/skills/enhance/SKILL.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>Restore-planning-disci...</td><td>January 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/158?tool=ast&topic=Enforcement+Hooks>Enforcement Hooks</a>
        </td><td>Introduces <code>review-enforcer.sh</code> and <code>commit-review-gate.sh</code> to monitor session transcripts for review documentation and block non-compliant git commits.<details><summary>Modified files (3)</summary><ul><li>flow/hooks/hooks.json</li>
<li>flow/scripts/hooks/pre-tool/commit-review-gate.sh</li>
<li>flow/scripts/hooks/stop/review-enforcer.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>Restore-planning-disci...</td><td>January 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/158?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hybrid Rule of Five enforcement that warns during work and blocks commits without 3+ documented review passes. Exploration sessions remain exempt. Includes a checklist and a TDD reminder to encourage better reviews.

- **New Features**
  - PreToolUse commit gate blocks git commits when Edit/Write was used and fewer than 3 passes are found; emergency bypass with --skip-review.
  - Stop hook warns at session end if code changes lack review passes; no blocking.
  - Registered new hooks and strengthened Rule of Five requirements; added completion checklist and TDD reminder.
  - Version bumps: flow 1.32.0 → 1.33.0, devtools 1.46.0 → 1.47.0.

<sup>Written for commit 528e7cd5a33f9e562a7e1fbfb697499d5f75ccab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

