### PR TITLE
docs(claude): add versioning guidance for plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# Claude Code Guidelines
+
+## Versioning Requirements
+
+When modifying any plugin, you MUST update version numbers in ALL locations.
+
+### Semantic Versioning
+
+- **PATCH** (x.y.Z): Bug fixes, documentation, minor tweaks
+- **MINOR** (x.Y.0): New features, backward-compatible changes
+- **MAJOR** (X.0.0): Breaking changes, removed features
+
+### Files to Update
+
+For each plugin change, update these files:
+
+#### 1. Plugin Manifest
+`<plugin>/.claude-plugin/plugin.json` → Update `"version"` field
+
+#### 2. Root README
+`README.md` → Update version in plugin section header:
+- `### Plan Mode (vX.Y.Z)`
+- `### Build Mode (vX.Y.Z)`
+- `### Git (vX.Y.Z)`
+
+#### 3. Plugin README
+`<plugin>/README.md` → Update version in:
+- Title: `# <Plugin> Plugin vX.Y.Z`
+- Version History section (add entry describing changes)
+
+### Version History Format
+
+Add a new entry at the top of the Version History section:
+
+```markdown
+- **vX.Y.Z**: Brief description of changes
+```
+
+If the plugin README lacks a Version History section, add one before the License section.
+
+### When to Version
+
+**DO bump version:**
+- New features, commands, agents, skills, hooks
+- Bug fixes
+- Configuration changes
+- Behavior changes
+
+**DON'T bump version:**
+- Typo fixes in comments
+- Whitespace/formatting only
+- Changes to unrelated files
+
+### Checklist
+
+Before completing any plugin change:
+- [ ] Determine version bump type (patch/minor/major)
+- [ ] Update `<plugin>/.claude-plugin/plugin.json`
+- [ ] Update `README.md` section header
+- [ ] Update `<plugin>/README.md` title
+- [ ] Add Version History entry in `<plugin>/README.md`


### PR DESCRIPTION
# User description
## Summary

Add CLAUDE.md to instruct Claude developers to maintain consistent version numbers across all plugin locations when making changes.

## Changes

- Created `CLAUDE.md` with comprehensive versioning guidance
- Covers semantic versioning rules (PATCH/MINOR/MAJOR)
- Specifies all 4 locations to update: plugin.json, root README, plugin README title, and Version History

## Files Changed

- `CLAUDE.md` (new) - 61 lines

<details>
<summary>Implementation Plan</summary>

# Plan: Add CLAUDE.md with Versioning Guidance

## Summary

Add a CLAUDE.md file to the repository root that instructs Claude to update version numbers across all locations when making changes to any plugin.

## Current State

**Monorepo structure** with 3 plugins: `build-mode`, `plan-mode`, `git`

### Version Locations by Plugin

| Plugin | plugin.json | Root README | Plugin README |
|--------|-------------|-------------|---------------|
| plan-mode | `plan-mode/.claude-plugin/plugin.json` → `"version": "2.3.1"` | Line 63: `### Plan Mode (v2.3.1)` | Title: `# Plan Mode Plugin v2.3.1` + Version History section |
| build-mode | `build-mode/.claude-plugin/plugin.json` → `"version": "1.0.0"` | Line 83: `### Build Mode (v1.0.0)` | No version (should add) |
| git | `git/.claude-plugin/plugin.json` → `"version": "1.0.0"` | Line 107: `### Git (v1.0.0)` | No version (should add) |

## Implementation

Create `/CLAUDE.md` with versioning guidance covering semantic versioning, file locations, Version History format, and a checklist.

</details>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduces a <code>CLAUDE.md</code> file to establish standardized versioning protocols for AI-driven development within the plugin monorepo. Ensures that version updates are consistently applied across manifests, root documentation, and individual plugin READMEs.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>chore-plugins-archive-...</td><td>January 19, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/203?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added CLAUDE.md with plugin versioning guidance to keep versions consistent across the monorepo. It outlines semantic versioning (patch/minor/major), lists where to update (plugin.json, root README, plugin README title, Version History), and includes a short checklist to prevent missed updates.

<sup>Written for commit 0eecd83abec1f485955a2ba78e964b2da1432dbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

