### PR TITLE
Sync Codex MCP servers and relax plan hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This marketplace provides three integrated plugins that work together:
 
 ## Plugins
 
-### Plan Mode (v2.5.0)
+### Plan Mode (v2.5.1)
 
 Structured planning with a 7-phase workflow:
 
@@ -182,6 +182,8 @@ The setup script:
 3. Force-updates all plugins (uninstall + reinstall for latest versions)
 4. Cleans up unauthorized plugins/marketplaces
 5. Installs official Anthropic plugins (plugin-dev, typescript-lsp)
+6. Syncs plugin skills and commands to Codex (`~/.codex`) when run directly
+7. Syncs plugin MCP servers into Codex config (`~/.codex/config.toml`) when run directly
 
 It can run:
 - Directly via curl for initial setup

--- a/plan-mode/.claude-plugin/plugin.json
+++ b/plan-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-mode",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "7-phase planning workflow with structured exploration, clarifying questions, confidence-based validation, and Linear integration",
   "author": {
     "name": "Roderik van der Veer"

--- a/plan-mode/README.md
+++ b/plan-mode/README.md
@@ -1,4 +1,4 @@
-# Plan Mode Plugin v2.5.0
+# Plan Mode Plugin v2.5.1
 
 Enhanced planning workflow for Claude Code with structured exploration, clarifying questions, confidence-based validation, and Linear integration.
 
@@ -198,6 +198,7 @@ Linear integration uses OAuth (SSE transport) - authenticate via browser when pr
 
 ## Version History
 
+- **v2.5.1**: Remove UserPromptSubmit hook to prevent stop-hook blocks on background task notifications
 - **v2.5.0**: Make hooks advisory-only (fail-open), detect plan mode via permissions as a fallback to native EnterPlanMode, remove stop-time blocking
 - **v2.4.1**: Fix prompt hooks to approve non-planning requests instead of blocking, preventing infinite loops
 - **v2.4.0**: Add iterative-retrieval skill for subagent context refinement with automatic integration into Phase 1 exploration

--- a/plan-mode/hooks/hooks.json
+++ b/plan-mode/hooks/hooks.json
@@ -13,18 +13,6 @@
         ]
       }
     ],
-    "UserPromptSubmit": [
-      {
-        "matcher": "(?i)(\\bplan mode\\b|\\bcreate\\b.*\\bplan\\b|\\bwrite\\b.*\\bspec\\b|\\bbreak\\b.*\\bdown\\b|\\bdesign\\b.*\\bimplementation\\b|\\bfeature\\b.*\\bplan\\b)",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Determine whether the user is explicitly requesting a plan/spec/design/breakdown. If yes, return 'approve' with a systemMessage to use the 7-phase planning workflow with clarifying questions and documentation. If not, return 'approve' with no systemMessage.",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "EnterPlanMode",

--- a/setup.sh
+++ b/setup.sh
@@ -213,6 +213,639 @@ cleanup_plugins() {
     done
 }
 
+# ============================================
+# Codex Sync Functions
+# ============================================
+
+# Check if Codex is available
+check_codex_available() {
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    [[ -d "$codex_home" ]]
+}
+
+# Get the install path for a plugin from installed_plugins.json
+get_plugin_install_path() {
+    local plugin_id="$1"
+    local installed_file="$HOME/.claude/plugins/installed_plugins.json"
+
+    [[ -f "$installed_file" ]] || return 1
+
+    jq -r --arg pid "$plugin_id" '
+        def path_of(p):
+            (p.installPath // p.install_path // p.path // (p.installPaths[0] // empty));
+        if .plugins? then
+            if (.plugins | type) == "object" then
+                path_of((.plugins[$pid] | if type == "array" then .[0] else . end) // empty)
+            elif (.plugins | type) == "array" then
+                path_of((.plugins | map(select(.id == $pid or .pluginId == $pid or .name == $pid)) | .[0]) // empty)
+            else
+                empty
+            end
+        else
+            empty
+        end
+    ' "$installed_file" 2>/dev/null
+}
+
+# Check if a word is in a space-separated string (Bash 3.2 compatible)
+string_contains() {
+    local needle="$1"
+    local haystack="$2"
+    [[ " $haystack " == *" $needle "* ]]
+}
+
+# Copy a directory to target (rsync if available, else cp fallback)
+sync_directory() {
+    local source_dir="$1"
+    local target_dir="$2"
+
+    if command -v rsync &>/dev/null; then
+        rsync -a --delete "$source_dir/" "$target_dir/" 2>/dev/null
+        return $?
+    fi
+
+    rm -rf "$target_dir"
+    mkdir -p "$target_dir"
+    cp -R "$source_dir/." "$target_dir/" 2>/dev/null
+}
+
+# Update the name field in SKILL.md when namespacing
+update_skill_name() {
+    local skill_file="$1"
+    local new_name="$2"
+
+    [[ -f "$skill_file" ]] || return 0
+
+    if ! head -n 1 "$skill_file" | grep -q "^---$"; then
+        return 0
+    fi
+
+    awk -v new_name="$new_name" '
+        BEGIN { in_front = 0; done = 0 }
+        NR == 1 && $0 == "---" { in_front = 1; print; next }
+        in_front && $0 == "---" { in_front = 0; print; next }
+        in_front && !done && $0 ~ /^name:[[:space:]]*/ {
+            print "name: " new_name
+            done = 1
+            next
+        }
+        { print }
+    ' "$skill_file" > "${skill_file}.tmp" && mv "${skill_file}.tmp" "$skill_file"
+}
+
+# Sync a single skill directory to Codex
+sync_skill_to_codex() {
+    local source_dir="$1"
+    local target_name="$2"
+    local codex_home="$3"
+    local original_name="$4"
+    local target_dir="$codex_home/skills/$target_name"
+
+    mkdir -p "$target_dir"
+    if ! sync_directory "$source_dir" "$target_dir"; then
+        return 1
+    fi
+
+    if [[ "$target_name" != "$original_name" ]]; then
+        update_skill_name "$target_dir/SKILL.md" "$target_name"
+    fi
+}
+
+# Sync a single command file to Codex
+sync_command_to_codex() {
+    local source_file="$1"
+    local target_name="$2"
+    local codex_home="$3"
+    local target_dir="$codex_home/commands"
+
+    mkdir -p "$target_dir"
+    cp "$source_file" "$target_dir/$target_name" 2>/dev/null
+}
+
+# Clean up orphaned skills and commands in Codex (Bash 3.2 compatible)
+cleanup_codex_orphans() {
+    local expected_skills="$1"
+    local expected_commands="$2"
+    local codex_home="$3"
+
+    local codex_skills="$codex_home/skills"
+    local codex_commands="$codex_home/commands"
+
+    # Cleanup orphaned skills directories
+    if [[ -d "$codex_skills" ]]; then
+        for dir in "$codex_skills"/*/; do
+            [[ -d "$dir" ]] || continue
+            local dirname
+            dirname=$(basename "$dir")
+
+            # Skip .system directory (Codex system skills)
+            [[ "$dirname" == ".system" ]] && continue
+
+            if ! string_contains "$dirname" "$expected_skills"; then
+                info "Removing orphaned Codex skill: $dirname"
+                rm -rf "$dir"
+            fi
+        done
+    fi
+
+    # Cleanup orphaned command files
+    if [[ -d "$codex_commands" ]]; then
+        for file in "$codex_commands"/*; do
+            [[ -f "$file" ]] || continue
+            local filename
+            filename=$(basename "$file")
+
+            if ! string_contains "$filename" "$expected_commands"; then
+                info "Removing orphaned Codex command: $filename"
+                rm -f "$file"
+            fi
+        done
+    fi
+}
+
+# Main function to sync all plugins to Codex
+sync_all_to_codex() {
+    if ! check_codex_available; then
+        info "Codex not installed (~/.codex not found), skipping sync"
+        return 0
+    fi
+
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local installed_file="$HOME/.claude/plugins/installed_plugins.json"
+
+    if [[ ! -f "$installed_file" ]]; then
+        warn "Claude installed_plugins.json not found, skipping Codex sync"
+        return 0
+    fi
+
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    local skills_manifest="$temp_dir/skills.tsv"
+    local commands_manifest="$temp_dir/commands.tsv"
+    local default_skill_map="$temp_dir/skill-defaults.tsv"
+    local default_command_map="$temp_dir/command-defaults.tsv"
+
+    local plugin_id
+    local plugin_name
+    local install_path
+    local found_plugins=0
+
+    for plugin_id in "${ALLOWED_PLUGINS[@]}"; do
+        plugin_name="${plugin_id%@*}"
+        install_path=$(get_plugin_install_path "$plugin_id")
+
+        if [[ -z "$install_path" || ! -d "$install_path" ]]; then
+            continue
+        fi
+
+        found_plugins=$((found_plugins + 1))
+
+        # Sync skills from this plugin
+        if [[ -d "$install_path/skills" ]]; then
+            for skill_dir in "$install_path/skills"/*/; do
+                [[ -d "$skill_dir" ]] || continue
+                local skill_name
+                skill_name=$(basename "$skill_dir")
+                printf "%s\t%s\t%s\n" "$skill_name" "$plugin_name" "$skill_dir" >> "$skills_manifest"
+            done
+        fi
+
+        # Sync commands from this plugin
+        if [[ -d "$install_path/commands" ]]; then
+            for cmd_file in "$install_path/commands"/*.md; do
+                [[ -f "$cmd_file" ]] || continue
+                local cmd_name
+                cmd_name=$(basename "$cmd_file")
+                printf "%s\t%s\t%s\n" "$cmd_name" "$plugin_name" "$cmd_file" >> "$commands_manifest"
+            done
+        fi
+    done
+
+    if [[ $found_plugins -eq 0 ]]; then
+        warn "No installed plugin paths found, skipping Codex sync"
+        rm -rf "$temp_dir"
+        return 0
+    fi
+
+    if [[ ! -s "$skills_manifest" && ! -s "$commands_manifest" ]]; then
+        warn "No plugin skills or commands found to sync, leaving Codex unchanged"
+        rm -rf "$temp_dir"
+        return 0
+    fi
+
+    mkdir -p "$codex_home/skills"
+    mkdir -p "$codex_home/commands"
+
+    local dup_skills=""
+    local dup_commands=""
+
+    if [[ -s "$skills_manifest" ]]; then
+        dup_skills=$(cut -f1 "$skills_manifest" | sort | uniq -d | tr '\n' ' ')
+    fi
+
+    if [[ -s "$commands_manifest" ]]; then
+        dup_commands=$(cut -f1 "$commands_manifest" | sort | uniq -d | tr '\n' ' ')
+    fi
+
+    # Determine defaults for duplicates (first plugin in order wins)
+    : > "$default_skill_map"
+    : > "$default_command_map"
+
+    if [[ -n "$dup_skills" && -s "$skills_manifest" ]]; then
+        while IFS=$'\t' read -r skill_name plugin_name source_dir; do
+            if string_contains "$skill_name" "$dup_skills"; then
+                if ! grep -Fq "^${skill_name}\t" "$default_skill_map"; then
+                    printf "%s\t%s\n" "$skill_name" "$plugin_name" >> "$default_skill_map"
+                fi
+            fi
+        done < "$skills_manifest"
+    fi
+
+    if [[ -n "$dup_commands" && -s "$commands_manifest" ]]; then
+        while IFS=$'\t' read -r cmd_name plugin_name source_file; do
+            if string_contains "$cmd_name" "$dup_commands"; then
+                if ! grep -Fq "^${cmd_name}\t" "$default_command_map"; then
+                    printf "%s\t%s\n" "$cmd_name" "$plugin_name" >> "$default_command_map"
+                fi
+            fi
+        done < "$commands_manifest"
+    fi
+
+    if [[ -n "$dup_skills" ]]; then
+        warn "Codex skill name collisions detected; namespacing duplicates as <plugin>__<skill>"
+    fi
+
+    if [[ -n "$dup_commands" ]]; then
+        warn "Codex command name collisions detected; namespacing duplicates as <plugin>__<command>.md"
+    fi
+
+    local expected_skills=""
+    local expected_commands=""
+    local skill_count=0
+    local cmd_count=0
+
+    # Sync skills
+    if [[ -s "$skills_manifest" ]]; then
+        while IFS=$'\t' read -r skill_name plugin_name source_dir; do
+            if string_contains "$skill_name" "$dup_skills"; then
+                local namespaced_skill="${plugin_name}__${skill_name}"
+                if sync_skill_to_codex "$source_dir" "$namespaced_skill" "$codex_home" "$skill_name"; then
+                    expected_skills="$expected_skills $namespaced_skill"
+                    skill_count=$((skill_count + 1))
+                fi
+
+                if grep -Fq "^${skill_name}\t${plugin_name}$" "$default_skill_map"; then
+                    if sync_skill_to_codex "$source_dir" "$skill_name" "$codex_home" "$skill_name"; then
+                        expected_skills="$expected_skills $skill_name"
+                        skill_count=$((skill_count + 1))
+                    fi
+                fi
+            else
+                if sync_skill_to_codex "$source_dir" "$skill_name" "$codex_home" "$skill_name"; then
+                    expected_skills="$expected_skills $skill_name"
+                    skill_count=$((skill_count + 1))
+                fi
+            fi
+        done < "$skills_manifest"
+    fi
+
+    # Sync commands
+    if [[ -s "$commands_manifest" ]]; then
+        while IFS=$'\t' read -r cmd_name plugin_name source_file; do
+            if string_contains "$cmd_name" "$dup_commands"; then
+                local namespaced_cmd="${plugin_name}__${cmd_name}"
+                if sync_command_to_codex "$source_file" "$namespaced_cmd" "$codex_home"; then
+                    expected_commands="$expected_commands $namespaced_cmd"
+                    cmd_count=$((cmd_count + 1))
+                fi
+
+                if grep -Fq "^${cmd_name}\t${plugin_name}$" "$default_command_map"; then
+                    if sync_command_to_codex "$source_file" "$cmd_name" "$codex_home"; then
+                        expected_commands="$expected_commands $cmd_name"
+                        cmd_count=$((cmd_count + 1))
+                    fi
+                fi
+            else
+                if sync_command_to_codex "$source_file" "$cmd_name" "$codex_home"; then
+                    expected_commands="$expected_commands $cmd_name"
+                    cmd_count=$((cmd_count + 1))
+                fi
+            fi
+        done < "$commands_manifest"
+    fi
+
+    cleanup_codex_orphans "$expected_skills" "$expected_commands" "$codex_home"
+
+    if [[ $skill_count -gt 0 || $cmd_count -gt 0 ]]; then
+        success "Synced $skill_count skills and $cmd_count commands to Codex"
+    else
+        info "No skills or commands to sync"
+    fi
+
+    rm -rf "$temp_dir"
+}
+
+# ============================================
+# Codex MCP Sync Functions
+# ============================================
+
+toml_string() {
+    printf "%s" "$1" | jq -R '@json'
+}
+
+toml_table_key() {
+    local key="$1"
+    if [[ "$key" =~ ^[A-Za-z0-9_]+$ ]]; then
+        echo "$key"
+    else
+        printf '"%s"' "$(printf "%s" "$key" | sed 's/"/\\"/g')"
+    fi
+}
+
+append_mcp_table() {
+    local name="$1"
+    local command="$2"
+    local args_json="$3"
+    local url="$4"
+    local cwd="$5"
+    local bearer_token_env_var="$6"
+    local startup_timeout_sec="$7"
+    local tool_timeout_sec="$8"
+    local enabled="$9"
+    local enabled_tools_json="${10}"
+    local disabled_tools_json="${11}"
+    local env_json="${12}"
+    local env_vars_json="${13}"
+    local http_headers_json="${14}"
+    local env_http_headers_json="${15}"
+    local block_file="${16}"
+
+    local table_key
+    table_key=$(toml_table_key "$name")
+
+    {
+        echo "[mcp_servers.${table_key}]"
+        if [[ -n "$command" ]]; then
+            echo "command = $(toml_string "$command")"
+        fi
+        if [[ -n "$args_json" && "$args_json" != "[]" ]]; then
+            echo "args = $args_json"
+        fi
+        if [[ -n "$url" && -z "$command" ]]; then
+            echo "url = $(toml_string "$url")"
+        fi
+        if [[ -n "$cwd" ]]; then
+            echo "cwd = $(toml_string "$cwd")"
+        fi
+        if [[ -n "$bearer_token_env_var" ]]; then
+            echo "bearer_token_env_var = $(toml_string "$bearer_token_env_var")"
+        fi
+        if [[ -n "$startup_timeout_sec" ]]; then
+            echo "startup_timeout_sec = $startup_timeout_sec"
+        fi
+        if [[ -n "$tool_timeout_sec" ]]; then
+            echo "tool_timeout_sec = $tool_timeout_sec"
+        fi
+        if [[ -n "$enabled" ]]; then
+            echo "enabled = $enabled"
+        fi
+        if [[ -n "$enabled_tools_json" && "$enabled_tools_json" != "[]" ]]; then
+            echo "enabled_tools = $enabled_tools_json"
+        fi
+        if [[ -n "$disabled_tools_json" && "$disabled_tools_json" != "[]" ]]; then
+            echo "disabled_tools = $disabled_tools_json"
+        fi
+        echo ""
+    } >> "$block_file"
+
+    if [[ -n "$env_json" && "$env_json" != "{}" ]]; then
+        echo "[mcp_servers.${table_key}.env]" >> "$block_file"
+        echo "$env_json" | jq -r 'to_entries[] | "\(.key) = \(.value|@json)"' >> "$block_file"
+        echo "" >> "$block_file"
+    fi
+
+    if [[ -n "$env_vars_json" && "$env_vars_json" != "{}" ]]; then
+        echo "[mcp_servers.${table_key}.env_vars]" >> "$block_file"
+        echo "$env_vars_json" | jq -r 'to_entries[] | "\(.key) = \(.value|@json)"' >> "$block_file"
+        echo "" >> "$block_file"
+    fi
+
+    if [[ -n "$http_headers_json" && "$http_headers_json" != "{}" ]]; then
+        echo "[mcp_servers.${table_key}.http_headers]" >> "$block_file"
+        echo "$http_headers_json" | jq -r 'to_entries[] | "\(.key) = \(.value|@json)"' >> "$block_file"
+        echo "" >> "$block_file"
+    fi
+
+    if [[ -n "$env_http_headers_json" && "$env_http_headers_json" != "{}" ]]; then
+        echo "[mcp_servers.${table_key}.env_http_headers]" >> "$block_file"
+        echo "$env_http_headers_json" | jq -r 'to_entries[] | "\(.key) = \(.value|@json)"' >> "$block_file"
+        echo "" >> "$block_file"
+    fi
+}
+
+update_codex_config_block() {
+    local config_file="$1"
+    local block_file="$2"
+    local begin_marker="# BEGIN: agent-marketplace MCP servers (managed by setup.sh)"
+    local end_marker="# END: agent-marketplace MCP servers (managed by setup.sh)"
+
+    if [[ -f "$config_file" ]]; then
+        if grep -Fq "$begin_marker" "$config_file"; then
+            local temp_file
+            temp_file=$(mktemp)
+            awk -v begin="$begin_marker" -v end="$end_marker" -v block="$block_file" '
+                $0 == begin {
+                    while ((getline line < block) > 0) print line
+                    close(block)
+                    in_block = 1
+                    next
+                }
+                in_block && $0 == end { in_block = 0; next }
+                !in_block { print }
+            ' "$config_file" > "$temp_file"
+            mv "$temp_file" "$config_file"
+        else
+            echo "" >> "$config_file"
+            cat "$block_file" >> "$config_file"
+        fi
+    else
+        mkdir -p "$(dirname "$config_file")"
+        cat "$block_file" > "$config_file"
+    fi
+}
+
+sync_codex_mcp_servers() {
+    if ! check_codex_available; then
+        info "Codex not installed (~/.codex not found), skipping MCP sync"
+        return 0
+    fi
+
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local installed_file="$HOME/.claude/plugins/installed_plugins.json"
+
+    if [[ ! -f "$installed_file" ]]; then
+        warn "Claude installed_plugins.json not found, skipping Codex MCP sync"
+        return 0
+    fi
+
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    local mcp_manifest="$temp_dir/mcp.jsonl"
+    local default_mcp_map="$temp_dir/mcp-defaults.tsv"
+    local block_file="$temp_dir/mcp-block.toml"
+
+    local plugin_id
+    local plugin_name
+    local install_path
+    local mcp_file
+    local found_plugins=0
+
+    for plugin_id in "${ALLOWED_PLUGINS[@]}"; do
+        plugin_name="${plugin_id%@*}"
+        install_path=$(get_plugin_install_path "$plugin_id")
+
+        if [[ -z "$install_path" || ! -d "$install_path" ]]; then
+            continue
+        fi
+
+        found_plugins=$((found_plugins + 1))
+        mcp_file="$install_path/.mcp.json"
+
+        if [[ -f "$mcp_file" ]]; then
+            jq -c --arg plugin "$plugin_name" '
+                .mcpServers // {} | to_entries[] |
+                {
+                  name: .key,
+                  plugin: $plugin,
+                  command: (.value.command // ""),
+                  args: (.value.args // []),
+                  url: (.value.url // ""),
+                  type: (.value.type // ""),
+                  env: (.value.env // {}),
+                  env_vars: (.value.env_vars // .value.envVars // {}),
+                  cwd: (.value.cwd // ""),
+                  bearer_token_env_var: (.value.bearer_token_env_var // .value.bearerTokenEnvVar // ""),
+                  http_headers: (.value.http_headers // .value.httpHeaders // {}),
+                  env_http_headers: (.value.env_http_headers // .value.envHttpHeaders // {}),
+                  startup_timeout_sec: (.value.startup_timeout_sec // .value.startupTimeoutSec // empty),
+                  tool_timeout_sec: (.value.tool_timeout_sec // .value.toolTimeoutSec // empty),
+                  enabled: (.value.enabled // empty),
+                  enabled_tools: (.value.enabled_tools // .value.enabledTools // []),
+                  disabled_tools: (.value.disabled_tools // .value.disabledTools // [])
+                }
+            ' "$mcp_file" >> "$mcp_manifest"
+        fi
+    done
+
+    if [[ $found_plugins -eq 0 ]]; then
+        warn "No installed plugin paths found, skipping Codex MCP sync"
+        rm -rf "$temp_dir"
+        return 0
+    fi
+
+    if [[ ! -s "$mcp_manifest" ]]; then
+        info "No MCP servers found in plugins, skipping Codex MCP sync"
+        rm -rf "$temp_dir"
+        return 0
+    fi
+
+    local dup_servers
+    dup_servers=$(jq -r '.name' "$mcp_manifest" | sort | uniq -d | tr '\n' ' ')
+
+    : > "$default_mcp_map"
+    if [[ -n "$dup_servers" ]]; then
+        while IFS= read -r line; do
+            local name
+            local plugin
+            name=$(echo "$line" | jq -r '.name')
+            plugin=$(echo "$line" | jq -r '.plugin')
+            if string_contains "$name" "$dup_servers"; then
+                if ! grep -Fq "^${name}\t" "$default_mcp_map"; then
+                    printf "%s\t%s\n" "$name" "$plugin" >> "$default_mcp_map"
+                fi
+            fi
+        done < "$mcp_manifest"
+        warn "Codex MCP server name collisions detected; namespacing duplicates as <plugin>__<server>"
+    fi
+
+    {
+        echo "# BEGIN: agent-marketplace MCP servers (managed by setup.sh)"
+        echo "# Generated from installed plugin .mcp.json files."
+        echo ""
+    } > "$block_file"
+
+    while IFS= read -r line; do
+        local name
+        local plugin
+        local command
+        local args_json
+        local url
+        local type
+        local env_json
+        local env_vars_json
+        local cwd
+        local bearer_token_env_var
+        local http_headers_json
+        local env_http_headers_json
+        local startup_timeout_sec
+        local tool_timeout_sec
+        local enabled
+        local enabled_tools_json
+        local disabled_tools_json
+
+        name=$(echo "$line" | jq -r '.name')
+        plugin=$(echo "$line" | jq -r '.plugin')
+        command=$(echo "$line" | jq -r '.command')
+        args_json=$(echo "$line" | jq -c '.args')
+        url=$(echo "$line" | jq -r '.url')
+        type=$(echo "$line" | jq -r '.type')
+        env_json=$(echo "$line" | jq -c '.env')
+        env_vars_json=$(echo "$line" | jq -c '.env_vars')
+        cwd=$(echo "$line" | jq -r '.cwd')
+        bearer_token_env_var=$(echo "$line" | jq -r '.bearer_token_env_var')
+        http_headers_json=$(echo "$line" | jq -c '.http_headers')
+        env_http_headers_json=$(echo "$line" | jq -c '.env_http_headers')
+        startup_timeout_sec=$(echo "$line" | jq -r '.startup_timeout_sec // empty')
+        tool_timeout_sec=$(echo "$line" | jq -r '.tool_timeout_sec // empty')
+        enabled=$(echo "$line" | jq -r '.enabled // empty')
+        enabled_tools_json=$(echo "$line" | jq -c '.enabled_tools')
+        disabled_tools_json=$(echo "$line" | jq -c '.disabled_tools')
+
+        if [[ "$type" == "sse" && "$name" == "linear" && "$url" == *"mcp.linear.app/sse"* ]]; then
+            url="${url%/sse}/mcp"
+        fi
+
+        if [[ -z "$command" && -z "$url" ]]; then
+            warn "Skipping MCP server '$name' (missing command/url)"
+            continue
+        fi
+
+        if string_contains "$name" "$dup_servers"; then
+            local namespaced="${plugin}__${name}"
+            append_mcp_table "$namespaced" "$command" "$args_json" "$url" "$cwd" "$bearer_token_env_var" \
+                "$startup_timeout_sec" "$tool_timeout_sec" "$enabled" "$enabled_tools_json" "$disabled_tools_json" \
+                "$env_json" "$env_vars_json" "$http_headers_json" "$env_http_headers_json" "$block_file"
+
+            if grep -Fq "^${name}\t${plugin}$" "$default_mcp_map"; then
+                append_mcp_table "$name" "$command" "$args_json" "$url" "$cwd" "$bearer_token_env_var" \
+                    "$startup_timeout_sec" "$tool_timeout_sec" "$enabled" "$enabled_tools_json" "$disabled_tools_json" \
+                    "$env_json" "$env_vars_json" "$http_headers_json" "$env_http_headers_json" "$block_file"
+            fi
+        else
+            append_mcp_table "$name" "$command" "$args_json" "$url" "$cwd" "$bearer_token_env_var" \
+                "$startup_timeout_sec" "$tool_timeout_sec" "$enabled" "$enabled_tools_json" "$disabled_tools_json" \
+                "$env_json" "$env_vars_json" "$http_headers_json" "$env_http_headers_json" "$block_file"
+        fi
+    done < "$mcp_manifest"
+
+    echo "# END: agent-marketplace MCP servers (managed by setup.sh)" >> "$block_file"
+
+    update_codex_config_block "$codex_home/config.toml" "$block_file"
+    success "Synced MCP servers to Codex config"
+
+    rm -rf "$temp_dir"
+}
+
 echo "Step 1: Cleanup"
 echo "---------------"
 cleanup_plugins
@@ -250,6 +883,15 @@ force_update_plugin "plan-mode@settlemint" "plan-mode (structured planning)"
 force_update_plugin "build-mode@settlemint" "build-mode (TDD implementation)"
 force_update_plugin "git@settlemint" "git (git workflow automation)"
 echo ""
+
+# Step 5: Sync to Codex (only on direct execution, not on SessionStart hook)
+if [[ "$IS_DIRECT_EXECUTION" == "true" ]]; then
+    echo "Step 5: Syncing Codex"
+    echo "---------------------"
+    sync_all_to_codex
+    sync_codex_mcp_servers
+    echo ""
+fi
 
 # Summary
 echo "================================"


### PR DESCRIPTION
Sync plugin MCP servers into Codex config with collision-safe namespacing. Remove the plan-mode UserPromptSubmit hook that was stopping on background task notifications. Bump plan-mode to 2.5.1 and document the new setup behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic sync of plugin skills, commands, and MCP servers into Codex with collision-safe namespacing, and removes the plan-mode UserPromptSubmit hook to prevent stop-blocks from background notifications. Also bumps Plan Mode to v2.5.1 and updates docs.

- **New Features**
  - Syncs plugin skills/commands to ~/.codex and cleans orphans when setup.sh is run directly.
  - Imports MCP servers from each plugin’s .mcp.json into ~/.codex/config.toml with <plugin>__<name> namespacing on collisions and a default chosen by plugin order.
  - Normalizes Linear SSE server URLs from /sse to /mcp.

- **Bug Fixes**
  - Removes the UserPromptSubmit hook in plan-mode to avoid stop-hook blocks from background notifications.
  - Updates Plan Mode to v2.5.1 in plugin.json and README.

<sup>Written for commit 5daad0aa204fe059243aa371dfcb592e35cd18ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

