### PR TITLE
feat(plan-mode): mandate specialized agents for planning, fix skill references

### DIFF
--- a/CLAUDE.template.md
+++ b/CLAUDE.template.md
@@ -21,7 +21,7 @@ Use planning for tasks that:
 - Have unclear requirements
 - Need user approval before implementation
 
-**Invoke planning:** `Skill({ skill: "plan-mode:plan" })` or `/plan`
+**Invoke planning:** `Skill({ skill: "plan-mode:planning-methodology" })` or `/plan`
 
 **Planning produces a written specification with 2-5 minute tasks.**
 
@@ -116,14 +116,25 @@ When agent results are incomplete:
 
 **Load planning skill:** `Skill({ skill: "plan-mode:planning-methodology" })`
 
+### Mandatory: Use Plan-Mode Agents
+
+**NEVER use "Explore" or "general-purpose" for planning tasks.**
+
+| Phase | Invocation |
+|-------|------------|
+| Context Gathering | `Task({ subagent_type: "plan-mode:context-researcher", prompt: "..." })` |
+| Architecture Analysis | `Task({ subagent_type: "plan-mode:architecture-analyst", prompt: "..." })` |
+| Task Decomposition | `Task({ subagent_type: "plan-mode:task-decomposer", prompt: "..." })` |
+| Plan Validation | `Task({ subagent_type: "plan-mode:plan-validator", prompt: "..." })` |
+
 ### 7-Phase Planning
 
-1. **Context Gathering** - Launch parallel Explore agents
+1. **Context Gathering** - `plan-mode:context-researcher` with 4-phase exploration
 2. **Clarifying Questions** - One question at a time, multiple choice preferred
 3. **Specification** - Six Core Areas, exact file paths, no vague language
-4. **Architecture Decision** - 2-3 options with trade-offs, recommend one
-5. **Task Decomposition** - 2-5 minute tasks with `[parallel]`/`[serial]` markers
-6. **Validation** - Rule of Five convergence
+4. **Architecture Decision** - `plan-mode:architecture-analyst` with trade-offs
+5. **Task Decomposition** - `plan-mode:task-decomposer` with 2-5 min tasks
+6. **Validation** - `plan-mode:plan-validator` with Rule of Five
 7. **Documentation** - Write plan, ask about Linear integration
 
 ### Task Requirements
@@ -266,7 +277,7 @@ When agent results are incomplete:
 
 | Command/Skill | Purpose | Invocation |
 |---------------|---------|------------|
-| /plan | Start 7-phase planning workflow | `Skill({ skill: "plan-mode:plan" })` |
+| /plan | Start 7-phase planning workflow | `Skill({ skill: "plan-mode:planning-methodology" })` |
 | /build | Execute plan with TDD and agents | `Skill({ skill: "build-mode:build" })` |
 | /review | Run comprehensive code review | `Skill({ skill: "build-mode:review" })` |
 | /commit | Create conventional commit | `Skill({ skill: "git:commit" })` |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This marketplace provides three integrated plugins that work together:
 
 ## Plugins
 
-### Plan Mode (v2.6.0)
+### Plan Mode (v2.7.0)
 
 Structured planning with a 7-phase workflow:
 

--- a/plan-mode/.claude-plugin/plugin.json
+++ b/plan-mode/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-mode",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "7-phase planning workflow with structured exploration, clarifying questions, confidence-based validation, and Linear integration",
   "author": {
     "name": "Roderik van der Veer"

--- a/plan-mode/README.md
+++ b/plan-mode/README.md
@@ -1,4 +1,4 @@
-# Plan Mode Plugin v2.6.0
+# Plan Mode Plugin v2.7.0
 
 Enhanced planning workflow for Claude Code with structured exploration, clarifying questions, confidence-based validation, and Linear integration.
 
@@ -192,6 +192,7 @@ Linear integration uses OAuth (SSE transport) - authenticate via browser when pr
 
 ## Version History
 
+- **v2.7.0**: Add Task tool hook to guide agent selection. Update CLAUDE.template.md to mandate plan-mode agents instead of Explore. Fix wrong skill references.
 - **v2.6.0**: Skills now run in built-in agent contexts via `context: fork` + `agent: Plan`. Removed `/plan` command - planning-methodology skill now contains full workflow with Task() spawns. Simplified hooks.
 - **v2.5.8**: Trim agents and skills for conciseness (40-80% reduction) - tokens are gold
 - **v2.5.7**: Add Skill() and Task() invocation format to commands for better discoverability

--- a/plan-mode/hooks/hooks.json
+++ b/plan-mode/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Trigger planning methodology skill on plan mode entry",
+  "description": "Guide agent selection for planning tasks",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,16 @@
           {
             "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"permissionDecision\":\"allow\"},\"systemMessage\":\"<system-reminder>Load planning methodology: Skill({ skill: \\\"plan-mode:planning-methodology\\\" })</system-reminder>\"}'",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"hookSpecificOutput\":{\"permissionDecision\":\"allow\"},\"systemMessage\":\"<system-reminder>AGENT SELECTION: For planning/research use plan-mode:context-researcher, plan-mode:architecture-analyst, plan-mode:task-decomposer, plan-mode:plan-validator. NEVER use Explore or general-purpose.</system-reminder>\"}'",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary

Mandate the use of specialized plan-mode agents instead of generic Explore agents during planning workflows. Fix incorrect skill references and add guidance via Task tool hook.

## Why

The SOPS injection infrastructure was not achieving its goal of using specialized agents. Investigation revealed:

1. CLAUDE.template.md instructed agents to use generic Explore agents instead of plan-mode:context-researcher
2. Plan-mode specialized agents were not documented
3. Wrong skill reference in Quick Reference table (plan-mode:plan doesn't exist)
4. EnterPlanMode hook doesn't trigger in Conductor's built-in plan mode

This resulted in only 1 out of 16 agent spawns using specialized agents across the hanoi project.

## Design Decisions

- **Approach:** Mandate plan-mode agents in templates and enforce via hooks
- **Alternatives considered:** Make generic Explore agents smarter (complexity), add more hook matchers (less reliable)
- **Trade-offs:** Task tool hook fires on all Task calls, not just planning context (acceptable overhead)

## What Changed

- CLAUDE.template.md | 23 updates (agent table, skill reference fixes)
- plan-mode/hooks/hooks.json | 12 additions (Task tool hook)
- plan-mode/.claude-plugin/plugin.json | version bump to 2.7.0
- plan-mode/README.md | version history update
- README.md | version reference update

### Key Changes

- Add mandatory agent selection guidance in planning section
- Add Task tool PreToolUse hook to guide agent selection
- Fix skill reference from non-existent plan-mode:plan to planning-methodology
- Version bump with detailed changelog entry

## How to Test

1. Re-run setup script to update ~/.claude/CLAUDE.md with template
2. Start new planning session in hanoi project
3. Verify Task tool hook fires with agent selection guidance
4. Verify agents spawned use plan-mode:context-researcher NOT Explore

## Commits

- 37aea81 feat(plan-mode): mandate specialized agents for planning, fix skill references

<details>
<summary>Implementation Plan</summary>

# Fix: SOPS Injection Not Using Specialized Agents

## Root Causes Identified

### 1. CLAUDE.md Instructs Use of Generic Explore Agents
**File:** `/Users/roderik/.claude/CLAUDE.md`
**Line 119-121:** The 7-Phase Planning section says:
```
1. **Context Gathering** - Launch parallel Explore agents
```
This directly tells agents to use generic `Explore` instead of `plan-mode:context-researcher`.

### 2. Specialized Plan-Mode Agents Not Documented
The CLAUDE.md only documents build-mode agents:
- `build-mode:task-implementer`
- `build-mode:spec-reviewer`
- etc.

But it DOES NOT document plan-mode agents:
- `plan-mode:context-researcher`
- `plan-mode:architecture-analyst`
- `plan-mode:task-decomposer`
- `plan-mode:plan-validator`

### 3. Wrong Skill Reference
**Line 269:** References `Skill({ skill: "plan-mode:plan" })` but this skill doesn't exist.
Should be: `Skill({ skill: "plan-mode:planning-methodology" })`

### 4. EnterPlanMode Hook Doesn't Fire in Conductor
The hook triggers on `EnterPlanMode` tool, but Conductor's built-in plan mode activates without calling that tool.

## Implementation

### Task 1: Update CLAUDE.template.md Planning Section
Mandate plan-mode agents instead of generic Explore, add agent invocation table.

### Task 2: Fix Skill References
Change plan-mode:plan to plan-mode:planning-methodology in two locations.

### Task 3: Add Task Tool Hook
New PreToolUse hook on Task tool matcher to guide agent selection.

### Task 4: Update Plugin Version
Bump plan-mode to 2.7.0 and update all version references.

## Verification

Users will see agent guidance on next planning session after re-running setup script to sync CLAUDE.template.md.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces use of plan‑mode specialized agents during planning to replace generic Explore usage. Fixes wrong skill references and adds a Task hook that guides agent selection; bumps plan‑mode to v2.7.0.

- **New Features**
  - Task PreToolUse hook that reminds planners to use plan-mode subagents.
  - Template now mandates subagents per phase (context-researcher, architecture-analyst, task-decomposer, plan-validator).
  - Version bump to v2.7.0 and docs updated.

- **Bug Fixes**
  - Replaced non-existent plan-mode:plan with plan-mode:planning-methodology.
  - Worked around EnterPlanMode hook gap by moving guidance to the Task tool path.

<sup>Written for commit 37aea81c48473dedb3e232e612c1b68a26f23e6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

