### PR TITLE
fix(build-mode): strengthen TDD hook messages with explicit REQUIRED language

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.2.0)
+### Build Mode (v1.2.1)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,4 +1,4 @@
-# Build Mode Plugin v1.2.0
+# Build Mode Plugin v1.2.1
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
@@ -215,6 +215,7 @@ Every completion claim requires evidence:
 
 ## Version History
 
+- **v1.2.1**: Strengthened TDD hook messages with explicit REQUIRED/MANDATORY language and `<system-reminder>` formatting to reduce Claude ignoring reminders
 - **v1.2.0**: Add iterative-retrieval skill for subagent context refinement with automatic integration into debugging and review workflows
 - **v1.1.1**: Fixed Playwright MCP package name from `@anthropic/mcp-playwright` to `@playwright/mcp`
 - **v1.1.0**: Replaced slow LLM-based hooks with fast command-based hooks - TDD enforcement now via emphatic skill instructions (superpowers-style) instead of per-edit LLM validation. Zero LLM calls per edit cycle.

--- a/build-mode/hooks/scripts/completion-gate.sh
+++ b/build-mode/hooks/scripts/completion-gate.sh
@@ -4,10 +4,10 @@ set -uo pipefail
 
 INPUT=$(cat)
 
-# Remind about verification before completion
+# MANDATORY verification gate before completion
 cat <<EOFMSG
 {
   "continue": true,
-  "systemMessage": "Before completing: Verify tests pass, lint is clean, and CI gates satisfied. Evidence required for all claims."
+  "systemMessage": "<system-reminder>MANDATORY VERIFICATION GATE: You MUST NOT complete until you have FRESH evidence that: (1) All tests pass, (2) Lint is clean, (3) CI gates satisfied. Run verification commands NOW and include output as evidence. Claims without evidence are violations.</system-reminder>"
 }
 EOFMSG

--- a/build-mode/hooks/scripts/tdd-gate.sh
+++ b/build-mode/hooks/scripts/tdd-gate.sh
@@ -13,19 +13,19 @@ if [[ "$FILE_PATH" =~ \.(md|json|yaml|yml|toml|html|svg|css|lock)$ ]] || \
 elif [[ "$FILE_PATH" =~ (test|spec)\.(ts|tsx|js|jsx)$ ]] || \
      [[ "$FILE_PATH" =~ _test\.(py|go|rs)$ ]] || \
      [[ "$FILE_PATH" =~ test_.*\.py$ ]]; then
-  # Test file - encourage with brief message
+  # Test file - encourage with verification reminder
   cat <<EOFMSG
 {
   "decision": "approve",
-  "systemMessage": "Writing test first. Good TDD practice."
+  "systemMessage": "Good: Writing test first. REQUIRED: Verify this test FAILS before writing implementation code."
 }
 EOFMSG
 else
-  # Implementation file - remind about TDD
+  # Implementation file - STRONG TDD enforcement
   cat <<EOFMSG
 {
   "decision": "approve",
-  "systemMessage": "TDD Reminder: This is implementation code. Ensure you wrote a failing test first and watched it fail before writing this code."
+  "systemMessage": "<system-reminder>REQUIRED: TDD COMPLIANCE - This is implementation code. You MUST have written a FAILING test first and watched it fail BEFORE writing this code. If you did not: DELETE this code, write the test, verify RED, then re-implement. No exceptions.</system-reminder>"
 }
 EOFMSG
 fi


### PR DESCRIPTION
## Summary

Strengthened TDD hook messages to use explicit REQUIRED/MANDATORY language instead of soft reminders. Claude was sometimes ignoring the polite wording; this update uses formatting and language patterns that Claude recognizes as authoritative.

## Why

The TDD hooks were using soft, suggestive language like "TDD Reminder: Ensure you wrote..." while the skill file uses much stronger language ("NOT negotiable", "Delete the code"). This mismatch allowed Claude to rationalize skipping TDD steps. The hooks now match the severity of the skill instructions.

## What Changed

- `build-mode/hooks/scripts/tdd-gate.sh` - Implementation files now get `<system-reminder>REQUIRED: TDD COMPLIANCE...` with consequence statements
- `build-mode/hooks/scripts/completion-gate.sh` - Now says `MANDATORY VERIFICATION GATE` with explicit numbered requirements  
- `build-mode/.claude-plugin/plugin.json` - Version 1.1.1 → 1.1.2
- `README.md` - Updated Build Mode version
- `build-mode/README.md` - Updated version and added history entry

```
 README.md                                   | 2 +-
 build-mode/.claude-plugin/plugin.json       | 2 +-
 build-mode/README.md                        | 3 ++-
 build-mode/hooks/scripts/completion-gate.sh | 4 ++--
 build-mode/hooks/scripts/tdd-gate.sh        | 8 ++++----
 5 files changed, 10 insertions(+), 9 deletions(-)
```

## How to Test

1. [ ] Edit a `.ts` implementation file → verify REQUIRED TDD message appears
2. [ ] Edit a `.test.ts` file → verify test file message with FAILS reminder appears
3. [ ] Attempt to complete a task → verify MANDATORY VERIFICATION GATE message appears

## Commits

- fix(build-mode): strengthen TDD hook messages with explicit REQUIRED language

<details>
<summary>Implementation Plan</summary>

# Plan: Make TDD Hook Reminders More Explicit

## Problem

The TDD hooks output soft, suggestive language that Claude sometimes ignores:
- **Current TDD Gate message:** "TDD Reminder: This is implementation code. Ensure you wrote a failing test first and watched it fail before writing this code."
- **Current Completion Gate message:** "Before completing: Verify tests pass, lint is clean, and CI gates satisfied. Evidence required for all claims."

These messages are polite reminders, but the skill file (`SKILL.md`) uses much stronger language like `<EXTREMELY-IMPORTANT>`, "NOT negotiable", and "Delete the code". The hooks should match this severity.

## Solution

Strengthen the hook messages with:
1. **REQUIRED/MANDATORY keywords** - explicit obligation language
2. **System-reminder-style tags** - `<system-reminder>` or `<REQUIRED>` formatting
3. **Consequence statements** - what happens if ignored
4. **Shorter, more direct phrasing** - commands not suggestions

## Files to Modify

1. `build-mode/hooks/scripts/tdd-gate.sh` (line 25-29) - implementation file message
2. `build-mode/hooks/scripts/completion-gate.sh` (line 11) - completion message
3. `build-mode/.claude-plugin/plugin.json` - version bump to 1.1.2
4. `README.md` - update version in Build Mode section
5. `build-mode/README.md` - update version and add history entry

## Proposed Changes

### 1. `tdd-gate.sh` - Implementation File Message

**Before:**
```
"TDD Reminder: This is implementation code. Ensure you wrote a failing test first and watched it fail before writing this code."
```

**After:**
```
"<system-reminder>REQUIRED: TDD COMPLIANCE - This is implementation code. You MUST have written a FAILING test first and watched it fail BEFORE writing this code. If you did not: DELETE this code, write the test, verify RED, then re-implement. No exceptions.</system-reminder>"
```

### 2. `tdd-gate.sh` - Test File Message (minor enhancement)

**Before:**
```
"Writing test first. Good TDD practice."
```

**After:**
```
"Good: Writing test first. REQUIRED: Verify this test FAILS before implementing code."
```

### 3. `completion-gate.sh` - Completion Message

**Before:**
```
"Before completing: Verify tests pass, lint is clean, and CI gates satisfied. Evidence required for all claims."
```

**After:**
```
"<system-reminder>MANDATORY VERIFICATION GATE: You MUST NOT complete until you have FRESH evidence that: (1) All tests pass, (2) Lint is clean, (3) CI gates satisfied. Run verification commands NOW and include output as evidence. Claims without evidence are violations.</system-reminder>"
```

## Version Update

- **New version:** 1.1.2 (patch - strengthening existing behavior, not new features)

## Verification

After changes:
1. Manually trigger the hooks by editing a `.ts` file
2. Verify the new messages appear in hook output
3. Confirm the `<system-reminder>` format is respected by Claude

## Summary

| File | Change |
|------|--------|
| `tdd-gate.sh` | Stronger REQUIRED language, consequence statements |
| `completion-gate.sh` | MANDATORY gate with evidence requirements |
| `plugin.json` | Version 1.1.1 → 1.1.2 |
| `README.md` | Version update |
| `build-mode/README.md` | Version + history entry |

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened TDD and completion gate messages with explicit REQUIRED/MANDATORY language and <system-reminder> formatting to enforce test-first and verification before completion. Updated Build Mode to v1.2.1 and refreshed READMEs.

- **Refactors**
  - tdd-gate.sh: Implementation edits show “REQUIRED: TDD COMPLIANCE” with clear consequences.
  - tdd-gate.sh: Test edits remind to verify the test fails before writing code.
  - completion-gate.sh: “MANDATORY VERIFICATION GATE” with numbered checks and evidence requirement.
  - Version bump to 1.2.1 in plugin.json and READMEs, with a new history entry.

<sup>Written for commit 2107c96c1bbe8aec762287466dc9a6cf4e1aec35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

