### PR TITLE
fix(build-mode): correct Playwright MCP package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.1.0)
+### Build Mode (v1.1.1)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/.mcp.json
+++ b/build-mode/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@anthropic/mcp-playwright@latest"]
+      "args": ["@playwright/mcp@latest"]
     }
   }
 }

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,4 +1,4 @@
-# Build Mode Plugin v1.1.0
+# Build Mode Plugin v1.1.1
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
@@ -215,6 +215,7 @@ Every completion claim requires evidence:
 
 ## Version History
 
+- **v1.1.1**: Fixed Playwright MCP package name from `@anthropic/mcp-playwright` to `@playwright/mcp`
 - **v1.1.0**: Replaced slow LLM-based hooks with fast command-based hooks - TDD enforcement now via emphatic skill instructions (superpowers-style) instead of per-edit LLM validation. Zero LLM calls per edit cycle.
 - **v1.0.3**: Fixed TDD hook test detection - improved prompt to properly recognize test file edits and test runs in conversation history
 - **v1.0.2**: Changed TDD hook from soft reminders to hard blocking - code edits now require test evidence


### PR DESCRIPTION
## Summary

Update the Playwright MCP server package from the incorrect `@anthropic/mcp-playwright@latest` to the correct `@playwright/mcp@latest`.

## Why

The build-mode plugin was referencing a non-existent Anthropic package instead of the official Playwright MCP server package.

## What Changed

- `build-mode/.mcp.json` - Fixed package name
- `build-mode/.claude-plugin/plugin.json` - Version bump 1.1.0 → 1.1.1
- `build-mode/README.md` - Updated version and added changelog entry
- `README.md` - Updated build-mode version in section header

## How to Test

1. [x] Verify package exists: `npm view @playwright/mcp`
2. [ ] Test MCP server loads correctly in Claude Code

## Commits

- fix(build-mode): correct Playwright MCP package name

<details>
<summary>Implementation Plan</summary>

# Fix Playwright MCP Package Name

## Summary

Update the Playwright MCP server package from the incorrect `@anthropic/mcp-playwright@latest` to the correct `@playwright/mcp@latest`.

## Change

**File:** `build-mode/.mcp.json`

```json
// Before
"args": ["@anthropic/mcp-playwright@latest"]

// After
"args": ["@playwright/mcp@latest"]
```

## Version Bump

This is a bug fix (patch version):

- `build-mode/.claude-plugin/plugin.json`: `1.1.0` → `1.1.1`
- `README.md`: Update build-mode version in section header
- `build-mode/README.md`: Update title and add version history entry

## Verification

1. Verify the JSON is valid after edit
2. Confirm the package exists: `npm view @playwright/mcp`

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the Playwright MCP server package in build-mode to use @playwright/mcp@latest instead of the nonexistent @anthropic/mcp-playwright. This fixes MCP server loading and bumps the plugin to v1.1.1.

- **Bug Fixes**
  - build-mode/.mcp.json: use @playwright/mcp@latest
  - build-mode/.claude-plugin/plugin.json: version 1.1.0 → 1.1.1
  - README files: updated version and changelog entry

<sup>Written for commit b78b11394ad46c4a81f4c911cf30a29fba6b6ade. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

