### PR TITLE
feat(plan-mode): make Linear integration question mandatory

### DIFF
--- a/plan-mode/commands/plan.md
+++ b/plan-mode/commands/plan.md
@@ -66,17 +66,25 @@ Use the plan-validator agent to:
 - Detect vague language (target: 0 occurrences)
 - Determine plan readiness with quality score
 
-## Phase 7: Documentation & Integration
+## Phase 7: Documentation & Linear Integration (REQUIRED)
+
+**CRITICAL: This phase is MANDATORY. The planning workflow is NOT complete until you ask about Linear.**
 
 After validation completes:
-1. Write the plan to the plan file
-2. Use AskUserQuestion to offer Linear integration with these options:
-   - Create new Linear ticket with this plan
-   - Update existing Linear ticket (provide ticket ID)
-   - Skip Linear integration
 
-If user chooses Linear integration, use the Linear MCP tools to create or update the ticket with the plan content.
+1. Write the plan to the plan file
+
+2. **REQUIRED: Use AskUserQuestion to ask about Linear integration.** Present these options:
+   - Create new Linear ticket with this plan
+   - Update existing Linear ticket (user provides ticket ID)
+   - Skip Linear integration for now
+
+3. If user chooses Linear integration, use the Linear MCP tools to create or update the ticket with the plan content.
+
+**You MUST ask the Linear question before considering this workflow complete. Do not skip this step.**
 
 ---
 
 Execute phases sequentially, using the specialized agents. Each agent chains to the next automatically. Provide cumulative output at each phase.
+
+**Reminder: Phase 7 (Linear integration question) is required before completing the workflow.**

--- a/plan-mode/skills/planning-methodology/SKILL.md
+++ b/plan-mode/skills/planning-methodology/SKILL.md
@@ -191,7 +191,9 @@ Apply Rule of Five convergence with self-verification.
 
 See `references/rule-of-five.md` for detailed prompts.
 
-### Phase 7: Documentation & Integration
+### Phase 7: Documentation & Linear Integration (REQUIRED)
+
+**CRITICAL: This phase is MANDATORY. The planning workflow is NOT complete until you ask about Linear.**
 
 Persist plan with frequent commit strategy.
 
@@ -200,11 +202,13 @@ Persist plan with frequent commit strategy.
 - Commit after each 2-5 minute task
 - Enable easy rollback and progress tracking
 
-**Linear Integration:**
-Use AskUserQuestion to offer:
+**Linear Integration (REQUIRED):**
+You MUST use AskUserQuestion to ask about Linear integration before completing the workflow:
 1. Create new Linear ticket with plan
-2. Update existing Linear ticket
-3. Skip Linear integration
+2. Update existing Linear ticket (user provides ID)
+3. Skip Linear integration for now
+
+**Do not skip this step. Always ask the Linear question.**
 
 ## Agent Workflow
 


### PR DESCRIPTION
# User description
## Summary

Ensures that the Linear integration question is always asked as part of the plan-mode workflow. The Phase 7 (Documentation & Linear Integration) step is now mandatory and cannot be skipped, guaranteeing users are prompted about creating/updating Linear tickets for their plans.

## Why

The original hook-based approach to remind users about Linear integration had a fundamental limitation: prompt-based hooks lack context about what happened during the planning session. The plan file existed but wasn't being linked to Linear tickets. By making the question mandatory in the command and skill documentation, we ensure it's always asked, regardless of hook limitations.

## Design Decisions

- **Approach:** Strengthen documentation requirements rather than adding complex state tracking
- **Alternatives considered:** 
  - Add state-based file tracking (more complex)
  - Add PreToolUse hooks on ExitPlanMode (still subject to hook context limitations)
- **Trade-offs:** Documentation-based approach is simpler but relies on Claude following instructions; more complex hook approaches would have higher maintenance burden

## What Changed

- `plan-mode/commands/plan.md` (22 lines added/modified)
- `plan-mode/skills/planning-methodology/SKILL.md` (14 lines added/modified)

### Key Changes

- Renamed Phase 7 to "Documentation & Linear Integration (REQUIRED)"
- Added "CRITICAL: This phase is MANDATORY" notice in both files
- Changed "offer" language to "ask about" with "You MUST" emphasis
- Added explicit "Do not skip this step" reminders
- Clarified that users can still choose to skip, but must be asked first

## How to Test

1. [x] Verify plan.md Phase 7 section emphasizes mandatory Linear question
2. [x] Verify SKILL.md Phase 7 section has identical strong language
3. [x] Confirm both files have "CRITICAL", "MANDATORY", and "MUST" keywords
4. [x] Ensure the wording prevents accidental skipping of Linear question

## Commits

```
c475c87 feat(plan-mode): make Linear integration question mandatory in Phase 7
```

<details>
<summary>Implementation Plan</summary>

# Review: Linear Ticket Question Not Appearing in Plan-Mode Flow

## Problem Summary

The user expected to receive a question about Linear tickets when using the plan-mode workflow, but the question never appeared.

## Root Cause Analysis

The plan-mode plugin has two mechanisms for triggering the Linear ticket question:

### 1. Phase 7 in the `/plan` Command
The `commands/plan.md` defines Phase 7 with instructions to ask about Linear integration.

### 2. Stop Hook Safety Net
The `hooks/hooks.json` has a Stop hook attempting to remind about Linear integration.

## Why It's Not Working

**The prompt-based Stop hook has a fundamental limitation:**

Hooks receive input via stdin but the prompt-based hook doesn't receive the conversation history. The model processing the hook prompt has no context about what happened in the session, so it likely just approves the stop because it can't verify whether planning actually occurred.

## Solution Implemented

Strengthened the documentation in both `commands/plan.md` and `planning-methodology/SKILL.md` to make Phase 7 mandatory with clear language that cannot be overlooked:

- Marked Phase 7 as "(REQUIRED)"
- Added "CRITICAL: This phase is MANDATORY" notice
- Changed to "You MUST ask" language
- Added "Do not skip this step" reminders

This simpler approach avoids complex state tracking while ensuring the Linear question is never accidentally skipped, since it's now a documented mandatory requirement.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Phase 7 (Documentation & Linear Integration) mandatory in plan-mode so users are always asked about creating or updating a Linear ticket before finishing the workflow. Updated plan.md and SKILL.md with clear “REQUIRED” and “MUST ask” language; users can still skip after being asked.

- **New Features**
  - Phase 7 renamed to “Documentation & Linear Integration (REQUIRED)” and cannot be skipped.
  - Updated plan-mode/commands/plan.md and plan-mode/skills/planning-methodology/SKILL.md with strong prompts and reminders.
  - If the user opts in, use Linear MCP tools to create or update the ticket.

<sup>Written for commit c475c87e340aa4bd5d0478ebf75d462d197be6a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the plan-mode workflow to ensure the Linear integration question is mandatory during Phase 7. Modifies the planning command and methodology skill to enforce that users are always prompted about ticket creation or updates before the workflow concludes.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/201?tool=ast>(Baz)</a>.