### PR TITLE
refactor(skills): move commands to workflow frontmatter

### DIFF
--- a/devtools/.claude-plugin/plugin.json
+++ b/devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devtools",
   "description": "Modern development tools for React, APIs, blockchain, databases, and testing. MCP-first skills with Context7 integration for up-to-date documentation.",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "author": {
     "name": "SettleMint",
     "email": "support@settlemint.com"

--- a/devtools/skills/git/workflows/branch-create.md
+++ b/devtools/skills/git/workflows/branch-create.md
@@ -1,6 +1,8 @@
 ---
 name: branch-create
 description: Create feature branch with naming convention
+user_invocable: true
+command: /branch
 ---
 
 <objective>

--- a/devtools/skills/git/workflows/commit.md
+++ b/devtools/skills/git/workflows/commit.md
@@ -1,6 +1,8 @@
 ---
 name: commit
 description: Create conventional commit with selective staging
+user_invocable: true
+command: /commit
 ---
 
 <context>

--- a/devtools/skills/git/workflows/pr-create.md
+++ b/devtools/skills/git/workflows/pr-create.md
@@ -1,6 +1,8 @@
 ---
 name: pr-create
 description: Create pull request with smart defaults and user options
+user_invocable: true
+command: /pr
 ---
 
 <context>

--- a/devtools/skills/git/workflows/pr-fix-reviews.md
+++ b/devtools/skills/git/workflows/pr-fix-reviews.md
@@ -1,6 +1,8 @@
 ---
 name: pr-fix-reviews
 description: Fix PR review comments and CI failures with educational feedback
+user_invocable: true
+command: /fix-pr-reviews
 ---
 
 <context>

--- a/devtools/skills/git/workflows/pr-update.md
+++ b/devtools/skills/git/workflows/pr-update.md
@@ -1,6 +1,8 @@
 ---
 name: pr-update
 description: Update PR title and body from commits
+user_invocable: true
+command: /pr-update
 ---
 
 <context>

--- a/devtools/skills/git/workflows/push.md
+++ b/devtools/skills/git/workflows/push.md
@@ -1,6 +1,8 @@
 ---
 name: push
 description: Push commits to remote with QA awareness
+user_invocable: true
+command: /push
 ---
 
 <context>

--- a/devtools/skills/git/workflows/sync.md
+++ b/devtools/skills/git/workflows/sync.md
@@ -1,6 +1,8 @@
 ---
 name: sync
 description: Sync branch with main via merge or rebase
+user_invocable: true
+command: /sync
 ---
 
 <context>

--- a/flow/skills/fix-pr-reviews/SKILL.md
+++ b/flow/skills/fix-pr-reviews/SKILL.md
@@ -2,8 +2,6 @@
 name: fix-pr-reviews
 description: Fix all unresolved PR review comments and CI failures. Resolves threads after pushing fixes.
 license: MIT
-user_invocable: true
-command: /fix-pr-reviews
 argument-hint: "[PR number, defaults to current branch PR]"
 triggers:
   - "fix pr"


### PR DESCRIPTION
# User description
## Summary

Add `user_invocable: true` and `command: /[name]` frontmatter to each workflow file in `devtools/skills/git/workflows/`, enabling them to be invoked directly as commands.

## Why

- Commands were previously only accessible via the `/git` router with subcommands
- Moving commands to individual skill frontmatter enables direct invocation while preserving router-based routing
- Aligns with the skill system pattern where commands are defined in the skills/workflows they execute
- Removes duplicate command definition from `flow:fix-pr-reviews` skill

## What changed

- Added `user_invocable: true` and `command: /[name]` to 7 git workflow files:
  - `commit.md` → `/commit`
  - `branch-create.md` → `/branch`
  - `pr-create.md` → `/pr`
  - `pr-update.md` → `/pr-update`
  - `push.md` → `/push`
  - `sync.md` → `/sync`
  - `pr-fix-reviews.md` → `/fix-pr-reviews`
- Removed duplicate command from `flow/skills/fix-pr-reviews/SKILL.md`
- Bumped `devtools` plugin version: 1.51.0 → 1.52.0

## Impact

- Users can now invoke git workflows directly via slash commands (/commit, /branch, etc.)
- No breaking changes: existing /git router subcommands still work
- Cleaner architecture: command definitions colocated with their implementations

## Verification

- All 7 workflow files have valid YAML frontmatter
- Commands are unique across all skills
- Commands match the git router's routing table exactly

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactors git skill invocation by moving command definitions directly into workflow frontmatter to enable direct slash command access. Updates the <code>devtools</code> plugin version and removes redundant command definitions to align with the new architecture.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/168?tool=ast&topic=Plugin+Maintenance>Plugin Maintenance</a>
        </td><td>Bumps the <code>devtools</code> plugin version to <code>1.52.0</code> and removes a duplicate command definition from the <code>fix-pr-reviews</code> skill file.<details><summary>Modified files (2)</summary><ul><li>devtools/.claude-plugin/plugin.json</li>
<li>flow/skills/fix-pr-reviews/SKILL.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>chore-policy-prevent-b...</td><td>January 17, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/168?tool=ast&topic=Workflow+Commands>Workflow Commands</a>
        </td><td>Enables direct invocation for git workflows by adding <code>user_invocable: true</code> and specific <code>command</code> paths to the frontmatter of various markdown workflow files.<details><summary>Modified files (7)</summary><ul><li>devtools/skills/git/workflows/branch-create.md</li>
<li>devtools/skills/git/workflows/commit.md</li>
<li>devtools/skills/git/workflows/pr-create.md</li>
<li>devtools/skills/git/workflows/pr-fix-reviews.md</li>
<li>devtools/skills/git/workflows/pr-update.md</li>
<li>devtools/skills/git/workflows/push.md</li>
<li>devtools/skills/git/workflows/sync.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>chore-setup-remove-una...</td><td>January 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/168?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved slash command definitions into each git workflow’s frontmatter to enable direct invocation (/commit, /branch, /pr, etc.). Existing /git router subcommands still work, with cleaner, colocated command definitions.

- **Refactors**
  - Added user_invocable: true and command to 7 workflows: commit, branch-create, pr-create, pr-update, push, sync, pr-fix-reviews.
  - Removed duplicate /fix-pr-reviews command from flow/skills/fix-pr-reviews/SKILL.md.
  - Bumped devtools plugin version to 1.52.0.

<sup>Written for commit 74808f10a71b7e30a052db4a33cef113baa54124. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

