### PR TITLE
feat(flow): enforce rule of five with automatic review hooks

### DIFF
--- a/flow/.claude-plugin/plugin.json
+++ b/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Router-based agent enhancement and workflow automation for Claude Code. Central router for Rule of Five patterns, domain skill routing, and coding rules.",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "author": {
     "name": "Roderik van der Veer",
     "email": "roderik@settlemint.com"

--- a/flow/hooks/hooks.json
+++ b/flow/hooks/hooks.json
@@ -53,6 +53,15 @@
         ]
       },
       {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool/edit-review-checkpoint.sh"
+          }
+        ]
+      },
+      {
         "matcher": "ExitPlanMode",
         "hooks": [
           {
@@ -76,6 +85,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/stop/review-enforcer.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/stop/auto-review-spawner.sh"
           }
         ]
       }

--- a/flow/scripts/hooks/pre-tool/edit-review-checkpoint.sh
+++ b/flow/scripts/hooks/pre-tool/edit-review-checkpoint.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Block Edit/Write after N changes without documented review pass
+# Enforces Rule of Five checkpoints during implementation
+#
+# Checks for:
+# - Edit/Write tool calls in transcript
+# - Review pass documentation ("## Pass") since last checkpoint
+# - Blocks after threshold (default: 10) edits without documented pass
+#
+# Threshold configurable via CLAUDE_REVIEW_CHECKPOINT env var
+# Override: Include "[SKIP-CHECKPOINT]" in recent message (audited)
+#
+# Excludes: test files, config files, markdown, generated files
+
+set +e
+
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME="edit-review-checkpoint"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+log_init
+
+# Default threshold (configurable)
+CHECKPOINT_THRESHOLD=${CLAUDE_REVIEW_CHECKPOINT:-10}
+
+# Read tool input from stdin
+TOOL_INPUT=$(cat)
+TOOL_NAME=$(echo "$TOOL_INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
+TRANSCRIPT_PATH=$(echo "$TOOL_INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
+
+# Skip if not Edit or Write
+if [[ "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "Write" ]]; then
+  exit 0
+fi
+
+# Skip if no file path
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# --- Check if file should be excluded ---
+is_excluded() {
+  local file="$1"
+
+  # Test files
+  [[ "$file" =~ \.test\.(ts|tsx|js|jsx)$ ]] && return 0
+  [[ "$file" =~ \.spec\.(ts|tsx|js|jsx)$ ]] && return 0
+  [[ "$file" =~ __tests__/ ]] && return 0
+
+  # Config files
+  [[ "$file" =~ (vitest|vite|jest|next|tailwind|postcss|eslint|biome|prettier)\.config ]] && return 0
+  [[ "$file" =~ tsconfig ]] && return 0
+  [[ "$file" =~ package\.json$ ]] && return 0
+
+  # Type declarations
+  [[ "$file" =~ \.d\.ts$ ]] && return 0
+
+  # Markdown and docs
+  [[ "$file" =~ \.md$ ]] && return 0
+  [[ "$file" =~ \.mdx$ ]] && return 0
+
+  # Generated files
+  [[ "$file" =~ /generated/ ]] && return 0
+  [[ "$file" =~ \.generated\. ]] && return 0
+  [[ "$file" =~ /migrations/ ]] && return 0
+
+  # Scripts and hooks (this plugin)
+  [[ "$file" =~ /scripts/hooks/ ]] && return 0
+
+  # Non-code files
+  [[ ! "$file" =~ \.(ts|tsx|js|jsx|py|go|rs|sol)$ ]] && return 0
+
+  return 1
+}
+
+# Skip excluded files
+if is_excluded "$FILE_PATH"; then
+  log_debug "event=SKIP_EXCLUDED" "file=$FILE_PATH"
+  exit 0
+fi
+
+# No transcript - allow (can't verify)
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+  log_debug "event=SKIP_NO_TRANSCRIPT"
+  exit 0
+fi
+
+# --- Check for bypass marker in recent messages ---
+HAS_BYPASS=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "text") | .text // ""] |
+  join(" ") |
+  test("\\[SKIP-CHECKPOINT\\]")
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "false")
+
+if [[ "$HAS_BYPASS" == "true" ]]; then
+  log_warn "event=CHECKPOINT_BYPASS" "file=$FILE_PATH"
+  # Audit bypass
+  AUDIT_DIR="/tmp/claude-audit"
+  mkdir -p "$AUDIT_DIR" 2>/dev/null || true
+  echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] SKIP-CHECKPOINT used for $FILE_PATH" >>"$AUDIT_DIR/checkpoint-bypass.log" 2>/dev/null || true
+  exit 0
+fi
+
+# --- Count Edit/Write operations on code files ---
+# Count all Edit/Write tool_use entries for code files
+EDIT_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "tool_use" and (.name == "Edit" or .name == "Write")) |
+   .input.file_path // "" |
+   select(test("\\.(ts|tsx|js|jsx|py|go|rs|sol)$")) |
+   select(test("\\.(test|spec)\\.(ts|tsx|js|jsx)$") | not) |
+   select(test("__tests__/") | not) |
+   select(test("(vitest|vite|jest|next|tailwind|postcss|eslint|biome|prettier)\\.config") | not) |
+   select(test("tsconfig") | not) |
+   select(test("\\.d\\.ts$") | not) |
+   select(test("/generated/") | not) |
+   select(test("/migrations/") | not) |
+   select(test("/scripts/hooks/") | not)] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+# Handle null or empty
+if [[ "$EDIT_COUNT" == "null" || -z "$EDIT_COUNT" ]]; then
+  EDIT_COUNT=0
+fi
+
+log_debug "event=EDIT_COUNT" "count=$EDIT_COUNT" "threshold=$CHECKPOINT_THRESHOLD"
+
+# Under threshold - allow
+if [[ "$EDIT_COUNT" -lt "$CHECKPOINT_THRESHOLD" ]]; then
+  exit 0
+fi
+
+# --- Check for review pass documentation ---
+# Look for "## Pass" patterns in assistant messages
+PASS_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "text") | .text // ""] |
+  join(" ") |
+  [match("(?i)(## pass|\\*\\*pass\\s*[1-5]|### pass)"; "g")] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+if [[ "$PASS_COUNT" == "null" || -z "$PASS_COUNT" ]]; then
+  PASS_COUNT=0
+fi
+
+log_info "event=CHECKPOINT_CHECK" "edit_count=$EDIT_COUNT" "pass_count=$PASS_COUNT" "threshold=$CHECKPOINT_THRESHOLD"
+
+# Has documented passes - allow
+if [[ "$PASS_COUNT" -gt 0 ]]; then
+  log_info "event=CHECKPOINT_PASSED" "passes=$PASS_COUNT"
+  exit 0
+fi
+
+# --- Block: too many edits without review pass ---
+log_warn "event=CHECKPOINT_BLOCK" "edit_count=$EDIT_COUNT" "threshold=$CHECKPOINT_THRESHOLD"
+
+REASON="Edit checkpoint: Too many code changes without review pass.
+
+Code edits: $EDIT_COUNT (threshold: $CHECKPOINT_THRESHOLD)
+Review passes: 0
+
+Rule of Five requires periodic review during implementation.
+
+Before continuing, document a review pass:
+
+## Pass N: Review - EVIDENCE
+- What I checked: [specific areas reviewed]
+- Findings: [issues found or 'No issues']
+- Evidence: [test output, code citations]
+
+Example:
+## Pass 1: Standard Review - EVIDENCE
+- Checked: Type safety, error handling
+- Findings: Missing null check at src/auth.ts:42 - FIXED
+- Evidence: \`bun run typecheck\` passes
+
+Override: Include [SKIP-CHECKPOINT] in your message (audited)"
+
+jq -n --arg reason "$REASON" '{"decision": "block", "reason": $reason}'
+exit 0

--- a/flow/scripts/hooks/pre-tool/edit-review-checkpoint.test.sh
+++ b/flow/scripts/hooks/pre-tool/edit-review-checkpoint.test.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Tests for edit-review-checkpoint.sh hook
+# Run: bash flow/scripts/hooks/pre-tool/edit-review-checkpoint.test.sh
+
+set -e
+
+SCRIPT_DIR=$(dirname "$0")
+HOOK="$SCRIPT_DIR/edit-review-checkpoint.sh"
+TEST_DIR=$(mktemp -d)
+TRANSCRIPT="$TEST_DIR/transcript.jsonl"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+TESTS_RUN=0
+TESTS_PASSED=0
+
+setup() {
+  rm -rf "$TEST_DIR"
+  mkdir -p "$TEST_DIR"
+  mkdir -p "/tmp/claude-audit"
+  export CLAUDE_PROJECT_DIR="$TEST_DIR"
+  export CLAUDE_SESSION_ID="test-session-$$"
+  # Reset checkpoint threshold to default
+  unset CLAUDE_REVIEW_CHECKPOINT
+}
+
+# Helper to create transcript with specific tool uses
+create_transcript() {
+  local content="$1"
+  echo "$content" >"$TRANSCRIPT"
+}
+
+# Helper to create transcript with N Edit operations
+create_transcript_with_edits() {
+  local count=$1
+  local has_pass=${2:-false}
+  local content=""
+
+  for ((i = 1; i <= count; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"/src/file$i.ts\"}}]}}\n"
+  done
+
+  if [[ "$has_pass" == "true" ]]; then
+    content="${content}{\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"## Pass 1: Review - EVIDENCE\\n- Checked code\"}]}}\n"
+  fi
+
+  echo -e "$content" >"$TRANSCRIPT"
+}
+
+# Run the hook and capture output
+run_hook() {
+  local file_path="${1:-/src/component.ts}"
+  echo "{\"tool_name\": \"Edit\", \"tool_input\": {\"file_path\": \"$file_path\"}, \"transcript_path\": \"$TRANSCRIPT\"}" | bash "$HOOK" 2>/dev/null || true
+}
+
+# Assert hook blocks with specific reason
+assert_blocks() {
+  local reason_pattern="$1"
+  local file_path="${2:-/src/component.ts}"
+  local output
+  output=$(run_hook "$file_path")
+
+  if echo "$output" | jq -e '.decision == "block"' >/dev/null 2>&1; then
+    if echo "$output" | jq -r '.reason' | grep -qiE "$reason_pattern"; then
+      return 0
+    else
+      echo "Expected reason to match '$reason_pattern' but got:"
+      echo "$output" | jq -r '.reason'
+      return 1
+    fi
+  else
+    echo "Expected hook to block but it didn't. Output:"
+    echo "$output"
+    return 1
+  fi
+}
+
+# Assert hook allows (no output or empty)
+assert_allows() {
+  local file_path="${1:-/src/component.ts}"
+  local output
+  output=$(run_hook "$file_path")
+
+  if [[ -z "$output" ]] || echo "$output" | jq -e '.decision != "block"' >/dev/null 2>&1; then
+    return 0
+  else
+    echo "Expected hook to allow but it blocked. Output:"
+    echo "$output"
+    return 1
+  fi
+}
+
+# Test runner
+run_test() {
+  local name="$1"
+  local test_fn="$2"
+  TESTS_RUN=$((TESTS_RUN + 1))
+
+  setup
+
+  if $test_fn; then
+    echo -e "${GREEN}PASS${NC}: $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $name"
+  fi
+}
+
+# --- Test Cases ---
+
+test_allow_under_threshold() {
+  # 9 edits should be allowed (threshold is 10)
+  create_transcript_with_edits 9
+  assert_allows
+}
+
+test_block_at_threshold() {
+  # 10 edits without pass should block
+  create_transcript_with_edits 10
+  assert_blocks "review pass"
+}
+
+test_allow_with_pass_documented() {
+  # 10 edits but pass documented should allow
+  create_transcript_with_edits 10 true
+  assert_allows
+}
+
+test_skip_test_files() {
+  # Edits to test files should not count
+  create_transcript_with_edits 15
+  assert_allows "/src/component.test.ts"
+}
+
+test_skip_config_files() {
+  # Edits to config files should be allowed
+  create_transcript_with_edits 15
+  assert_allows "vitest.config.ts"
+}
+
+test_skip_markdown_files() {
+  # Edits to markdown files should be allowed
+  create_transcript_with_edits 15
+  assert_allows "README.md"
+}
+
+test_custom_threshold() {
+  # Custom threshold via env var
+  export CLAUDE_REVIEW_CHECKPOINT=5
+  create_transcript_with_edits 5
+  assert_blocks "review pass"
+}
+
+test_skip_checkpoint_bypass() {
+  # [SKIP-CHECKPOINT] in recent message allows bypass
+  create_transcript_with_edits 10
+  # Add bypass marker
+  echo '{"message":{"content":[{"type":"text","text":"[SKIP-CHECKPOINT] Emergency fix"}]}}' >>"$TRANSCRIPT"
+  assert_allows
+}
+
+test_no_transcript_allows() {
+  # No transcript file - should allow (can't verify)
+  local output
+  output=$(echo '{"tool_name": "Edit", "tool_input": {"file_path": "/src/file.ts"}, "transcript_path": "/nonexistent"}' | bash "$HOOK" 2>/dev/null || true)
+  [[ -z "$output" ]]
+}
+
+test_write_tool_also_counted() {
+  # Write tool should also count toward threshold
+  local content=""
+  for ((i = 1; i <= 10; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Write\",\"input\":{\"file_path\":\"/src/new$i.ts\"}}]}}\n"
+  done
+  echo -e "$content" >"$TRANSCRIPT"
+  assert_blocks "review pass"
+}
+
+test_mixed_edit_write() {
+  # Mix of Edit and Write should count together
+  local content=""
+  for ((i = 1; i <= 5; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"/src/edit$i.ts\"}}]}}\n"
+  done
+  for ((i = 1; i <= 5; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Write\",\"input\":{\"file_path\":\"/src/write$i.ts\"}}]}}\n"
+  done
+  echo -e "$content" >"$TRANSCRIPT"
+  assert_blocks "review pass"
+}
+
+# --- Run Tests ---
+
+echo "Running edit-review-checkpoint.sh tests..."
+echo ""
+
+run_test "Allow under threshold (9 edits)" test_allow_under_threshold
+run_test "Block at threshold (10 edits)" test_block_at_threshold
+run_test "Allow with pass documented" test_allow_with_pass_documented
+run_test "Skip test files" test_skip_test_files
+run_test "Skip config files" test_skip_config_files
+run_test "Skip markdown files" test_skip_markdown_files
+run_test "Custom threshold via env var" test_custom_threshold
+run_test "Skip checkpoint bypass marker" test_skip_checkpoint_bypass
+run_test "No transcript allows (can't verify)" test_no_transcript_allows
+run_test "Write tool also counted" test_write_tool_also_counted
+run_test "Mixed Edit/Write count together" test_mixed_edit_write
+
+echo ""
+echo "================================"
+echo "Tests: $TESTS_PASSED/$TESTS_RUN passed"
+
+# Cleanup
+rm -rf "$TEST_DIR"
+
+if [[ $TESTS_PASSED -eq $TESTS_RUN ]]; then
+  echo -e "${GREEN}All tests passed!${NC}"
+  exit 0
+else
+  echo -e "${RED}Some tests failed${NC}"
+  exit 1
+fi

--- a/flow/scripts/hooks/stop/auto-review-spawner.sh
+++ b/flow/scripts/hooks/stop/auto-review-spawner.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Stop hook: Auto-spawn reviewer agents when code changes detected without review
+# Enforces Rule of Five by spawning pr-review-toolkit agents
+#
+# Checks for:
+# - Edit/Write tool usage on code files
+# - Review pass documentation ("## Pass") in messages
+# - Spawns reviewers if >5 code edits AND no review passes
+#
+# Anti-loop protection:
+# - Skips if agent_type != "main" (subagents don't trigger)
+# - Skips if agent_type contains "review" (review agents don't trigger)
+#
+# Spawns these agents based on changed file types:
+# - pr-review-toolkit:code-reviewer (always)
+# - pr-review-toolkit:silent-failure-hunter (always)
+# - pr-review-toolkit:pr-test-analyzer (if test files changed)
+# - pr-review-toolkit:type-design-analyzer (if type definitions changed)
+
+set +e
+
+SCRIPT_DIR=$(dirname "$0")
+SCRIPT_NAME="auto-review-spawner"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+log_init
+
+# Minimum edits to trigger auto-spawn
+MIN_EDITS_FOR_SPAWN=5
+
+# Read hook input from stdin
+HOOK_INPUT=$(cat)
+
+# Parse hook input
+TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
+AGENT_TYPE=$(echo "$HOOK_INPUT" | jq -r '.agent_type // "main"' 2>/dev/null || echo "main")
+
+# --- Anti-loop protection ---
+# Skip for subagents
+if [[ "$AGENT_TYPE" != "main" ]]; then
+  log_info "event=SKIP" "reason=subagent" "agent_type=$AGENT_TYPE"
+  exit 0
+fi
+
+# Skip for review agents (prevent recursive spawning)
+if [[ "$AGENT_TYPE" == *"review"* ]]; then
+  log_info "event=SKIP" "reason=review_agent" "agent_type=$AGENT_TYPE"
+  exit 0
+fi
+
+# No transcript - nothing to check
+if [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]]; then
+  log_info "event=SKIP" "reason=no_transcript"
+  exit 0
+fi
+
+# --- Count code file edits ---
+CODE_EDIT_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "tool_use" and (.name == "Edit" or .name == "Write")) |
+   .input.file_path // "" |
+   select(test("\\.(ts|tsx|js|jsx|py|go|rs|sol)$")) |
+   select(test("\\.(test|spec)\\.(ts|tsx|js|jsx)$") | not) |
+   select(test("\\.d\\.ts$") | not)] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+if [[ "$CODE_EDIT_COUNT" == "null" || -z "$CODE_EDIT_COUNT" ]]; then
+  CODE_EDIT_COUNT=0
+fi
+
+# Under threshold - no spawn needed
+if [[ "$CODE_EDIT_COUNT" -lt "$MIN_EDITS_FOR_SPAWN" ]]; then
+  log_info "event=SKIP" "reason=under_threshold" "count=$CODE_EDIT_COUNT" "threshold=$MIN_EDITS_FOR_SPAWN"
+  exit 0
+fi
+
+# --- Check for review pass documentation ---
+PASS_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "text") | .text // ""] |
+  join(" ") |
+  [match("(?i)(## pass|\\*\\*pass\\s*[1-5]|### pass)"; "g")] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+if [[ "$PASS_COUNT" == "null" || -z "$PASS_COUNT" ]]; then
+  PASS_COUNT=0
+fi
+
+# Has review passes - no spawn needed
+if [[ "$PASS_COUNT" -ge 3 ]]; then
+  log_info "event=SKIP" "reason=has_review_passes" "passes=$PASS_COUNT"
+  exit 0
+fi
+
+# --- Check for test files changed ---
+TEST_FILE_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "tool_use" and (.name == "Edit" or .name == "Write")) |
+   .input.file_path // "" |
+   select(test("\\.(test|spec)\\.(ts|tsx|js|jsx)$"))] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+# --- Check for type definition changes ---
+TYPE_DEF_COUNT=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "tool_use" and (.name == "Edit" or .name == "Write")) |
+   .input.file_path // "" |
+   select(test("\\.d\\.ts$|/types/"))] |
+  length
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
+
+# --- Get list of changed files ---
+CHANGED_FILES=$(jq -s '
+  [.[] | .message.content[]? |
+   select(.type == "tool_use" and (.name == "Edit" or .name == "Write")) |
+   .input.file_path // ""] |
+  unique | join(", ")
+' "$TRANSCRIPT_PATH" 2>/dev/null || echo "")
+
+log_info "event=SPAWN_REVIEWERS" "code_edits=$CODE_EDIT_COUNT" "passes=$PASS_COUNT" "test_files=$TEST_FILE_COUNT" "type_defs=$TYPE_DEF_COUNT"
+
+# --- Output spawn instructions ---
+cat <<EOF
+
+<auto-review-spawn>
+REQUIRED: Code changes detected without documented review passes.
+
+Code edits: $CODE_EDIT_COUNT files
+Review passes: $PASS_COUNT (need 3)
+Changed files: $CHANGED_FILES
+
+Spawn these reviewer agents to complete Rule of Five:
+
+Task({
+  subagent_type: "pr-review-toolkit:code-reviewer",
+  description: "Review code changes for CLAUDE.md compliance",
+  prompt: "Review these files for bugs, logic errors, and CLAUDE.md violations: $CHANGED_FILES"
+})
+
+Task({
+  subagent_type: "pr-review-toolkit:silent-failure-hunter",
+  description: "Check error handling",
+  prompt: "Check these files for silent failures, missing error handling, and logging gaps: $CHANGED_FILES"
+})
+EOF
+
+# Conditional spawns based on file types
+if [[ "$TEST_FILE_COUNT" -gt 0 ]]; then
+  cat <<EOF
+
+Task({
+  subagent_type: "pr-review-toolkit:pr-test-analyzer",
+  description: "Analyze test coverage",
+  prompt: "Analyze test coverage and quality for the changed code files"
+})
+EOF
+fi
+
+if [[ "$TYPE_DEF_COUNT" -gt 0 ]]; then
+  cat <<EOF
+
+Task({
+  subagent_type: "pr-review-toolkit:type-design-analyzer",
+  description: "Review type definitions",
+  prompt: "Analyze type design for encapsulation and invariant expression"
+})
+EOF
+fi
+
+cat <<EOF
+
+After spawning reviewers, document your review passes:
+## Pass 1: Standard Review - EVIDENCE
+## Pass 2: Deep Review - EVIDENCE
+## Pass 3: Architecture Review - EVIDENCE
+</auto-review-spawn>
+EOF
+
+exit 0

--- a/flow/scripts/hooks/stop/auto-review-spawner.test.sh
+++ b/flow/scripts/hooks/stop/auto-review-spawner.test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Tests for auto-review-spawner.sh hook
+# Run: bash flow/scripts/hooks/stop/auto-review-spawner.test.sh
+
+set -e
+
+SCRIPT_DIR=$(dirname "$0")
+HOOK="$SCRIPT_DIR/auto-review-spawner.sh"
+TEST_DIR=$(mktemp -d)
+TRANSCRIPT="$TEST_DIR/transcript.jsonl"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+TESTS_RUN=0
+TESTS_PASSED=0
+
+setup() {
+  rm -rf "$TEST_DIR"
+  mkdir -p "$TEST_DIR"
+  export CLAUDE_PROJECT_DIR="$TEST_DIR"
+}
+
+# Helper to create transcript with N Edit operations on code files
+create_transcript_with_code_edits() {
+  local count=$1
+  local has_pass=${2:-false}
+  local content=""
+
+  for ((i = 1; i <= count; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"/src/file$i.ts\"}}]}}\n"
+  done
+
+  if [[ "$has_pass" == "true" ]]; then
+    content="${content}{\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"## Pass 1: Review\\n## Pass 2: Review\\n## Pass 3: Review\"}]}}\n"
+  fi
+
+  echo -e "$content" >"$TRANSCRIPT"
+}
+
+# Helper to create transcript with test file edits
+create_transcript_with_test_edits() {
+  local count=$1
+  local content=""
+
+  for ((i = 1; i <= count; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"/src/file$i.test.ts\"}}]}}\n"
+  done
+
+  echo -e "$content" >"$TRANSCRIPT"
+}
+
+# Run the hook and capture output
+run_hook() {
+  local agent_type="${1:-main}"
+  echo "{\"transcript_path\": \"$TRANSCRIPT\", \"agent_type\": \"$agent_type\"}" | bash "$HOOK" 2>/dev/null || true
+}
+
+# Assert hook outputs spawn instructions
+assert_spawns_reviewers() {
+  local output
+  output=$(run_hook)
+
+  if echo "$output" | grep -qiE "pr-review-toolkit|code-reviewer|silent-failure-hunter"; then
+    return 0
+  else
+    echo "Expected hook to output reviewer spawn instructions but got:"
+    echo "$output"
+    return 1
+  fi
+}
+
+# Assert hook outputs nothing (no spawn needed)
+assert_no_spawn() {
+  local agent_type="${1:-main}"
+  local output
+  output=$(run_hook "$agent_type")
+
+  if [[ -z "$output" ]]; then
+    return 0
+  else
+    echo "Expected no output but got:"
+    echo "$output"
+    return 1
+  fi
+}
+
+# Test runner
+run_test() {
+  local name="$1"
+  local test_fn="$2"
+  TESTS_RUN=$((TESTS_RUN + 1))
+
+  setup
+
+  if $test_fn; then
+    echo -e "${GREEN}PASS${NC}: $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $name"
+  fi
+}
+
+# --- Test Cases ---
+
+test_spawn_on_code_edits_without_review() {
+  # 6 code edits without review passes should trigger spawn
+  create_transcript_with_code_edits 6
+  assert_spawns_reviewers
+}
+
+test_no_spawn_under_threshold() {
+  # 4 code edits (under threshold of 5) should not trigger
+  create_transcript_with_code_edits 4
+  assert_no_spawn
+}
+
+test_no_spawn_with_review_passes() {
+  # 10 code edits but with review passes should not trigger
+  create_transcript_with_code_edits 10 true
+  assert_no_spawn
+}
+
+test_skip_subagents() {
+  # Subagents should not trigger spawning
+  create_transcript_with_code_edits 10
+  assert_no_spawn "general-purpose"
+}
+
+test_skip_review_agents() {
+  # Review agents should not trigger spawning (anti-loop)
+  create_transcript_with_code_edits 10
+  assert_no_spawn "pr-review-toolkit:code-reviewer"
+}
+
+test_no_transcript_no_spawn() {
+  # No transcript - should not spawn
+  local output
+  output=$(echo '{"transcript_path": "/nonexistent", "agent_type": "main"}' | bash "$HOOK" 2>/dev/null || true)
+  [[ -z "$output" ]]
+}
+
+test_includes_code_reviewer() {
+  create_transcript_with_code_edits 6
+  local output
+  output=$(run_hook)
+  echo "$output" | grep -qi "code-reviewer"
+}
+
+test_includes_silent_failure_hunter() {
+  create_transcript_with_code_edits 6
+  local output
+  output=$(run_hook)
+  echo "$output" | grep -qi "silent-failure-hunter"
+}
+
+test_includes_test_analyzer_when_tests_changed() {
+  # Create transcript with both code and test files
+  # Need at least 5 code edits to trigger the spawner
+  local content=""
+  for ((i = 1; i <= 6; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"/src/file$i.ts\"}}]}}\n"
+  done
+  for ((i = 1; i <= 3; i++)); do
+    content="${content}{\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"/src/file$i.test.ts\"}}]}}\n"
+  done
+  echo -e "$content" >"$TRANSCRIPT"
+
+  local output
+  output=$(run_hook)
+  echo "$output" | grep -qi "pr-test-analyzer"
+}
+
+# --- Run Tests ---
+
+echo "Running auto-review-spawner.sh tests..."
+echo ""
+
+run_test "Spawn reviewers on code edits without review" test_spawn_on_code_edits_without_review
+run_test "No spawn under threshold (4 edits)" test_no_spawn_under_threshold
+run_test "No spawn with review passes documented" test_no_spawn_with_review_passes
+run_test "Skip subagents" test_skip_subagents
+run_test "Skip review agents (anti-loop)" test_skip_review_agents
+run_test "No transcript - no spawn" test_no_transcript_no_spawn
+run_test "Output includes code-reviewer" test_includes_code_reviewer
+run_test "Output includes silent-failure-hunter" test_includes_silent_failure_hunter
+run_test "Output includes pr-test-analyzer when tests changed" test_includes_test_analyzer_when_tests_changed
+
+echo ""
+echo "================================"
+echo "Tests: $TESTS_PASSED/$TESTS_RUN passed"
+
+# Cleanup
+rm -rf "$TEST_DIR"
+
+if [[ $TESTS_PASSED -eq $TESTS_RUN ]]; then
+  echo -e "${GREEN}All tests passed!${NC}"
+  exit 0
+else
+  echo -e "${RED}Some tests failed${NC}"
+  exit 1
+fi

--- a/flow/skills/enhance/SKILL.md
+++ b/flow/skills/enhance/SKILL.md
@@ -478,6 +478,37 @@ Apply 5-angle investigation. Cite file:line for findings.`
 
 </quick_reference>
 
+<enforcement_hooks>
+
+## Rule of Five Enforcement (AUTOMATED)
+
+These hooks automatically enforce Rule of Five during implementation:
+
+| Hook | When | Action |
+|------|------|--------|
+| `edit-review-checkpoint.sh` | Every 10 Edit/Write calls | BLOCK until review pass documented |
+| `review-enforcer.sh` | Stop (session end) | BLOCK if <3 passes for code changes |
+| `auto-review-spawner.sh` | Stop (session end) | Auto-spawn reviewer agents if no review |
+| `commit-review-gate.sh` | git commit | BLOCK without documented passes |
+
+**Checkpoint behavior:**
+- After 10 code file edits, you must document a review pass before more edits
+- Pass format: `## Pass N: Review - EVIDENCE`
+- Threshold configurable via `CLAUDE_REVIEW_CHECKPOINT` env var
+
+**Auto-spawn behavior:**
+- If >5 code edits AND no passes documented, spawns these agents:
+  - `pr-review-toolkit:code-reviewer` (always)
+  - `pr-review-toolkit:silent-failure-hunter` (always)
+  - `pr-review-toolkit:pr-test-analyzer` (if test files changed)
+  - `pr-review-toolkit:type-design-analyzer` (if type definitions changed)
+
+**Override markers (audited to /tmp/claude-audit/):**
+- `[SKIP-CHECKPOINT]` - Bypass edit checkpoint
+- `[REVIEW-BYPASS]` - Bypass review enforcer at Stop
+
+</enforcement_hooks>
+
 <workflow_files>
 
 Detailed patterns for each agent type:


### PR DESCRIPTION
# User description
## Summary

Add three enforcement hooks to ensure Rule of Five compliance during implementation:
- `edit-review-checkpoint.sh`: Blocks code edits after 10 changes without documented review pass
- `auto-review-spawner.sh`: Auto-spawns review agents when code changes detected without review
- Strengthened `review-enforcer.sh`: Now BLOCKS instead of WARNS at session end

## Why

Review skills from `pr-review-toolkit` were not being automatically triggered, and Rule of Five was only enforced at commit/stop/plan-exit points. This created a gap during implementation where Claude could make 80+ edits without mandatory review checkpoints. The hooks close this gap by enforcing reviews during active development.

## Design decisions

1. **State tracking**: Use transcript (`.claude/projects/*/transcript.jsonl`) directly—no external state files
2. **Anti-loop protection**: Skip subagents and review agents to prevent recursive spawning
3. **Override mechanism**: Support `[SKIP-CHECKPOINT]` and `[REVIEW-BYPASS]` markers with audit trails to `/tmp/claude-audit/`
4. **Configurability**: `CLAUDE_REVIEW_CHECKPOINT` env var for threshold (default: 10 edits)
5. **Conditional spawning**: Auto-spawn only pr-test-analyzer when tests changed, type-design-analyzer when types changed

## What changed

- **New files** (4):
  - `flow/scripts/hooks/pre-tool/edit-review-checkpoint.sh` + test
  - `flow/scripts/hooks/stop/auto-review-spawner.sh` + test
- **Modified files** (4):
  - `flow/scripts/hooks/stop/review-enforcer.sh`: WARN → BLOCK
  - `flow/hooks/hooks.json`: Added PreToolUse and Stop hook entries
  - `flow/skills/enhance/SKILL.md`: Added enforcement documentation
  - `flow/.claude-plugin/plugin.json`: Version bump 1.38.0 → 1.39.0

## How to test

1. **Unit tests**: All 29 tests passing
   - `edit-review-checkpoint.test.sh`: 11/11
   - `auto-review-spawner.test.sh`: 9/9
   - `plan-quality-gate.test.sh`: 9/9 (existing, verified)

2. **Manual verification**:
   - Test checkpoint triggers at 10 edits: Edit 10 code files, verify hook blocks
   - Test pass detection: Document "## Pass 1: Review - EVIDENCE", verify unblocks
   - Test auto-spawner: Generate 6+ code edits without review, verify hook outputs Task spawn instructions
   - Test overrides: Use `[SKIP-CHECKPOINT]` or `[REVIEW-BYPASS]` markers, verify audit trail written

3. **Integration test scenario**:
   - Make 10 code edits to flow plugin code files
   - Verify PreToolUse hook blocks on 11th edit with "## Pass N: Review" guidance
   - Document pass with evidence (test output, architecture notes, etc.)
   - Verify checkpoint unblocks for next edit
   - Session end: Verify Stop hook checks for 3+ passes

## AI Assistance

- [x] AI assisted with:
  - Hook script design and implementation
  - Test case development (TDD)
  - Shell script validation and formatting
  - Error handling logic

## Risk Assessment

| Category | Risk Level | Notes |
|----------|------------|-------|
| Complexity | Medium | Shell scripts use jq and transcript parsing; tested thoroughly |
| Breaking changes | None | Hooks are additive; enforce existing Rule of Five |
| Security | Low | Audit trails to `/tmp/claude-audit/`, cleared on reboot |
| Performance | Low | Lightweight jq queries on JSON transcript |
| Data integrity | None | Read-only operations on transcript |

**Review focus:** Hook logic correctness (edit counting, pass detection), test coverage adequacy, audit trail implementation

## Proof of Function

- Test output: 29/29 tests passing (edit-review-checkpoint: 11, auto-review-spawner: 9, plan-quality-gate: 9)
- Manual verification: Hooks fire correctly on test transcripts with mock Edit/Write operations; pass detection works as designed

## Checklist

- [x] Self-reviewed the diff
- [x] Added comprehensive tests (TDD)
- [x] Shell scripts formatted and linted
- [x] No debug code or temporary markers left in
- [x] Completed AI disclosure section
- [x] Filled proof of function with evidence

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforces the 'Rule of Five' review process by introducing automated hooks that block excessive code edits without documented reviews and auto-spawn review agents. Integrates these checkpoints into the <code>PreToolUse</code> and <code>Stop</code> lifecycle events to ensure continuous code quality during development.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/170?tool=ast&topic=Config+%26+Docs>Config & Docs</a>
        </td><td>Registers the new hooks in the plugin configuration and updates the skill documentation to explain the automated enforcement behavior and override mechanisms.<details><summary>Modified files (3)</summary><ul><li>flow/.claude-plugin/plugin.json</li>
<li>flow/hooks/hooks.json</li>
<li>flow/skills/enhance/SKILL.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>feat-plugins-integrate...</td><td>January 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/170?tool=ast&topic=Enforcement+Hooks>Enforcement Hooks</a>
        </td><td>Implements shell scripts that monitor the transcript for code edits and review documentation, blocking further changes or session termination if review thresholds are not met.<details><summary>Modified files (5)</summary><ul><li>flow/scripts/hooks/pre-tool/edit-review-checkpoint.sh</li>
<li>flow/scripts/hooks/pre-tool/edit-review-checkpoint.test.sh</li>
<li>flow/scripts/hooks/stop/auto-review-spawner.sh</li>
<li>flow/scripts/hooks/stop/auto-review-spawner.test.sh</li>
<li>flow/scripts/hooks/stop/review-enforcer.sh</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/170?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Rule of Five during development by blocking long edit runs without review and auto-spawning reviewer agents when needed. This prevents unreviewed changes and raises overall review quality.

- **New Features**
  - PreToolUse edit-review-checkpoint: Blocks Edit/Write after 10 code edits without a documented "## Pass" review. Configurable via CLAUDE_REVIEW_CHECKPOINT. Supports [SKIP-CHECKPOINT] with audit.
  - Stop review-enforcer: Now blocks at session end if fewer than 3 review passes are documented. Supports [REVIEW-BYPASS] with audit.
  - Stop auto-review-spawner: If >5 code edits and no passes, outputs tasks to spawn pr-review-toolkit reviewers (code-reviewer, silent-failure-hunter). Conditionally adds pr-test-analyzer and type-design-analyzer. Skips subagents and review agents to avoid loops.
  - hooks.json wires the new hooks; SKILL.md documents enforcement; plugin version bumped to 1.39.0. Includes tests for each hook.

<sup>Written for commit dd494710c3d49832cee655c3747a9caaf09e0023. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

