### PR TITLE
feat(plan-mode): add SessionStart and UserPromptSubmit hooks for Conductor compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This marketplace provides three integrated plugins that work together:
 
 ## Plugins
 
-### Plan Mode (v2.3.2)
+### Plan Mode (v2.3.3)
 
 Structured planning with a 7-phase workflow:
 

--- a/plan-mode/.claude-plugin/plugin.json
+++ b/plan-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-mode",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "7-phase planning workflow with structured exploration, clarifying questions, confidence-based validation, and Linear integration",
   "author": {
     "name": "Roderik van der Veer"

--- a/plan-mode/README.md
+++ b/plan-mode/README.md
@@ -1,4 +1,4 @@
-# Plan Mode Plugin v2.3.2
+# Plan Mode Plugin v2.3.3
 
 Enhanced planning workflow for Claude Code with structured exploration, clarifying questions, confidence-based validation, and Linear integration.
 
@@ -198,6 +198,7 @@ Linear integration uses OAuth (SSE transport) - authenticate via browser when pr
 
 ## Version History
 
+- **v2.3.3**: Add SessionStart and UserPromptSubmit hooks for Conductor plan mode compatibility
 - **v2.3.2**: Fixed Stop hook JSON validation error by using natural language instructions instead of explicit approve/block format
 - **v2.3.1**: Fixed skill name format for AgentSkills compliance (lowercase-hyphens), added TOC to reference files
 - **v2.3.0**: Added Octocode MCP for semantic code research, LSP analysis, and GitHub cross-repo search

--- a/plan-mode/hooks/hooks.json
+++ b/plan-mode/hooks/hooks.json
@@ -1,6 +1,30 @@
 {
   "description": "Enhanced planning workflow hooks - orchestrates multi-phase planning with Linear integration",
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "If this session involves planning (plan mode active, user mentions planning/design/spec/breakdown), apply the 7-phase planning methodology from the planning-methodology skill. Phases: Context Gathering → Clarifying Questions → Specification → Architecture → Task Decomposition → Validation → Documentation & Linear. Phase 7 Linear integration question is MANDATORY.",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "(?i)(plan mode|planning|create.*plan|design.*implementation|break.*down|write.*spec|feature.*plan)",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Planning context detected. Execute the 7-phase planning methodology:\n\n1. **Context Gathering** - Use context-researcher agent with 4-phase structured exploration\n2. **Clarifying Questions** - Use AskUserQuestion for edge cases, scope, requirements BEFORE designing\n3. **Specification & Analysis** - Six Core Areas checklist, three-tier boundaries (Always/Ask/Never)\n4. **Architecture Decision** - Use architecture-analyst agent, compare options, ADR format\n5. **Task Decomposition** - Use task-decomposer agent for 2-5 min tasks with parallelization markers\n6. **Validation** - Use plan-validator agent with confidence filtering (≥80%), Rule of Five\n7. **Documentation & Linear** - Persist plan to file, MUST ask about Linear integration\n\n**CRITICAL:** You MUST use AskUserQuestion to ask about Linear integration before completing. This is non-negotiable.",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "EnterPlanMode",


### PR DESCRIPTION
## Summary

Add `SessionStart` and `UserPromptSubmit` hooks to activate the 7-phase planning workflow when using Conductor's plan mode, which bypasses Claude Code's native `EnterPlanMode` tool.

## Why

The 7-phase planning workflow wasn't activating in Conductor because:
- Conductor injects its own plan mode system prompt directly
- It doesn't call the `EnterPlanMode` tool that triggers the existing hook
- Users in Conductor plan mode weren't getting the enhanced planning methodology

## Design Decisions

- **Approach:** Added two new hook events while keeping the existing `EnterPlanMode` hook
- **Alternatives considered:** Could have removed the `EnterPlanMode` hook entirely, but keeping it maintains compatibility with Claude Code's native plan mode
- **Trade-offs:** `SessionStart` hook fires on every session (even non-planning ones), but the prompt is lightweight and only activates if planning context is detected

## What Changed

```
 README.md                            |  2 +-
 plan-mode/.claude-plugin/plugin.json |  2 +-
 plan-mode/README.md                  |  3 ++-
 plan-mode/hooks/hooks.json           | 24 ++++++++++++++++++++++++
 4 files changed, 28 insertions(+), 3 deletions(-)
```

### Key Changes

- Added `SessionStart` hook that fires once per session with general 7-phase planning awareness
- Added `UserPromptSubmit` hook that triggers on plan-related keywords (planning, create plan, design implementation, etc.)
- Kept existing `PreToolUse` (EnterPlanMode) hook for Claude Code native plan mode support
- Bumped version to 2.3.3

## How to Test

1. [ ] Start a new Conductor workspace in plan mode, verify 7-phase workflow instructions appear
2. [ ] Send a message with "plan a feature", verify UserPromptSubmit hook triggers
3. [ ] Use Claude Code native `EnterPlanMode` tool, verify PreToolUse hook still works
4. [ ] Complete a planning session, verify Linear question is asked

## Commits

- ccbd41e feat(plan-mode): add SessionStart and UserPromptSubmit hooks for Conductor compatibility

<details>
<summary>Implementation Plan</summary>

# Fix Plan Mode 7-Phase Workflow Activation

## Problem Analysis

The 7-phase planning workflow doesn't activate because there are **two different plan modes** that don't communicate:

### 1. Conductor's Plan Mode (Currently Active)
- Activated by Conductor app directly
- Injects `<system-reminder>Plan mode is active...</system-reminder>` into system prompt
- Has its own 5-phase workflow defined in the system reminder
- **Does NOT call the `EnterPlanMode` tool**

### 2. Claude Code's EnterPlanMode Tool + Plugin Hook
- Activated when Claude calls the `EnterPlanMode` tool
- Triggers the plugin's `PreToolUse` hook
- This loads the 7-phase `planning-methodology` skill

### Why It Doesn't Activate
The hook matcher `"EnterPlanMode"` only fires when Claude **calls the `EnterPlanMode` tool**. Conductor bypasses this by injecting its own plan mode system prompt directly, so the hook never fires.

## Solution (User-Approved Approach)

Implement **both** `UserPromptSubmit` and `SessionStart` hooks while **keeping** the existing `EnterPlanMode` hook. This provides comprehensive coverage:

- **SessionStart**: Fires once per session with general planning awareness
- **UserPromptSubmit**: Fires on plan-related keywords for targeted activation
- **PreToolUse (EnterPlanMode)**: Keep for Claude Code native plan mode support

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SessionStart and UserPromptSubmit hooks to activate the 7-phase planning workflow in Conductor’s plan mode, which doesn’t call EnterPlanMode. Conductor users now get the same planning experience, including the mandatory Linear integration question.

- **New Features**
  - SessionStart hook adds planning awareness once per session; activates only when planning context is detected.
  - UserPromptSubmit hook triggers the 7-phase flow on planning keywords.
  - Keeps PreToolUse (EnterPlanMode) for Claude Code native plan mode.
  - Bumps plan-mode version to 2.3.3.

<sup>Written for commit ccbd41e4ec2c8e79450c0a238f66b1212a4275db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

