### PR TITLE
feat(build-mode): add proactive agent orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.2.1)
+### Build Mode (v1.3.0)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,4 +1,4 @@
-# Build Mode Plugin v1.2.1
+# Build Mode Plugin v1.3.0
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
@@ -215,6 +215,7 @@ Every completion claim requires evidence:
 
 ## Version History
 
+- **v1.3.0**: Added proactive agent orchestration - SessionStart hook injects agent guidance, all agent descriptions updated with PROACTIVELY keyword, implementing-code skill now explicitly requires build-mode agents instead of generic Explore/general-purpose agents
 - **v1.2.1**: Strengthened TDD hook messages with explicit REQUIRED/MANDATORY language and `<system-reminder>` formatting to reduce Claude ignoring reminders
 - **v1.2.0**: Add iterative-retrieval skill for subagent context refinement with automatic integration into debugging and review workflows
 - **v1.1.1**: Fixed Playwright MCP package name from `@anthropic/mcp-playwright` to `@playwright/mcp`

--- a/build-mode/agents/code-reviewer.md
+++ b/build-mode/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Use this agent when reviewing code quality, checking for best practices, or auditing implementation patterns. Examples:
+description: PROACTIVELY spawn this agent after any code changes to review quality, check for best practices, and audit implementation patterns. This agent should be used proactively as part of the build workflow. Examples:
 
 <example>
 Context: User wants code review

--- a/build-mode/agents/completion-validator.md
+++ b/build-mode/agents/completion-validator.md
@@ -1,6 +1,6 @@
 ---
 name: completion-validator
-description: Use this agent as the final gate before marking work complete. Runs comprehensive verification ensuring all requirements met, tests pass, and evidence captured. Examples:
+description: PROACTIVELY spawn this agent as the MANDATORY final gate before marking ANY work complete. This agent should be used proactively to run comprehensive verification ensuring all requirements met, tests pass, and evidence captured. Examples:
 
 <example>
 Context: All reviews passed

--- a/build-mode/agents/quality-reviewer.md
+++ b/build-mode/agents/quality-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: quality-reviewer
-description: Use this agent to review code quality after spec compliance passes. Performs 3-pass review on style, patterns, and maintainability. Examples:
+description: PROACTIVELY spawn this agent after spec review passes to assess code quality. This agent should be used proactively to perform 3-pass review on style, patterns, and maintainability. Examples:
 
 <example>
 Context: Spec review passed

--- a/build-mode/agents/security-reviewer.md
+++ b/build-mode/agents/security-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: security-reviewer
-description: Use this agent when reviewing code for security vulnerabilities, performing security audits, or checking authentication/authorization patterns. Examples:
+description: PROACTIVELY spawn this agent when code touches auth, payments, user data, or security-sensitive areas. This agent should be used proactively to review security vulnerabilities, perform security audits, and check authentication/authorization patterns. Examples:
 
 <example>
 Context: User asking about security of code

--- a/build-mode/agents/silent-failure-hunter.md
+++ b/build-mode/agents/silent-failure-hunter.md
@@ -1,6 +1,6 @@
 ---
 name: silent-failure-hunter
-description: Use this agent to find error handling gaps and silent failures in code. Runs on all code changes to ensure errors are properly handled and logged. Examples:
+description: PROACTIVELY spawn this agent on ALL code changes to find error handling gaps and silent failures. This agent should be used proactively as part of the build workflow to ensure errors are properly handled and logged. Examples:
 
 <example>
 Context: Code changes made

--- a/build-mode/agents/spec-reviewer.md
+++ b/build-mode/agents/spec-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: spec-reviewer
-description: Use this agent to verify implementation matches requirements. Spawned after task-implementer completes to perform 3-pass spec compliance review. Examples:
+description: PROACTIVELY spawn this agent immediately after implementation to verify requirements are met. This agent should be used proactively to perform 3-pass spec compliance review. Examples:
 
 <example>
 Context: Task implementation completed

--- a/build-mode/agents/task-implementer.md
+++ b/build-mode/agents/task-implementer.md
@@ -1,6 +1,6 @@
 ---
 name: task-implementer
-description: Use this agent to implement individual tasks with TDD. Automatically spawned by build-mode orchestration for each task. Examples:
+description: PROACTIVELY spawn this agent for EVERY implementation task with TDD. This agent should be used proactively for all coding tasks to follow the Red-Green-Refactor cycle. Examples:
 
 <example>
 Context: User is executing a plan with multiple tasks

--- a/build-mode/agents/visual-tester.md
+++ b/build-mode/agents/visual-tester.md
@@ -1,6 +1,6 @@
 ---
 name: visual-tester
-description: Use this agent for browser-based visual verification of UI changes. Spawned when implementation involves frontend/UI components. Examples:
+description: PROACTIVELY spawn this agent when implementation involves ANY UI/frontend changes. This agent should be used proactively for browser-based visual verification of UI changes. Examples:
 
 <example>
 Context: Frontend component implemented

--- a/build-mode/hooks/hooks.json
+++ b/build-mode/hooks/hooks.json
@@ -1,6 +1,17 @@
 {
-  "description": "Build-mode quality gates: fast TDD reminder, CI validation, and progress preservation",
+  "description": "Build-mode quality gates: fast TDD reminder, CI validation, progress preservation, and agent orchestration guidance",
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "## Build Mode Agent Orchestration\n\nWhen implementing code, PROACTIVELY spawn build-mode agents using the Task tool:\n\n| Scenario | Agent | subagent_type |\n|----------|-------|---------------|\n| Implementing any task | task-implementer | build-mode:task-implementer |\n| After implementation | spec-reviewer | build-mode:spec-reviewer |\n| After spec passes | code-reviewer + quality-reviewer | build-mode:code-reviewer, build-mode:quality-reviewer |\n| Auth/payments/security code | security-reviewer | build-mode:security-reviewer |\n| Any code changes | silent-failure-hunter | build-mode:silent-failure-hunter |\n| UI/frontend changes | visual-tester | build-mode:visual-tester |\n| Before marking complete | completion-validator | build-mode:completion-validator |\n\n**IMPORTANT:** Use specialized build-mode agents, NOT generic Explore agents, for implementation tasks."
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit",

--- a/build-mode/skills/implementing-code/SKILL.md
+++ b/build-mode/skills/implementing-code/SKILL.md
@@ -177,11 +177,26 @@ Task 2 → Implementer₂ → Spec₂ → Quality₂ → ✓
 Task 3 → Implementer₃ → Spec₃ → Quality₃ → ✓
 ```
 
+### MANDATORY: Use Build-Mode Agents
+
+**NEVER use "Explore" or "general-purpose" for implementation tasks.** Always use the specialized build-mode agents:
+
+| Task | Agent | subagent_type |
+|------|-------|---------------|
+| Implementation | task-implementer | `build-mode:task-implementer` |
+| Requirements check | spec-reviewer | `build-mode:spec-reviewer` |
+| Code quality | code-reviewer | `build-mode:code-reviewer` |
+| Quality assessment | quality-reviewer | `build-mode:quality-reviewer` |
+| Security audit | security-reviewer | `build-mode:security-reviewer` |
+| Error handling | silent-failure-hunter | `build-mode:silent-failure-hunter` |
+| UI verification | visual-tester | `build-mode:visual-tester` |
+| Final gate | completion-validator | `build-mode:completion-validator` |
+
 ### Spawning Implementer
 
 ```javascript
 Task({
-  subagent_type: "general-purpose",
+  subagent_type: "build-mode:task-implementer",
   description: "Implement [task name]",
   prompt: `You are a TASK IMPLEMENTER. Follow TDD strictly.
 


### PR DESCRIPTION
## Summary

Add proactive agent orchestration to ensure build-mode subagents are actually used during implementation tasks. Previously, build-mode agents were never invoked (0 uses) while the generic Explore agent was used 54 times.

## Why

Analysis of session logs revealed that despite having 8 specialized build-mode agents (task-implementer, spec-reviewer, code-reviewer, etc.), Claude was defaulting to the generic "Explore" agent for all tasks. The root cause was:

1. Agent descriptions lacked "PROACTIVELY" keyword that triggers automatic usage
2. No SessionStart hook to inject agent guidance
3. implementing-code skill didn't explicitly require build-mode agents

## Design Decisions

- **Approach:** Two-pronged fix: SessionStart hook for guidance + proactive agent descriptions
- **Alternatives considered:** Skills-only approach (rejected - requires explicit /build invocation)
- **Trade-offs:** Slightly larger context from SessionStart hook, but guaranteed agent awareness

## What Changed

```
 README.md                                    |  2 +-
 build-mode/.claude-plugin/plugin.json        |  2 +-
 build-mode/README.md                         |  3 ++-
 build-mode/agents/code-reviewer.md           |  2 +-
 build-mode/agents/completion-validator.md    |  2 +-
 build-mode/agents/quality-reviewer.md        |  2 +-
 build-mode/agents/security-reviewer.md       |  2 +-
 build-mode/agents/silent-failure-hunter.md   |  2 +-
 build-mode/agents/spec-reviewer.md           |  2 +-
 build-mode/agents/task-implementer.md        |  2 +-
 build-mode/agents/visual-tester.md           |  2 +-
 build-mode/hooks/hooks.json                  | 13 ++++++++++++-
 build-mode/skills/implementing-code/SKILL.md | 17 ++++++++++++++++-
 13 files changed, 40 insertions(+), 13 deletions(-)
```

### Key Changes

- SessionStart hook injects agent orchestration table at every session
- All 8 agent descriptions updated with "PROACTIVELY" keyword
- implementing-code skill now has MANDATORY agent table with correct subagent_type values
- Version bump to 1.2.0

## How to Test

1. [ ] Start new session with implementation task (e.g., "add a login button")
2. [ ] Verify SessionStart hook fires (agent guidance message visible)
3. [ ] Check for build-mode agent usage: `rg '"subagent_type":"build-mode:' ~/.claude/projects -c`
4. [ ] Should see > 0 invocations of build-mode agents

## Commits

- feat(build-mode): add proactive agent orchestration

<details>
<summary>Implementation Plan</summary>

# Fix: Build-Mode Subagents Not Being Used

## Problem

Build-mode subagents are NEVER being invoked (0 uses). Claude defaults to generic "Explore" agent (54 uses).

## Solution

Implement **Option B + C**: SessionStart hook guidance AND skill-triggered orchestration. Make ALL agents proactive.

---

## Implementation Plan

### Task 1: Add SessionStart Hook with Agent Guidance

**File:** `build-mode/hooks/hooks.json`

Add SessionStart hook after opening `"hooks": {`:

```json
"SessionStart": [
  {
    "matcher": "*",
    "hooks": [
      {
        "type": "prompt",
        "prompt": "## Build Mode Agent Orchestration\n\nWhen implementing code, PROACTIVELY spawn build-mode agents using the Task tool:\n\n| Scenario | Agent | subagent_type |\n|----------|-------|---------------|\n| Implementing any task | task-implementer | build-mode:task-implementer |\n| After implementation | spec-reviewer | build-mode:spec-reviewer |\n| After spec passes | code-reviewer + quality-reviewer | build-mode:code-reviewer, build-mode:quality-reviewer |\n| Auth/payments/security code | security-reviewer | build-mode:security-reviewer |\n| Any code changes | silent-failure-hunter | build-mode:silent-failure-hunter |\n| UI/frontend changes | visual-tester | build-mode:visual-tester |\n| Before marking complete | completion-validator | build-mode:completion-validator |\n\n**IMPORTANT:** Use specialized build-mode agents, NOT generic Explore agents, for implementation tasks."
      }
    ]
  }
],
```

---

### Task 2: Update All Agent Descriptions to Be Proactive

Add "PROACTIVELY" keyword and stronger trigger language to each agent:

| File | Current Description Start | New Description Start |
|------|--------------------------|----------------------|
| `code-reviewer.md` | "Use this agent when reviewing code quality..." | "PROACTIVELY spawn this agent after any code changes to review quality..." |
| `silent-failure-hunter.md` | "Use this agent to find error handling gaps..." | "PROACTIVELY spawn this agent on ALL code changes to find error handling gaps..." |
| `security-reviewer.md` | "Use this agent when reviewing code for security..." | "PROACTIVELY spawn this agent when code touches auth, payments, user data, or security-sensitive areas..." |
| `completion-validator.md` | "Use this agent as the final gate..." | "PROACTIVELY spawn this agent as the MANDATORY final gate before marking ANY work complete..." |
| `spec-reviewer.md` | "Use this agent to verify implementation..." | "PROACTIVELY spawn this agent immediately after implementation to verify requirements..." |
| `task-implementer.md` | "Use this agent to implement individual tasks..." | "PROACTIVELY spawn this agent for EVERY implementation task with TDD..." |
| `quality-reviewer.md` | "Use this agent to review code quality..." | "PROACTIVELY spawn this agent after spec review passes to assess code quality..." |
| `visual-tester.md` | "Use this agent for browser-based visual verification..." | "PROACTIVELY spawn this agent when implementation involves ANY UI/frontend changes..." |

---

### Task 3: Add Agent Orchestration to implementing-code Skill

**File:** `build-mode/skills/implementing-code/SKILL.md`

Add new section after "## Subagent Orchestration" with MANDATORY agent table and correct subagent_type values.

---

### Task 4: Update Version Numbers

Per CLAUDE.md requirements:
- `build-mode/.claude-plugin/plugin.json` → bump to 1.2.0 (minor: new feature)
- `README.md` → update build-mode version
- `build-mode/README.md` → update title + add version history entry

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds proactive agent orchestration in build-mode so specialized subagents are used for implementation tasks instead of the generic Explore agent. Improves reliability of the TDD workflow and ensures quality gates run.

- **New Features**
  - SessionStart hook injects build-mode agent guidance.
  - All 8 agent descriptions updated with “PROACTIVELY” triggers.
  - implementing-code skill now mandates build-mode subagents via subagent_type.
  - Version bumped to v1.3.0.

- **Migration**
  - Start a new session to load the SessionStart guidance.
  - Use the Task tool with build-mode subagent_type for implementation and reviews.
  - Optional: verify build-mode agent usage in logs.

<sup>Written for commit 9f312ecceb3fe8203ae9d05a813846cd3219f480. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

