### PR TITLE
feat(git): add /update-pr command for updating PR title and body

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ TDD-driven implementation with quality gates:
 | `visual-tester` | UI verification |
 | `completion-validator` | Final gate |
 
-### Git (v1.1.0)
+### Git (v1.2.0)
 
 Git workflow automation:
 
@@ -115,6 +115,7 @@ Git workflow automation:
 | `/commit-push` | Commit and push in one step |
 | `/branch` | Create branch: `username/type/slug` |
 | `/pr` | Create PR with template body |
+| `/update-pr` | Update PR title and body from commits |
 | `/push` | Safe push with force-with-lease |
 | `/sync` | Merge/rebase from main |
 | `/clean-gone` | Remove deleted branches |

--- a/git/.claude-plugin/plugin.json
+++ b/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Git workflow automation with conventional commits, smart branching, PR templates, and safe push/sync operations",
   "author": {
     "name": "Roderik van der Veer",

--- a/git/README.md
+++ b/git/README.md
@@ -1,4 +1,4 @@
-# Git Plugin v1.1.0
+# Git Plugin v1.2.0
 
 Git workflow automation with conventional commits, smart branching, PR templates, and safe push/sync operations.
 
@@ -10,6 +10,7 @@ Git workflow automation with conventional commits, smart branching, PR templates
 | `/commit-push` | Commit and push to remote in one step |
 | `/branch` | Create branch with `username/type/slug` naming |
 | `/pr` | Create PR with template-based body, draft/auto-merge options |
+| `/update-pr` | Update PR title and body from commits, preserving valuable content |
 | `/push` | Push with safety checks and force-with-lease |
 | `/sync` | Merge or rebase from main with conflict guidance |
 | `/clean-gone` | Remove local branches deleted from remote |
@@ -81,6 +82,7 @@ Helper scripts in `scripts/`:
 
 ## Version History
 
+- **v1.2.0**: Add `/update-pr` command to update PR title and body from commits, preserving user description and review agent findings
 - **v1.1.0**: Add `/commit-push` command for combined commit and push workflow
 - **v1.0.0**: Initial release with commit, branch, pr, push, sync, clean-gone commands
 

--- a/git/commands/update-pr.md
+++ b/git/commands/update-pr.md
@@ -1,0 +1,139 @@
+---
+name: update-pr
+description: Update PR title and body from commits
+argument-hint: [--regenerate] [PR number]
+---
+
+Update an existing PR's title and body based on current commits, preserving valuable content.
+
+## Current State
+
+```bash
+gh pr view --json number,title,body,baseRefName 2>/dev/null || echo "No PR found"
+```
+
+## Workflow
+
+### Step 1: Validate PR Exists
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null)
+[[ -z "$PR_NUM" ]] && echo "ERROR: No PR found for current branch"
+```
+
+If no PR found → stop and instruct to use `/pr` first.
+
+### Step 2: Analyze Existing Body
+
+Fetch current PR body and identify sections:
+
+```bash
+gh pr view --json body -q '.body'
+```
+
+**Parse for preserved content:**
+- `# User description` block (between `# User description` and `---`)
+- `## Summary by cubic` block (between `<!-- This is an auto-generated description by cubic. -->` markers)
+- Greptile findings (`<h3>Greptile Summary</h3>` to end of that block)
+- Gemini summaries (`## Summary of Changes` from gemini-code-assist)
+- Implementation Plan (`<details><summary>Implementation Plan</summary>` block)
+
+### Step 3: Decide Update Mode
+
+**Use Full Regenerate mode if:**
+- `--regenerate` flag is passed, OR
+- Body has no `# User description` section, OR
+- Body is dominated by auto-generated noise without clear structure
+
+**Otherwise use Incremental Update mode.**
+
+### Step 4: Gather Current Commits
+
+```bash
+BASE=$(gh pr view --json baseRefName -q '.baseRefName')
+git log origin/${BASE}..HEAD --pretty=format:"%s" | head -20
+git diff --stat origin/${BASE}
+```
+
+### Step 5: Generate Title
+
+- Single commit → use commit message as title
+- Multiple commits → `type(scope): summary of changes`
+- Mixed types → use most significant (feat > fix > refactor > docs > chore)
+
+### Step 6: Generate/Update Body
+
+**For Incremental Update:**
+1. Keep preserved `# User description` section exactly as-is
+2. Update `## Commits` with current commit list
+3. Update `## Files Changed` / `## What Changed` with current diff stat
+4. If plan file exists locally (`~/.claude/plans/*.md`), update Implementation Plan
+5. If no local plan but PR has Implementation Plan, keep existing
+6. Keep review agent sections (cubic, Greptile, Gemini) at the end
+
+**For Full Regenerate:**
+1. Select template based on primary commit type:
+
+| Commit Type | Template |
+|-------------|----------|
+| `feat` | `templates/pr-feature.md` |
+| `refactor`, `docs`, `chore`, `test` | `templates/pr-refactor.md` |
+| `fix`, other | `templates/pr-body.md` |
+
+2. Read template from `skills/using-git/templates/`
+3. Fill placeholders:
+   - `{{SUMMARY}}` - Brief description from commits
+   - `{{COMMITS}}` - List of commits
+   - `{{FILES_CHANGED}}` - Files modified from `git diff --stat`
+   - `{{WHY}}` - Extract from plan file or commit bodies
+   - `{{PLAN}}` - Full plan content if available
+
+4. Append preserved review agent findings at the end (cubic, Greptile, Gemini)
+
+**Include plan if available:**
+
+```bash
+PLAN_FILE=$(ls -t ~/.claude/plans/*.md 2>/dev/null | head -1)
+if [[ -n "$PLAN_FILE" ]]; then
+  PLAN_CONTENT=$(cat "$PLAN_FILE")
+fi
+```
+
+### Step 7: Update PR
+
+```bash
+gh pr edit $PR_NUM --title "type(scope): description"
+gh pr edit $PR_NUM --body "$(cat <<'EOF'
+[assembled body]
+EOF
+)"
+```
+
+### Step 8: Confirm Update
+
+```bash
+gh pr view --json url -q '.url'
+```
+
+## Constraints
+
+**Banned:**
+- Destroying user-written content in `# User description` section
+- Removing review agent findings (cubic, Greptile, Gemini) without `--regenerate`
+- Updating PR that doesn't exist
+- Replacing good structure with worse structure
+
+**Required:**
+- Preserve review agent findings by default
+- Title matches primary commit type
+- Incremental update unless `--regenerate` or body is broken
+
+## Success Criteria
+
+- [ ] PR exists for current branch
+- [ ] User description preserved (unless `--regenerate`)
+- [ ] Review agent sections preserved
+- [ ] Commits list reflects current branch state
+- [ ] Files changed reflects current diff
+- [ ] Title updated if commits changed
+- [ ] PR URL returned to user


### PR DESCRIPTION
## Summary

Add a new `/update-pr` command to the git plugin that updates existing PR titles and bodies based on current commits while preserving valuable content.

## Why

When working on a PR, commits change over time but manually updating the PR description is tedious. This command automates updating the PR while intelligently preserving user-written descriptions and review agent findings (cubic, Greptile, Gemini).

## Design Decisions

- **Approach:** Two-mode update system (incremental vs full regenerate)
- **Alternatives considered:** Always regenerating the entire body, but this would destroy valuable user content
- **Trade-offs:** More complex parsing logic to preserve content, but better user experience

## What Changed

```
 README.md                      |   3 +-
 git/.claude-plugin/plugin.json |   2 +-
 git/README.md                  |   4 +-
 git/commands/update-pr.md      | 139 +++++++++++++++++++++++++++++++++
 4 files changed, 145 insertions(+), 3 deletions(-)
```

### Key Changes

- New `/update-pr` command that updates PR title and body from commits
- Incremental update mode preserves `# User description` and review agent sections
- Full regenerate mode with `--regenerate` flag for broken PR bodies
- Smart title generation based on commit types (feat > fix > refactor > docs > chore)
- Template-based body generation using existing PR templates

## How to Test

1. [ ] Create a PR with `/pr`
2. [ ] Make additional commits
3. [ ] Run `/update-pr` and verify title/body updates correctly
4. [ ] Verify user description is preserved (if present)
5. [ ] Run `/update-pr --regenerate` and verify full regeneration

## Commits

- feat(git): add /update-pr command for updating PR title and body

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new /update-pr command to the git plugin that updates existing PR titles and bodies from the latest commits. Preserves user-written content by default and offers a full regenerate mode when needed.

- **New Features**
  - Add /update-pr with incremental updates that keep “User description” and review agent sections (cubic, Greptile, Gemini).
  - Support `--regenerate` to rebuild the body using PR templates when the structure is broken.
  - Generate smart titles based on commit types (feat > fix > refactor > docs > chore).
  - Keep or update Implementation Plan if available; update docs and bump plugin version to v1.2.0.

<sup>Written for commit 3cdf59737b297b9bb334b4a0d515a3ea22bc9670. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

