### PR TITLE
fix: correct Stop hook JSON validation by using natural language instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This marketplace provides three integrated plugins that work together:
 
 ## Plugins
 
-### Plan Mode (v2.3.1)
+### Plan Mode (v2.3.2)
 
 Structured planning with a 7-phase workflow:
 
@@ -80,7 +80,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.0.0)
+### Build Mode (v1.0.1)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,4 +1,4 @@
-# Build Mode Plugin
+# Build Mode Plugin v1.0.1
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
@@ -212,6 +212,11 @@ Every completion claim requires evidence:
 
 - **plan-mode**: Implementation planning and architecture
 - **devtools**: Developer tooling and utilities
+
+## Version History
+
+- **v1.0.1**: Fixed Stop hook JSON validation error by using natural language instructions instead of explicit approve/block format
+- **v1.0.0**: Initial release with TDD workflow, subagent orchestration, visual testing, and quality gates
 
 ## License
 

--- a/build-mode/hooks/hooks.json
+++ b/build-mode/hooks/hooks.json
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Completion Gate: Before stopping, verify: 1) All tests pass (evidence required), 2) Lint is clean, 3) No TODO items remaining for current task, 4) Self-review checklist completed. If any verification is missing, return 'block' with specific items needed. Otherwise return 'approve'.",
+            "prompt": "Completion Gate: Before stopping, verify: 1) All tests pass (evidence required), 2) Lint is clean, 3) No TODO items remaining for current task, 4) Self-review checklist completed. If any verification is missing, the agent should continue and address those items. If all verifications pass, the agent should stop.",
             "timeout": 15
           }
         ]

--- a/plan-mode/.claude-plugin/plugin.json
+++ b/plan-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-mode",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "7-phase planning workflow with structured exploration, clarifying questions, confidence-based validation, and Linear integration",
   "author": {
     "name": "Roderik van der Veer"

--- a/plan-mode/README.md
+++ b/plan-mode/README.md
@@ -1,4 +1,4 @@
-# Plan Mode Plugin v2.3.1
+# Plan Mode Plugin v2.3.2
 
 Enhanced planning workflow for Claude Code with structured exploration, clarifying questions, confidence-based validation, and Linear integration.
 
@@ -198,6 +198,7 @@ Linear integration uses OAuth (SSE transport) - authenticate via browser when pr
 
 ## Version History
 
+- **v2.3.2**: Fixed Stop hook JSON validation error by using natural language instructions instead of explicit approve/block format
 - **v2.3.1**: Fixed skill name format for AgentSkills compliance (lowercase-hyphens), added TOC to reference files
 - **v2.3.0**: Added Octocode MCP for semantic code research, LSP analysis, and GitHub cross-repo search
 - **v2.2.0**: Added brainstorming patterns (one question at a time, lead with recommendation, incremental presentation, YAGNI ruthlessly, revisit flexibility), Context7 MCP for latest documentation

--- a/plan-mode/hooks/hooks.json
+++ b/plan-mode/hooks/hooks.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check if this session involved planning (plan mode, feature planning, task breakdown). If YES and a plan was created:\n\n1. Remind to use AskUserQuestion to offer Linear integration:\n   - Option 1: Create new Linear ticket with the plan\n   - Option 2: Update existing Linear ticket (user provides ID)\n   - Option 3: Skip Linear integration\n\n2. If Linear was already offered or this wasn't a planning session, approve stopping.\n\nReturn 'approve' to stop or 'block' with reminder about Linear integration if planning occurred but Linear wasn't offered.",
+            "prompt": "Check if this session involved planning (plan mode, feature planning, task breakdown). If YES and a plan was created:\n\n1. Check if Linear integration was offered via AskUserQuestion with these options:\n   - Option 1: Create new Linear ticket with the plan\n   - Option 2: Update existing Linear ticket (user provides ID)\n   - Option 3: Skip Linear integration\n\n2. If Linear was already offered OR this wasn't a planning session, the agent should stop.\n\n3. If planning occurred but Linear wasn't offered, the agent should continue to offer Linear integration.",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
# User description
## Summary

Fixed Stop hook JSON validation errors in plan-mode and build-mode plugins by rewriting prompts to use natural language instructions instead of explicit `approve`/`block` responses.

**Problem:** Stop hooks were failing with "JSON validation failed" because they requested invalid response formats.

**Solution:** Rewrote Stop hook prompts to use natural language, letting Claude Code's internal evaluation handle JSON formatting.

**Version Updates:**
- plan-mode: v2.3.1 → v2.3.2
- build-mode: v1.0.0 → v1.0.1

## Related Issue

[GitHub Issue #11947 - Prompt-based Stop hook JSON validation error](https://github.com/anthropics/claude-code/issues/11947)

<details>
<summary>Implementation Plan</summary>

# Fix Stop Hook JSON Validation Errors

## Problem

Stop hooks in \`plan-mode/hooks/hooks.json\` and \`build-mode/hooks/hooks.json\` fail with "JSON validation failed" because they use an incorrect response format.

**Current (wrong)**: Prompts ask for \`'approve'\` or \`'block'\` responses
**Expected**: Claude Code expects \`{"ok": boolean, "reason": string}\` schema

## Solution

Rewrite Stop hook prompts to use **natural language instructions** without explicit JSON format requests. Let Claude Code's internal evaluation prompt handle JSON formatting.

### Changes Made

1. **plan-mode/hooks/hooks.json** - Line 22
   - Changed from: "Return 'approve' to stop or 'block' with reminder..."
   - Changed to: "If Linear was already offered OR this wasn't a planning session, the agent should stop. If planning occurred but Linear wasn't offered, the agent should continue to offer Linear integration."

2. **build-mode/hooks/hooks.json** - Line 34
   - Changed from: "If any verification is missing, return 'block'... Otherwise return 'approve'."
   - Changed to: "If any verification is missing, the agent should continue and address those items. If all verifications pass, the agent should stop."

3. Updated version numbers in plugin manifests and READMEs following semantic versioning

</details>

## Files Changed
- README.md
- build-mode/.claude-plugin/plugin.json
- build-mode/README.md
- build-mode/hooks/hooks.json
- plan-mode/.claude-plugin/plugin.json
- plan-mode/README.md
- plan-mode/hooks/hooks.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Stop hook JSON validation errors by switching prompts to natural language in plan-mode and build-mode. This removes schema failures when stopping; versions bumped to plan-mode v2.3.2 and build-mode v1.0.1.

- **Bug Fixes**
  - plan-mode/hooks: Prompt now tells the agent to stop or continue based on whether planning happened and Linear was offered.
  - build-mode/hooks: Prompt now tells the agent to stop or continue based on test/lint/TODO/self-review checks.

<sup>Written for commit 6299c99ca93be05f4484366862a60d52d691057f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes JSON validation errors in the Stop hooks by replacing explicit 'approve'/'block' instructions with natural language prompts. This change ensures compatibility with the internal schema evaluation of the <code>plan-mode</code> and <code>build-mode</code> plugins.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/205?tool=ast&topic=Hook+Prompt+Fixes>Hook Prompt Fixes</a>
        </td><td>Update the <code>prompt</code> field in <code>hooks.json</code> for both plugins to use natural language instead of explicit return values, preventing schema validation failures.<details><summary>Modified files (2)</summary><ul><li>build-mode/hooks/hooks.json</li>
<li>plan-mode/hooks/hooks.json</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>feat-build-mode-add-pr...</td><td>January 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/settlemint/agent-marketplace/205?tool=ast&topic=Version+Updates>Version Updates</a>
        </td><td>Increment the version numbers in <code>plugin.json</code> and update the <code>README.md</code> files to document the fix for the Stop hook validation error.<details><summary>Modified files (5)</summary><ul><li>README.md</li>
<li>build-mode/.claude-plugin/plugin.json</li>
<li>build-mode/README.md</li>
<li>plan-mode/.claude-plugin/plugin.json</li>
<li>plan-mode/README.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roderik@settlemint.com</td><td>feat-git-add-commit-pu...</td><td>January 19, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/settlemint/agent-marketplace/205?tool=ast>(Baz)</a>.