### PR TITLE
feat(build-mode): replace LLM hooks with fast command-based gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.0.3)
+### Build Mode (v1.1.0)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,4 +1,4 @@
-# Build Mode Plugin v1.0.3
+# Build Mode Plugin v1.1.0
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
@@ -215,6 +215,7 @@ Every completion claim requires evidence:
 
 ## Version History
 
+- **v1.1.0**: Replaced slow LLM-based hooks with fast command-based hooks - TDD enforcement now via emphatic skill instructions (superpowers-style) instead of per-edit LLM validation. Zero LLM calls per edit cycle.
 - **v1.0.3**: Fixed TDD hook test detection - improved prompt to properly recognize test file edits and test runs in conversation history
 - **v1.0.2**: Changed TDD hook from soft reminders to hard blocking - code edits now require test evidence
 - **v1.0.1**: Fixed Stop hook JSON validation error by using natural language instructions instead of explicit approve/block format

--- a/build-mode/hooks/hooks.json
+++ b/build-mode/hooks/hooks.json
@@ -1,26 +1,14 @@
 {
-  "description": "Build-mode quality gates: TDD reminders, CI validation, and progress preservation",
+  "description": "Build-mode quality gates: fast TDD reminder, CI validation, and progress preservation",
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Analyze the user's message. If it involves implementing code, modifying functionality, fixing bugs, or adding features to code files (*.ts, *.tsx, *.js, *.jsx, *.py, *.go, *.rs, etc.):\n\nReturn JSON with:\n- \"continue\": true\n- \"systemMessage\": \"<tdd-workflow>\\n## TDD Required\\n\\nBefore editing any code file, follow RED-GREEN-REFACTOR:\\n1. Write a failing test first\\n2. Run tests to confirm failure (for the RIGHT reason)\\n3. Write minimal code to pass\\n4. Run tests to confirm pass\\n\\nTest files (*.test.ts, *.spec.ts) can always be edited.\\nConfig/docs (*.json, *.md, *.yaml) skip TDD.\\n</tdd-workflow>\"\n\nIf the message is NOT about implementation (questions, research, planning), return only:\n- \"continue\": true\n\nAlways approve.",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "TDD Gate for Write/Edit operations.\n\n## Step 1: Check file type\nIf the file path matches ANY of these patterns, return {\"decision\": \"approve\"} immediately:\n- Documentation: *.md, *.txt, *.rst\n- Config files: *.json, *.yaml, *.yml, *.toml, *.config.*, .*, package.json, tsconfig.json\n- Styles: *.css, *.scss, *.less\n- Markup: *.html, *.svg\n- Plan files: any path containing .claude/plans/\n- Lock files: *.lock, *-lock.json\n\n## Step 2: Check if it's a TEST file\nIf the file being edited IS a test file (matches any of: *.test.ts, *.spec.ts, *.test.js, *.spec.js, *.test.tsx, *.spec.tsx, *_test.py, *_test.go, *_test.rs, test_*.py, *_spec.rb), return {\"decision\": \"approve\"} - writing tests is always encouraged.\n\n## Step 3: For implementation code files - Check for TDD evidence\nExtract the base filename (e.g., 'deployment-id' from 'deployment-id.ts').\n\nLook in the CONVERSATION HISTORY for ANY of these evidence types:\n\n### Evidence Type A: Corresponding test file was edited\nA file with matching base name + test pattern was edited earlier in this conversation:\n- {basename}.test.ts, {basename}.spec.ts, {basename}.test.js, etc.\n- Example: Editing 'utils/foo.ts' after 'utils/foo.test.ts' was edited = APPROVE\n\n### Evidence Type B: Test command was run\nA bash command containing test-related keywords was executed:\n- 'bun test', 'npm test', 'vitest', 'jest', 'pytest', 'go test', 'cargo test'\n- The output showed test results (pass/fail counts, test names, assertions)\n\n### Evidence Type C: Test failures visible\nTest output in the conversation shows failing tests related to the code being edited.\n\n## Decision Logic\n- If ANY evidence type (A, B, or C) is found: return {\"decision\": \"approve\"}\n- If NO evidence found: return {\"decision\": \"block\", \"reason\": \"TDD Required: No test evidence found for this code. Write a failing test first, run it to see it fail, then implement the code to make it pass.\"}\n\n## Important\n- Be GENEROUS in recognizing evidence - if tests were written and run, approve the edit\n- The test file doesn't need to be for the exact function, just for the same module/file\n- Test runs from earlier in the conversation still count as evidence",
-            "timeout": 10
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/tdd-gate.sh",
+            "timeout": 2
           }
         ]
       }
@@ -30,9 +18,9 @@
         "matcher": "*",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Completion Gate: Before stopping, verify: 1) All tests pass (evidence required), 2) Lint is clean, 3) No TODO items remaining for current task, 4) Self-review checklist completed. If any verification is missing, the agent should continue and address those items. If all verifications pass, the agent should stop.",
-            "timeout": 15
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/completion-gate.sh",
+            "timeout": 5
           }
         ]
       }

--- a/build-mode/hooks/scripts/completion-gate.sh
+++ b/build-mode/hooks/scripts/completion-gate.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Completion Gate - Fast pass-through with verification reminder (no LLM call)
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Remind about verification before completion
+cat <<EOFMSG
+{
+  "continue": true,
+  "systemMessage": "Before completing: Verify tests pass, lint is clean, and CI gates satisfied. Evidence required for all claims."
+}
+EOFMSG

--- a/build-mode/hooks/scripts/tdd-gate.sh
+++ b/build-mode/hooks/scripts/tdd-gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# TDD Gate - Fast file pattern check with contextual reminders (no LLM call)
+set -uo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+# Check file type and provide appropriate guidance
+if [[ "$FILE_PATH" =~ \.(md|json|yaml|yml|toml|html|svg|css|lock)$ ]] || \
+   [[ "$FILE_PATH" =~ \.claude/plans/ ]]; then
+  # Non-code files - silent approval
+  echo '{"decision": "approve"}'
+elif [[ "$FILE_PATH" =~ (test|spec)\.(ts|tsx|js|jsx)$ ]] || \
+     [[ "$FILE_PATH" =~ _test\.(py|go|rs)$ ]] || \
+     [[ "$FILE_PATH" =~ test_.*\.py$ ]]; then
+  # Test file - encourage with brief message
+  cat <<EOFMSG
+{
+  "decision": "approve",
+  "systemMessage": "Writing test first. Good TDD practice."
+}
+EOFMSG
+else
+  # Implementation file - remind about TDD
+  cat <<EOFMSG
+{
+  "decision": "approve",
+  "systemMessage": "TDD Reminder: This is implementation code. Ensure you wrote a failing test first and watched it fail before writing this code."
+}
+EOFMSG
+fi

--- a/build-mode/skills/implementing-code/SKILL.md
+++ b/build-mode/skills/implementing-code/SKILL.md
@@ -4,6 +4,26 @@ description: Executes implementation plans with TDD-driven development, subagent
 version: 1.0.0
 ---
 
+<EXTREMELY-IMPORTANT>
+## THE IRON LAW OF TDD
+
+**NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST.**
+
+This is NOT negotiable. This is NOT optional. You cannot rationalize your way out of this.
+
+If you write code before a test:
+1. DELETE the code
+2. Write the test
+3. Watch it FAIL
+4. THEN write the implementation
+
+"Just this once" is not acceptable.
+"It's too simple to test" is not acceptable.
+"I already know it works" is not acceptable.
+
+ALL of these mean: Delete code. Start over with TDD.
+</EXTREMELY-IMPORTANT>
+
 # Execution Methodology
 
 A systematic approach to implementing plans and tasks with TDD, subagent orchestration, and verification before completion.


### PR DESCRIPTION
## Summary

Replaced slow LLM-based hooks with fast command-based alternatives in build-mode, reducing per-edit overhead from ~3 LLM calls (30+ seconds) to 0 (instant).

**Key changes:**
- Removed UserPromptSubmit, PreToolUse, and Stop prompt-based hooks
- Added `tdd-gate.sh` for instant TDD reminders (2s vs 10s)
- Added `completion-gate.sh` for verification reminders (5s vs 15s)
- Enhanced skill with emphatic TDD language (superpowers-style)
- Hooks now provide contextual guidance without LLM overhead

## Why

The old LLM-based hooks examined conversation history on every edit and Stop event, causing 30+ second delays. By moving TDD enforcement to skill instructions (which Claude naturally follows) and replacing validation with fast command-based hooks, we achieve the same discipline with zero latency.

Approach inspired by `obra/superpowers` which enforces TDD through emphatic skill language only.

## Testing

Scripts verified to work correctly:
- `tdd-gate.sh` outputs TDD reminders for implementation files, encouragement for test files, silent approval for non-code
- `completion-gate.sh` outputs verification reminders
- All hook timeouts reduced from 10-15s to 2-5s

<details>
<summary>Implementation Plan</summary>

# Lighter TDD Enforcement - Implementation Plan

## Goal

Replace all **prompt-based (LLM) hooks** with:
1. **Strong skill-based guidance** (superpowers-style emphatic language)
2. **Fast command-based hooks** that do simple file pattern checks (no LLM calls)

## Current State (Heavy)

| Hook | Type | Timeout | Problem |
|------|------|---------|---------|
| UserPromptSubmit | prompt (LLM) | 5s | Extra LLM call every message |
| PreToolUse (Write/Edit) | prompt (LLM) | 10s | Extra LLM call every edit |
| Stop | prompt (LLM) | 15s | Extra LLM call on completion |
| PostToolUse (Bash) | command | 120s | Already efficient |
| PreCompact | command | 10s | Already efficient |

**Problem**: ~3 LLM calls per edit cycle = slow, expensive, flaky

## Target State (Light)

| Hook | Type | Timeout | Change |
|------|------|---------|--------|
| UserPromptSubmit | REMOVED | - | TDD reminder moved to skill |
| PreToolUse (Write/Edit) | command | 2s | Fast file pattern check |
| Stop | command | 5s | Simple pass-through |
| PostToolUse (Bash) | command | 120s | Keep as-is |
| PreCompact | command | 10s | Keep as-is |

**Result**: 0 LLM calls per edit cycle

## Implementation

1. Created `tdd-gate.sh` - Fast file pattern check with contextual reminders
2. Created `completion-gate.sh` - Verification reminders
3. Updated `hooks.json` - Removed prompt hooks, added command hooks
4. Enhanced `implementing-code/SKILL.md` - Added emphatic TDD section
5. Bumped version to 1.1.0 (minor: new feature)

## Verification

All hooks tested and working:
- Fast execution (instant, no LLM delay)
- Correct contextual messaging
- Proper file type detection
- Version updates completed

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced LLM-based hooks with fast command gates in build-mode to remove per-edit delays and make TDD enforcement instant. TDD guidance now lives in the skill, with lightweight, contextual reminders and zero LLM calls per edit.

- **Refactors**
  - Removed prompt hooks (UserPromptSubmit, PreToolUse, Stop) and added command gates in hooks.json with 2–5s timeouts.
  - Added tdd-gate.sh for file-type checks and TDD reminders; encourages test edits and silently approves non-code.
  - Added completion-gate.sh to remind verification before stopping.
  - Strengthened implementing-code/SKILL.md with explicit TDD rules.
  - Bumped plugin version to v1.1.0 and updated READMEs.

<sup>Written for commit fe806ba7deb72d56672a51612cb8ff686bd4da40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

