### PR TITLE
feat(build-mode): add proactive TDD enforcement with smart hook detection

### DIFF
--- a/build-mode/hooks/hooks.json
+++ b/build-mode/hooks/hooks.json
@@ -1,13 +1,25 @@
 {
   "description": "Build-mode quality gates: TDD reminders, CI validation, and progress preservation",
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Analyze the user's message. If it involves implementing code, modifying functionality, fixing bugs, or adding features to code files (*.ts, *.tsx, *.js, *.jsx, *.py, *.go, *.rs, etc.):\n\nReturn JSON with:\n- \"continue\": true\n- \"systemMessage\": \"<tdd-workflow>\\n## TDD Required\\n\\nBefore editing any code file, follow RED-GREEN-REFACTOR:\\n1. Write a failing test first\\n2. Run tests to confirm failure (for the RIGHT reason)\\n3. Write minimal code to pass\\n4. Run tests to confirm pass\\n\\nTest files (*.test.ts, *.spec.ts) can always be edited.\\nConfig/docs (*.json, *.md, *.yaml) skip TDD.\\n</tdd-workflow>\"\n\nIf the message is NOT about implementation (questions, research, planning), return only:\n- \"continue\": true\n\nAlways approve.",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "TDD Check: First check the file path. If it's a non-code file (*.md, *.json, *.yaml, *.yml, *.txt, *.css, *.html, plan files, config files, documentation), return 'approve' immediately - TDD does not apply to these files. For actual code files (*.ts, *.tsx, *.js, *.jsx, *.py, *.go, *.rs, etc.), verify a failing test exists for this behavior. If no test exists yet, gently remind to write the test first. If test already exists and fails for the right reason, approve the write. Return 'approve' to proceed or provide a brief reminder about TDD if needed.",
+            "prompt": "TDD Gate for Write/Edit operations.\n\n## Step 1: Check file type\nIf the file path is a non-code file (*.md, *.json, *.yaml, *.yml, *.txt, *.css, *.html, *.config.*, plan files, documentation), return 'approve' immediately.\n\n## Step 2: Check if it's a TEST file\nIf the file being edited IS a test file (*.test.ts, *.spec.ts, *.test.js, *.test.tsx, *_test.py, *_test.go, etc.), return 'approve' - writing tests is always allowed.\n\n## Step 3: For implementation code files\nLook at the CONVERSATION CONTEXT for evidence of TDD workflow:\n- Was a test file recently written or edited for this feature?\n- Was 'bun test', 'npm test', 'pytest', 'go test' or similar run recently?\n- Did test output show failures related to what's being implemented?\n\nIf YES to any of these: return 'approve' - TDD workflow is being followed.\n\nIf NO evidence of tests in conversation: return with a systemMessage reminder:\n\"<tdd-reminder>No test evidence found in conversation. Remember TDD: write failing test first, then implement.</tdd-reminder>\"\n\nThen return 'approve' to allow the edit. Use soft reminders, not hard blocks.",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
# User description
## Summary

Adds proactive TDD enforcement through UserPromptSubmit hook and improves PreToolUse hook to check conversation context for test evidence instead of hard blocking.

## Why

Previously, TDD enforcement was too strict—it blocked edits even when agents correctly followed TDD workflow (write test → run test → edit code). The hook couldn't see that tests were already written, causing frustrating errors like "Please write a failing test first" even after tests were already created and failing.

## Design Decisions

- **Approach:** Two-layer defense with proactive guidance (UserPromptSubmit) + smart verification (PreToolUse)
- **Alternatives considered:** Softer PreToolUse (warn once, block on retry) rejected because it wastes edit attempts
- **Trade-offs:** Relies on hook system reading conversation context

## What Changed

- `build-mode/hooks/hooks.json` - Enhanced hook configuration with UserPromptSubmit and improved PreToolUse

### Key Changes

- Add UserPromptSubmit hook to inject TDD workflow reminder at start of implementation tasks
- Improve PreToolUse hook to check conversation context for test evidence before blocking
- Always allow test file edits (*.test.ts, *.spec.ts) without TDD gate
- Always approve non-code files (config, docs, markdown) without TDD gate
- Use soft reminders instead of hard blocks when no test evidence found

## How to Test

1. Start a build-mode session
2. Request an implementation task
3. Verify UserPromptSubmit injects TDD guidance
4. Write a test file (should succeed)
5. Run tests (should show failure)
6. Edit implementation code (should succeed with test evidence in context)
7. Verify PreToolUse allows the edit without blocking

<details>
<summary>Implementation Plan</summary>

# Fix TDD Hook: Too Strict Blocking

## Problem
The PreToolUse TDD hook blocks edits even when the agent already wrote a failing test. The hook doesn't have context to know tests were already written—it just sees "editing .ts file" and blocks.

## Root Cause
The hook can't "verify a failing test exists" because it only sees the Edit tool input, not conversation history.

## Solution: Smarter PreToolUse Hook

Rewrite the hook prompt to:
1. Check if this is a code file (keep existing logic)
2. Look for evidence in recent conversation that a test was written/run
3. If test evidence exists → approve
4. If no evidence → remind (not block hard)

### Two-Layer Approach

1. **UserPromptSubmit** (proactive): Inject TDD reminder at start of implementation tasks
2. **PreToolUse** (verification): Check for test evidence, remind if missing, but don't hard-block

This prevents the frustrating loop where the agent does TDD correctly but still gets blocked.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds proactive TDD guidance and smarter verification in build-mode to reduce false blocks while keeping teams on the Red-Green-Refactor path.

- **New Features**
  - Add UserPromptSubmit hook to show a TDD workflow reminder for implementation tasks.
  - Update PreToolUse to scan conversation for recent tests/test runs and approve edits; if none found, send a soft TDD reminder and still approve.
  - Always allow edits to test files; auto-approve non-code files (docs/config).

<sup>Written for commit 06a1416e4d9015d339015e6185f5975f5d4ef48a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the TDD enforcement mechanism by introducing proactive guidance and context-aware verification to prevent unnecessary blocking of code edits. Updates the hook configuration to allow seamless transitions between writing tests and implementing code while maintaining quality standards.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>feat-build-mode-add-pr...</td><td>January 19, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/202?tool=ast>(Baz)</a>.