### PR TITLE
fix(plugins): make hooks advisory-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This marketplace provides three integrated plugins that work together:
 
 ## Plugins
 
-### Plan Mode (v2.4.1)
+### Plan Mode (v2.5.0)
 
 Structured planning with a 7-phase workflow:
 
@@ -80,7 +80,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.3.0)
+### Build Mode (v1.4.0)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,10 +1,10 @@
-# Build Mode Plugin v1.3.0
+# Build Mode Plugin v1.4.0
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
 ## Overview
 
-Build Mode complements Plan Mode by executing implementation plans with rigorous quality gates. It ensures code is **complete and correct before CI** through:
+Build Mode complements Plan Mode by executing implementation plans with rigorous quality gates. It guides you to verify code is **complete and correct before CI** through:
 
 - **TDD Workflow**: Red-Green-Refactor cycle for all changes
 - **Subagent Orchestration**: Fresh context per task prevents pollution
@@ -90,12 +90,12 @@ Core TDD and verification methodology:
 
 ## Hooks
 
+Advisory-only hooks that never block normal operations:
+
 | Hook | Event | Purpose |
 |------|-------|---------|
-| TDD Gate | PreToolUse (Write/Edit) | Blocks implementation without test evidence |
-| Completion Gate | Stop | Verify evidence before stopping |
-| Progress Preserver | PreCompact | Preserve state for context recovery |
-| CI Gate | PostToolUse (Bash) | Feedback on test/lint failures |
+| Agent Guidance | SessionStart | Suggest build-mode agents when build mode is detected |
+| TDD Reminder | PreToolUse (Write/Edit) | Reminder to follow TDD during implementation |
 
 ## Integration with Plan Mode
 
@@ -104,7 +104,7 @@ Build Mode is designed to work with Plan Mode:
 1. **Plan Mode** creates the implementation plan
 2. **Build Mode** executes each task with TDD
 3. Progress is tracked across both plugins
-4. Context compaction preserves plan state
+4. If context is compacted, re-open the plan file to resume
 
 ```bash
 # Typical workflow
@@ -215,6 +215,7 @@ Every completion claim requires evidence:
 
 ## Version History
 
+- **v1.4.0**: Make hooks advisory-only (fail-open), remove blocking command hooks, and detect build mode via permissions as a fallback to explicit /build
 - **v1.3.0**: Added proactive agent orchestration - SessionStart hook injects agent guidance, all agent descriptions updated with PROACTIVELY keyword, implementing-code skill now explicitly requires build-mode agents instead of generic Explore/general-purpose agents
 - **v1.2.1**: Strengthened TDD hook messages with explicit REQUIRED/MANDATORY language and `<system-reminder>` formatting to reduce Claude ignoring reminders
 - **v1.2.0**: Add iterative-retrieval skill for subagent context refinement with automatic integration into debugging and review workflows

--- a/build-mode/hooks/hooks.json
+++ b/build-mode/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Build-mode quality gates: fast TDD reminder, CI validation, progress preservation, and agent orchestration guidance",
+  "description": "Advisory build-mode guidance that never blocks normal operation; detect build mode via permissions or explicit entry",
   "hooks": {
     "SessionStart": [
       {
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "## Build Mode Agent Orchestration\n\nWhen implementing code, PROACTIVELY spawn build-mode agents using the Task tool:\n\n| Scenario | Agent | subagent_type |\n|----------|-------|---------------|\n| Implementing any task | task-implementer | build-mode:task-implementer |\n| After implementation | spec-reviewer | build-mode:spec-reviewer |\n| After spec passes | code-reviewer + quality-reviewer | build-mode:code-reviewer, build-mode:quality-reviewer |\n| Auth/payments/security code | security-reviewer | build-mode:security-reviewer |\n| Any code changes | silent-failure-hunter | build-mode:silent-failure-hunter |\n| UI/frontend changes | visual-tester | build-mode:visual-tester |\n| Before marking complete | completion-validator | build-mode:completion-validator |\n\n**IMPORTANT:** Use specialized build-mode agents, NOT generic Explore agents, for implementation tasks."
+            "prompt": "Inspect session metadata/permissions. If build mode is indicated (e.g., mode=build, build-only permissions, or /build invoked), return 'approve' with a systemMessage to follow build-mode workflow and PROACTIVELY use build-mode agents. If not build work, return 'approve' with no systemMessage."
           }
         ]
       }
@@ -17,45 +17,8 @@
         "matcher": "Write|Edit",
         "hooks": [
           {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/tdd-gate.sh",
-            "timeout": 2
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/completion-gate.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "PreCompact": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/preserve-progress.sh",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/ci-gate.sh",
-            "timeout": 120
+            "type": "prompt",
+            "prompt": "If in build mode and this is an implementation file (not a test/spec), return 'approve' with a systemMessage to follow TDD (write a failing test first, then implement, then refactor). Otherwise return 'approve' with no systemMessage."
           }
         ]
       }

--- a/build-mode/skills/implementing-code/SKILL.md
+++ b/build-mode/skills/implementing-code/SKILL.md
@@ -478,7 +478,7 @@ bun run ci
 # Typically runs: lint, typecheck, test, build
 ```
 
-**Hook behavior:** Stop event blocked until CI passes.
+**Hook behavior:** Advisory only; no blocking. Run CI before completion and cite evidence.
 
 ### Completion Checklist
 

--- a/plan-mode/.claude-plugin/plugin.json
+++ b/plan-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-mode",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "7-phase planning workflow with structured exploration, clarifying questions, confidence-based validation, and Linear integration",
   "author": {
     "name": "Roderik van der Veer"

--- a/plan-mode/README.md
+++ b/plan-mode/README.md
@@ -1,4 +1,4 @@
-# Plan Mode Plugin v2.4.1
+# Plan Mode Plugin v2.5.0
 
 Enhanced planning workflow for Claude Code with structured exploration, clarifying questions, confidence-based validation, and Linear integration.
 
@@ -45,7 +45,7 @@ Enhanced planning workflow for Claude Code with structured exploration, clarifyi
 
 ### Automatic Enhancement
 
-The plugin automatically enhances plan mode sessions. When you enter plan mode (via `EnterPlanMode`), the 7-phase workflow activates:
+The plugin automatically enhances plan mode sessions. When plan mode is detected (via `EnterPlanMode` or session permissions indicating plan mode), the 7-phase workflow activates:
 
 1. Structured codebase exploration with parallel agents
 2. Clarifying questions to resolve ambiguities
@@ -83,7 +83,7 @@ Core planning knowledge including:
 | `plan-validator` | 6 | Confidence-filtered validation (≥80%) |
 
 ### Hook: `enhance-planning`
-Automatically orchestrates planning phases when plan mode activates.
+Advisory-only guidance that never blocks normal operation; detects plan mode via permissions or explicit plan mode entry.
 
 ### MCP Servers
 
@@ -198,6 +198,7 @@ Linear integration uses OAuth (SSE transport) - authenticate via browser when pr
 
 ## Version History
 
+- **v2.5.0**: Make hooks advisory-only (fail-open), detect plan mode via permissions as a fallback to native EnterPlanMode, remove stop-time blocking
 - **v2.4.1**: Fix prompt hooks to approve non-planning requests instead of blocking, preventing infinite loops
 - **v2.4.0**: Add iterative-retrieval skill for subagent context refinement with automatic integration into Phase 1 exploration
 - **v2.3.3**: Add SessionStart and UserPromptSubmit hooks for Conductor plan mode compatibility

--- a/plan-mode/hooks/hooks.json
+++ b/plan-mode/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Enhanced planning workflow hooks - orchestrates multi-phase planning with Linear integration",
+  "description": "Advisory planning hints that never block normal operation; detect plan mode via permissions or explicit entry",
   "hooks": {
     "SessionStart": [
       {
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "If this session involves planning (plan mode active, user mentions planning/design/spec/breakdown), apply the 7-phase planning methodology from the planning-methodology skill. Phases: Context Gathering → Clarifying Questions → Specification → Architecture → Task Decomposition → Validation → Documentation & Linear. Phase 7 Linear integration question is MANDATORY. If this is NOT a planning session (e.g., debugging, troubleshooting, quick fixes, code review, general questions), simply approve and continue without any additional guidance.",
+            "prompt": "Inspect session metadata/permissions. If plan mode is indicated (e.g., mode=plan, plan-only permissions, or plan-mode mention), return 'approve' with a systemMessage reminding to follow the 7-phase planning workflow (Context -> Clarifying Questions -> Specification -> Architecture -> Tasks -> Validation -> Documentation & Linear). If not planning, return 'approve' with no systemMessage.",
             "timeout": 3
           }
         ]
@@ -15,11 +15,11 @@
     ],
     "UserPromptSubmit": [
       {
-        "matcher": "(?i)(plan mode|planning|create.*plan|design.*implementation|break.*down|write.*spec|feature.*plan)",
+        "matcher": "(?i)(\\bplan mode\\b|\\bcreate\\b.*\\bplan\\b|\\bwrite\\b.*\\bspec\\b|\\bbreak\\b.*\\bdown\\b|\\bdesign\\b.*\\bimplementation\\b|\\bfeature\\b.*\\bplan\\b)",
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Evaluate if this is truly a planning task. If this is debugging, troubleshooting, bug fixes, runtime errors, quick questions, or any non-planning work, return 'approve' immediately.\n\nOnly if this IS a genuine planning task, provide guidance to execute the 7-phase planning methodology:\n\n1. **Context Gathering** - Use context-researcher agent with 4-phase structured exploration\n2. **Clarifying Questions** - Use AskUserQuestion for edge cases, scope, requirements BEFORE designing\n3. **Specification & Analysis** - Six Core Areas checklist, three-tier boundaries (Always/Ask/Never)\n4. **Architecture Decision** - Use architecture-analyst agent, compare options, ADR format\n5. **Task Decomposition** - Use task-decomposer agent for 2-5 min tasks with parallelization markers\n6. **Validation** - Use plan-validator agent with confidence filtering (≥80%), Rule of Five\n7. **Documentation & Linear** - Persist plan to file, MUST ask about Linear integration\n\n**CRITICAL:** You MUST use AskUserQuestion to ask about Linear integration before completing. This is non-negotiable.",
+            "prompt": "Determine whether the user is explicitly requesting a plan/spec/design/breakdown. If yes, return 'approve' with a systemMessage to use the 7-phase planning workflow with clarifying questions and documentation. If not, return 'approve' with no systemMessage.",
             "timeout": 5
           }
         ]
@@ -31,20 +31,8 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "The user is entering plan mode. Return 'approve' to continue, with a systemMessage reminding to follow the 7-phase planning process:\n\n1. **Context Gathering** - Use context-researcher agent with structured exploration (4 phases)\n2. **Clarifying Questions** - Ask about edge cases, error handling, scope BEFORE designing\n3. **Specification & Analysis** - Six Core Areas checklist, boundaries\n4. **Architecture Decision** - Use architecture-analyst agent, apply clean implementation principle\n5. **Task Decomposition** - Use task-decomposer agent for 2-5 minute tasks with evidence\n6. **Validation** - Use plan-validator agent with confidence filtering (≥80%)\n7. **Documentation** - Persist plan and offer Linear integration\n\nAlways return 'approve' - never block entering plan mode.",
+            "prompt": "Plan mode detected. Return 'approve' with a systemMessage to follow the 7-phase planning process (Context -> Clarifying Questions -> Specification -> Architecture -> Tasks -> Validation -> Documentation & Linear). Never block.",
             "timeout": 10
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Check if this session involved planning (plan mode, feature planning, task breakdown). If this was NOT a planning session, return {\"continue\": false} to allow stopping.\n\nIf YES and a plan was created, check if Linear integration was offered. If Linear was already offered, return {\"continue\": false}. If planning occurred but Linear wasn't offered, return {\"continue\": true, \"systemMessage\": \"Remember to offer Linear integration before completing.\"}",
-            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary

Make plan/build hooks advisory-only and permission-aware so Conductor plan/build modes no longer block normal operation.

## Root cause

Blocking command hooks (Stop/PreToolUse/CI gates) and reliance on EnterPlanMode caused sessions started via permissions-only plan mode to behave as blocked workflows.

## The fix

- Remove blocking command hooks and keep advisory prompts only.
- Detect plan/build mode via session permissions as a fallback.
- Update plugin versions, docs, and skill note to reflect fail-open behavior.

## How to reproduce (before)

1. Start a Conductor session with plan/build permissions (without native EnterPlanMode).
2. Attempt normal operations and observe blocking gates (Stop/command hooks).

## How to verify (after)

1. Start a Conductor session with plan/build permissions.
2. Confirm hooks only inject advisory guidance and do not block normal operation.

## Risk assessment

Low — hook config and documentation changes only.

## AI Assistance

- [ ] No AI assistance used
- [x] AI assisted with: analysis, hook updates, documentation updates

## Proof of Function

- Before: plan/build sessions could be blocked by Stop/command hooks without EnterPlanMode
- After: hooks are advisory-only and do not block
- Regression test: Not added (config/doc change)

## Checklist

- [x] Identified root cause (not just symptoms)
- [ ] Added test to prevent regression
- [ ] Ran `bun run ci` locally
- [x] Checked for similar bugs elsewhere
- [x] Completed AI disclosure section
- [x] Filled proof of function with before/after evidence


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Plan and Build hooks advisory-only and permission-aware. Conductor plan/build sessions no longer block normal workflows.

- **Bug Fixes**
  - Remove blocking command hooks; keep prompts only (Stop, PreToolUse, PostToolUse, PreCompact removed).
  - Detect plan/build via session permissions or explicit entry (/build, EnterPlanMode).
  - Update docs and skills to reflect fail-open guidance.
  - Bump versions: Plan Mode v2.5.0, Build Mode v1.4.0.

<sup>Written for commit 95efb16d221e98df4f3ca6af79f80bc5aaadf129. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

