### PR TITLE
fix(build-mode): add missing timeout values to prompt hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.4.0)
+### Build Mode (v1.4.1)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,4 +1,4 @@
-# Build Mode Plugin v1.4.0
+# Build Mode Plugin v1.4.1
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
@@ -215,6 +215,7 @@ Every completion claim requires evidence:
 
 ## Version History
 
+- **v1.4.1**: Add missing timeout values to prompt hooks (fixes SessionStart:startup hook error)
 - **v1.4.0**: Make hooks advisory-only (fail-open), remove blocking command hooks, and detect build mode via permissions as a fallback to explicit /build
 - **v1.3.0**: Added proactive agent orchestration - SessionStart hook injects agent guidance, all agent descriptions updated with PROACTIVELY keyword, implementing-code skill now explicitly requires build-mode agents instead of generic Explore/general-purpose agents
 - **v1.2.1**: Strengthened TDD hook messages with explicit REQUIRED/MANDATORY language and `<system-reminder>` formatting to reduce Claude ignoring reminders

--- a/build-mode/hooks/hooks.json
+++ b/build-mode/hooks/hooks.json
@@ -7,7 +7,8 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Inspect session metadata/permissions. If build mode is indicated (e.g., mode=build, build-only permissions, or /build invoked), return 'approve' with a systemMessage to follow build-mode workflow and PROACTIVELY use build-mode agents. If not build work, return 'approve' with no systemMessage."
+            "prompt": "Inspect session metadata/permissions. If build mode is indicated (e.g., mode=build, build-only permissions, or /build invoked), return 'approve' with a systemMessage to follow build-mode workflow and PROACTIVELY use build-mode agents. If not build work, return 'approve' with no systemMessage.",
+            "timeout": 3
           }
         ]
       }
@@ -18,7 +19,8 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "If in build mode and this is an implementation file (not a test/spec), return 'approve' with a systemMessage to follow TDD (write a failing test first, then implement, then refactor). Otherwise return 'approve' with no systemMessage."
+            "prompt": "If in build mode and this is an implementation file (not a test/spec), return 'approve' with a systemMessage to follow TDD (write a failing test first, then implement, then refactor). Otherwise return 'approve' with no systemMessage.",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## Summary

Fixed SessionStart hook failures in build-mode by adding missing timeout specifications to prompt-type hooks. When Claude Code evaluates LLM-based hooks at session start, it requires a timeout value to know how long to wait for evaluation. The build-mode hooks were missing these, causing immediate timeouts.

## Why

When Claude Code starts a session, it evaluates SessionStart hooks to inject advisory guidance. Prompt-type hooks (which use LLM evaluation) need a timeout field. plan-mode had `"timeout": 3` but build-mode was missing timeouts entirely, causing the hook evaluation to fail immediately.

## Changes

- Added `"timeout": 3` to SessionStart hook 
- Added `"timeout": 10` to PreToolUse hook
- Bumped build-mode version to 1.4.1
- Updated README with version history entry

## Files Changed

- `build-mode/hooks/hooks.json` - Add timeout specifications
- `build-mode/.claude-plugin/plugin.json` - Bump version
- `build-mode/README.md` - Update version and docs
- `README.md` - Update plugin section header

## Verification

When you start a new Claude Code session, confirm:
- ✓ No "SessionStart:startup hook error" messages
- ✓ Hooks still provide advisory guidance (don't block)
- ✓ Both SessionStart and PreToolUse hooks evaluate properly

<details>
<summary>Implementation Plan</summary>

# Fix Startup Hooks Failing Immediately

## Problem
SessionStart hooks in build-mode fail immediately because they're **missing timeout values**. When Claude Code evaluates prompt-type hooks at session start, it needs a timeout to know how long to wait for the LLM evaluation. Without one, the hook fails.

## Root Cause
In commit `89575a1` (make hooks advisory-only), the build-mode SessionStart hook was simplified but **lost its timeout field**:

**plan-mode/hooks/hooks.json** - Has `"timeout": 3`:
```json
{
  "type": "prompt",
  "prompt": "...",
  "timeout": 3  // Present
}
```

**build-mode/hooks/hooks.json** - Missing timeout:
```json
{
  "type": "prompt",
  "prompt": "..."  // No timeout!
}
```

The build-mode PreToolUse hook is also missing a timeout.

## Fix

### Files to Modify

1. **build-mode/hooks/hooks.json**
   - Add `"timeout": 3` to SessionStart hook (line 10)
   - Add `"timeout": 10` to PreToolUse hook (line 22)

2. **build-mode/.claude-plugin/plugin.json**
   - Bump version from 1.4.0 to 1.4.1

3. **build-mode/README.md**
   - Update title version to 1.4.1
   - Add version history entry

4. **README.md** (root)
   - Update Build Mode version in section header

### Changes

**build-mode/hooks/hooks.json** - Add timeouts:
```json
{
  "description": "Advisory build-mode guidance...",
  "hooks": {
    "SessionStart": [
      {
        "matcher": "*",
        "hooks": [
          {
            "type": "prompt",
            "prompt": "Inspect session metadata/permissions...",
            "timeout": 3  // ADD THIS
          }
        ]
      }
    ],
    "PreToolUse": [
      {
        "matcher": "Write|Edit",
        "hooks": [
          {
            "type": "prompt",
            "prompt": "If in build mode...",
            "timeout": 10  // ADD THIS
          }
        ]
      }
    ]
  }
}
```

## Verification

1. Run Claude Code in a new terminal session
2. Confirm no "SessionStart:startup hook error" messages appear
3. Verify hooks are still advisory-only (don't block operations)

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing timeout values to build-mode prompt hooks to stop immediate timeouts at session start. Fixes the SessionStart startup hook error; hooks now evaluate properly and remain advisory.

- **Bug Fixes**
  - Timeouts added to prompt hooks: SessionStart (3s) and PreToolUse (10s).
  - Bumped build-mode to v1.4.1 and updated README.

<sup>Written for commit 977b445b43ec57c709de8a62b6743af2f22a2389. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

