### PR TITLE
feat(git): add /commit-push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ TDD-driven implementation with quality gates:
 | `visual-tester` | UI verification |
 | `completion-validator` | Final gate |
 
-### Git (v1.0.0)
+### Git (v1.1.0)
 
 Git workflow automation:
 
@@ -112,6 +112,7 @@ Git workflow automation:
 | Command | Purpose |
 |---------|---------|
 | `/commit` | Conventional commit with selective staging |
+| `/commit-push` | Commit and push in one step |
 | `/branch` | Create branch: `username/type/slug` |
 | `/pr` | Create PR with template body |
 | `/push` | Safe push with force-with-lease |

--- a/git/.claude-plugin/plugin.json
+++ b/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Git workflow automation with conventional commits, smart branching, PR templates, and safe push/sync operations",
   "author": {
     "name": "Roderik van der Veer",

--- a/git/README.md
+++ b/git/README.md
@@ -1,4 +1,4 @@
-# Git Plugin
+# Git Plugin v1.1.0
 
 Git workflow automation with conventional commits, smart branching, PR templates, and safe push/sync operations.
 
@@ -7,6 +7,7 @@ Git workflow automation with conventional commits, smart branching, PR templates
 | Command | Purpose |
 |---------|---------|
 | `/commit` | Create conventional commit with selective staging |
+| `/commit-push` | Commit and push to remote in one step |
 | `/branch` | Create branch with `username/type/slug` naming |
 | `/pr` | Create PR with template-based body, draft/auto-merge options |
 | `/push` | Push with safety checks and force-with-lease |
@@ -77,6 +78,11 @@ Helper scripts in `scripts/`:
 - `context.sh` - Git context (branch, status, changes)
 - `pr-info.sh` - PR metadata
 - `pr-checks.sh` - CI status
+
+## Version History
+
+- **v1.1.0**: Add `/commit-push` command for combined commit and push workflow
+- **v1.0.0**: Initial release with commit, branch, pr, push, sync, clean-gone commands
 
 ## License
 

--- a/git/commands/commit-push.md
+++ b/git/commands/commit-push.md
@@ -1,0 +1,114 @@
+---
+name: commit-push
+description: Create conventional commit and push to remote
+argument-hint: [message hint] [--force-with-lease]
+---
+
+Create a conventional commit with selective staging and push to remote in one step.
+
+## Current State
+
+```bash
+git status --short
+git diff --stat
+git branch --show-current
+git log origin/$(git branch --show-current)..HEAD --oneline 2>/dev/null || echo "New branch"
+```
+
+## Workflow
+
+1. **Review changes** - Check staged and unstaged files
+2. **Stage selectively** - Add only relevant files (never `git add .`)
+3. **Check for secrets** - Ensure no .env, .pem, .key, credentials staged
+4. **Determine type** - Choose commit type based on changes
+5. **Write message** - Use conventional format with descriptive body
+6. **Verify branch** - Block if on main/master
+7. **Push** - With appropriate flags (-u for new, --force-with-lease after rebase)
+
+## Format
+
+```
+type(scope): short description
+
+- Bullet point explaining what changed
+- Another bullet point if needed
+```
+
+## Commands
+
+```bash
+# Stage specific files
+git add src/feature.ts src/feature.test.ts
+
+# Commit with heredoc for multi-line
+git commit -m "$(cat <<'EOF'
+feat(auth): add login endpoint
+
+- Added POST /api/auth/login
+- Created AuthService with password verification
+- Added unit tests for authentication flow
+EOF
+)"
+
+# Push (new branch)
+git push -u origin $(git branch --show-current)
+
+# Push (existing branch)
+git push
+
+# Push (after rebase)
+git push --force-with-lease
+```
+
+## Push Types
+
+| Situation | Command | Why |
+|-----------|---------|-----|
+| New branch | `git push -u origin branch` | Sets upstream tracking |
+| Normal commits | `git push` | Standard push |
+| After rebase | `git push --force-with-lease` | Safer than --force |
+
+## Safety Checks
+
+### Protected Branches
+
+```bash
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "ERROR: Cannot push directly to $BRANCH"
+  exit 1
+fi
+```
+
+### Force Push Safety
+
+Always use `--force-with-lease` instead of `--force`:
+- Fails if remote has new commits you haven't seen
+- Prevents accidentally overwriting others' work
+
+## Constraints
+
+**Banned:**
+- `git add .` or `git add -A` without reviewing
+- Committing secrets, credentials, API keys, .env files
+- Amending commits that have been pushed
+- `git push --force` (use `--force-with-lease` instead)
+- Pushing directly to main/master
+
+**Required:**
+- Conventional commit format: `type(scope): description`
+- Selective file staging
+- Multi-line body for non-trivial changes (3+ files or logic changes)
+- Use `-u` flag for new branches
+- Use `--force-with-lease` after rebase/amend
+
+## Success Criteria
+
+- [ ] Commit uses `type(scope): description` format
+- [ ] Only relevant files staged
+- [ ] No secrets or sensitive files committed
+- [ ] Multi-line body for complex changes
+- [ ] Not pushing to protected branch
+- [ ] Using `-u` flag for new branches
+- [ ] Using `--force-with-lease` (not `--force`) if needed
+- [ ] Push completed successfully


### PR DESCRIPTION
# User description
## Summary

Add a new `/commit-push` command that combines commit and push workflows into a single operation. This is a convenience command for the common pattern of making a commit and immediately pushing to remote.

## What Changed

- **New command**: `/commit-push` - Commit with conventional format and push in one step
- **Safety checks**: Enforces selective staging, secret detection, and protected branch blocking
- **Version bump**: Updated git plugin to v1.1.0
- **Documentation**: Added command to README tables and version history

## Why

The combined workflow eliminates repetitive command chaining and maintains consistency with the plugin's safety-first approach. Users can now use `/commit-push` as a convenience when they want both operations together, while `/commit` and `/push` remain available for individual operations.

## Files Changed

- `git/commands/commit-push.md` - New command definition
- `git/.claude-plugin/plugin.json` - Version bump
- `README.md` - Updated git section  
- `git/README.md` - Added command, version history

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduces the <code>/commit-push</code> command to streamline the git workflow by combining conventional commits and remote pushing into a single operation. Enhances the git plugin by enforcing safety checks like secret detection and protected branch blocking during this combined process.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/204?tool=ast&topic=Docs+and+Versioning>Docs and Versioning</a>
        </td><td>Update the plugin version to <code>1.1.0</code> and document the new command across the project's README files and version history.<details><summary>Modified files (3)</summary><ul><li>README.md</li>
<li>git/.claude-plugin/plugin.json</li>
<li>git/README.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>docs-readme-add-compre...</td><td>January 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/204?tool=ast&topic=Commit-Push+Command>Commit-Push Command</a>
        </td><td>Implement the <code>/commit-push</code> command definition, including workflow steps for selective staging, conventional commit formatting, and safe push operations using <code>--force-with-lease</code>.<details><summary>Modified files (1)</summary><ul><li>git/commands/commit-push.md</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/204?tool=ast>(Baz)</a>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new /commit-push command that commits (conventional format) and pushes in one step with safety checks. Also bumps the git plugin to v1.1.0 and updates docs.

- **New Features**
  - Add /commit-push to create a commit and push in one step.
  - Enforces selective staging, secret checks, protected-branch blocking, and use of --force-with-lease after rebase.
  - Update READMEs with the new command and version history.

- **Dependencies**
  - Bump git plugin to v1.1.0.

<sup>Written for commit 56c9a4dad3638ad0ebbb00309a1b359e6d0ba2f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

