### PR TITLE
fix(hooks): remove unsupported SessionStart prompt hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This marketplace provides three integrated plugins that work together:
 
 ## Plugins
 
-### Plan Mode (v2.5.1)
+### Plan Mode (v2.5.2)
 
 Structured planning with a 7-phase workflow:
 
@@ -81,7 +81,7 @@ Structured planning with a 7-phase workflow:
 - **Context7** - Fetch latest package documentation
 - **Linear** - Ticket management integration
 
-### Build Mode (v1.4.1)
+### Build Mode (v1.4.2)
 
 TDD-driven implementation with quality gates:
 

--- a/build-mode/.claude-plugin/plugin.json
+++ b/build-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "build-mode",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion",
   "author": {
     "name": "Roderik van der Veer"

--- a/build-mode/README.md
+++ b/build-mode/README.md
@@ -1,4 +1,4 @@
-# Build Mode Plugin v1.4.1
+# Build Mode Plugin v1.4.2
 
 TDD-driven implementation execution with subagent orchestration, systematic debugging, visual testing, and verification before completion.
 
@@ -94,7 +94,6 @@ Advisory-only hooks that never block normal operations:
 
 | Hook | Event | Purpose |
 |------|-------|---------|
-| Agent Guidance | SessionStart | Suggest build-mode agents when build mode is detected |
 | TDD Reminder | PreToolUse (Write/Edit) | Reminder to follow TDD during implementation |
 
 ## Integration with Plan Mode
@@ -215,6 +214,7 @@ Every completion claim requires evidence:
 
 ## Version History
 
+- **v1.4.2**: Remove SessionStart hook (prompt hooks not supported for SessionStart event)
 - **v1.4.1**: Add missing timeout values to prompt hooks (fixes SessionStart:startup hook error)
 - **v1.4.0**: Make hooks advisory-only (fail-open), remove blocking command hooks, and detect build mode via permissions as a fallback to explicit /build
 - **v1.3.0**: Added proactive agent orchestration - SessionStart hook injects agent guidance, all agent descriptions updated with PROACTIVELY keyword, implementing-code skill now explicitly requires build-mode agents instead of generic Explore/general-purpose agents

--- a/build-mode/hooks/hooks.json
+++ b/build-mode/hooks/hooks.json
@@ -1,18 +1,6 @@
 {
   "description": "Advisory build-mode guidance that never blocks normal operation; detect build mode via permissions or explicit entry",
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Inspect session metadata/permissions. If build mode is indicated (e.g., mode=build, build-only permissions, or /build invoked), return 'approve' with a systemMessage to follow build-mode workflow and PROACTIVELY use build-mode agents. If not build work, return 'approve' with no systemMessage.",
-            "timeout": 3
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit",

--- a/plan-mode/.claude-plugin/plugin.json
+++ b/plan-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-mode",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "7-phase planning workflow with structured exploration, clarifying questions, confidence-based validation, and Linear integration",
   "author": {
     "name": "Roderik van der Veer"

--- a/plan-mode/README.md
+++ b/plan-mode/README.md
@@ -1,4 +1,4 @@
-# Plan Mode Plugin v2.5.1
+# Plan Mode Plugin v2.5.2
 
 Enhanced planning workflow for Claude Code with structured exploration, clarifying questions, confidence-based validation, and Linear integration.
 
@@ -198,6 +198,7 @@ Linear integration uses OAuth (SSE transport) - authenticate via browser when pr
 
 ## Version History
 
+- **v2.5.2**: Remove SessionStart hook (prompt hooks not supported for SessionStart event)
 - **v2.5.1**: Remove UserPromptSubmit hook to prevent stop-hook blocks on background task notifications
 - **v2.5.0**: Make hooks advisory-only (fail-open), detect plan mode via permissions as a fallback to native EnterPlanMode, remove stop-time blocking
 - **v2.4.1**: Fix prompt hooks to approve non-planning requests instead of blocking, preventing infinite loops

--- a/plan-mode/hooks/hooks.json
+++ b/plan-mode/hooks/hooks.json
@@ -1,18 +1,6 @@
 {
   "description": "Advisory planning hints that never block normal operation; detect plan mode via permissions or explicit entry",
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Inspect session metadata/permissions. If plan mode is indicated (e.g., mode=plan, plan-only permissions, or plan-mode mention), return 'approve' with a systemMessage reminding to follow the 7-phase planning workflow (Context -> Clarifying Questions -> Specification -> Architecture -> Tasks -> Validation -> Documentation & Linear). If not planning, return 'approve' with no systemMessage.",
-            "timeout": 3
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "EnterPlanMode",


### PR DESCRIPTION
## Summary

Removed SessionStart hooks from plan-mode and build-mode plugins that were causing startup errors. Prompt-based hooks are not supported for SessionStart events—only command-type hooks are allowed by Claude Code's hook API.

## Changes

- Removed SessionStart hooks from `plan-mode/hooks/hooks.json` and `build-mode/hooks/hooks.json`
- Bumped plan-mode to v2.5.2 and build-mode to v1.4.2
- Updated plugin manifests and README changelogs

## Why This Fix

The SessionStart hooks were advisory-only (always returned "approve"), so removing them has no functional impact. The plugins still provide guidance through PreToolUse hooks when relevant tools are used.

<details>
<summary>Implementation Plan</summary>

# Fix SessionStart Hook Errors

## Problem

Both `plan-mode` and `build-mode` plugins have SessionStart hooks using `"type": "prompt"`, but **prompt-based hooks are NOT supported for SessionStart events**.

From the Claude Code hook documentation (line 33-34):
> **Supported events:** Stop, SubagentStop, UserPromptSubmit, PreToolUse

SessionStart is NOT in this list. It only supports `command` type hooks.

## Solution

**Remove the SessionStart hooks entirely** from both plugins.

Rationale:
- The hooks were advisory-only (always return "approve")
- The intended functionality (detect mode and inject guidance) cannot be replicated with a command hook easily
- The plugins already have PreToolUse hooks that provide the same guidance when relevant tools are used
- UserPromptSubmit hooks could work but would add overhead to every prompt

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsupported SessionStart prompt hooks in plan-mode and build-mode to fix startup errors. No behavior change; guidance continues via PreToolUse hooks.

- **Bug Fixes**
  - Removed prompt-based SessionStart hooks (SessionStart supports command hooks only).
  - Fixed SessionStart:startup error on session start.
  - Bumped versions: plan-mode v2.5.2, build-mode v1.4.2; updated manifests and README changelogs.

<sup>Written for commit 9d62cba8f8432c33522b8ac061a17d0773844466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

