### PR TITLE
feat(commands): restore git workflow slash commands

### DIFF
--- a/.agents/setup.sh
+++ b/.agents/setup.sh
@@ -154,6 +154,13 @@ copy_templates() {
             cp "$claude_templates/.claude/scripts/validation/"*.sh "$PROJECT_ROOT/.claude/scripts/validation/" 2>/dev/null || true
             chmod +x "$PROJECT_ROOT/.claude/scripts/validation/"*.sh 2>/dev/null || true
         fi
+
+        # Copy commands if they exist
+        if [[ -d "$claude_templates/.claude/commands" ]]; then
+            mkdir -p "$PROJECT_ROOT/.claude/commands"
+            cp "$claude_templates/.claude/commands/"*.md "$PROJECT_ROOT/.claude/commands/" 2>/dev/null || true
+            echo "  Installed Claude commands"
+        fi
     fi
 
     # Compose CLAUDE.md from claude/ templates

--- a/.agents/templates/claude/.claude/commands/branch.md
+++ b/.agents/templates/claude/.claude/commands/branch.md
@@ -1,0 +1,7 @@
+---
+name: branch
+description: Create feature branch with naming convention
+argument-hint: "<type> <description>"
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "branch $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/clean-gone.md
+++ b/.agents/templates/claude/.claude/commands/clean-gone.md
@@ -1,0 +1,6 @@
+---
+name: clean-gone
+description: Remove local branches deleted from remote
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "clean-gone $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/commit-push.md
+++ b/.agents/templates/claude/.claude/commands/commit-push.md
@@ -1,0 +1,7 @@
+---
+name: commit-push
+description: Create conventional commit and push
+argument-hint: "[message hint]"
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "commit-push $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/commit.md
+++ b/.agents/templates/claude/.claude/commands/commit.md
@@ -1,0 +1,7 @@
+---
+name: commit
+description: Create conventional commit with all changes staged
+argument-hint: "[message hint]"
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "commit $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/fixup.md
+++ b/.agents/templates/claude/.claude/commands/fixup.md
@@ -1,0 +1,6 @@
+---
+name: fixup
+description: Fix PR review comments and CI failures
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "fixup $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/pr.md
+++ b/.agents/templates/claude/.claude/commands/pr.md
@@ -1,0 +1,7 @@
+---
+name: pr
+description: Create pull request with smart template
+argument-hint: "[--draft] [--auto-merge]"
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "pr $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/push.md
+++ b/.agents/templates/claude/.claude/commands/push.md
@@ -1,0 +1,6 @@
+---
+name: push
+description: Push commits to remote safely
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "push $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/review.md
+++ b/.agents/templates/claude/.claude/commands/review.md
@@ -1,0 +1,7 @@
+---
+name: review
+description: Run comprehensive code review
+argument-hint: "[files]"
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "review $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/sync.md
+++ b/.agents/templates/claude/.claude/commands/sync.md
@@ -1,0 +1,7 @@
+---
+name: sync
+description: Sync branch with main via merge or rebase
+argument-hint: "[--rebase | --merge] [base-branch]"
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "sync $ARGUMENTS" })`

--- a/.agents/templates/claude/.claude/commands/update-pr.md
+++ b/.agents/templates/claude/.claude/commands/update-pr.md
@@ -1,0 +1,7 @@
+---
+name: update-pr
+description: Update PR title and body from commits
+argument-hint: "[--regenerate]"
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "update-pr $ARGUMENTS" })`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Before each phase, output a gate check. Do not proceed if BLOCKED. Do not skip g
 ⚠️ **Gate rushing is a failure mode.** Each checked box requires proof in the same message.
 
 Gate requirements:
-- GATE-1 Planning: classification stated + checklist output.
+- GATE-1 Planning: classification stated + checklist output + research complete (mcp__octocode__* for code, mcp__context7__* for docs, mcp__exa__* for web/company research).
 - GATE-2 Plan Refinement: `Skill({ skill: "ask-questions-if-underspecified" })` tool call visible. **Local:** `AskUserQuestion` tool used. **Remote:** questions optional unless genuinely ambiguous.
 - GATE-3 Implementation: `Skill({ skill: "test-driven-development" })` tool call visible + Tasks created (or TodoWrite fallback) + task status set to in_progress + parallel agents considered for 2+ independent tasks (with appropriate `name` and `mode`).
 - GATE-4 Cleanup: all implementation tasks complete (TaskList shows no pending tasks for current work).
@@ -391,7 +391,9 @@ When `system-reminder` indicates "Plan mode is active", use this dedicated gate 
 PLAN-GATE-1 CHECK:
 - [ ] Classification stated (Trivial/Simple/Standard/Complex)
 - [ ] User request understood
-- [ ] Codebase exploration complete (if needed)
+- [ ] Codebase exploration complete (mcp__octocode__* for code search, Explore agent for structure)
+- [ ] Library docs checked (mcp__context7__* for external libs, local docs for project)
+- [ ] Web research done if needed (mcp__exa__* for current info, code examples, company research)
 STATUS: PASS | BLOCKED
 ```
 
@@ -468,6 +470,9 @@ Multi-Session Collaboration:
 - Gather context (Explore Task for large codebases; direct tools for small).
 - Repo-wide search if needed (mcp__octocode__* or local rg/git).
 - Check docs (mcp__context7__* if available; else local docs/README).
+- Web research if needed (mcp__exa__web_search_exa for current info, mcp__exa__get_code_context_exa for code examples).
+- Company/competitor research (mcp__exa__company_research_exa, mcp__exa__linkedin_search_exa).
+- Deep research for complex topics (mcp__exa__deep_researcher_start → mcp__exa__deep_researcher_check).
 - If modifying existing behavior: `Skill({ skill: "systematic-debugging" })`.
 - Draft plan with file paths and 2-5 minute tasks; mark parallelizable tasks.
 - If complex/architectural: `mcp__codex` (Claude Code only).
@@ -561,6 +566,16 @@ Multi-Session Collaboration:
 - /plan, plan this, design approach, implementation plan -> `Skill({ skill: "planning workflow" })`
 - unclear/ambiguous/missing requirements -> `Skill({ skill: "ask-questions-if-underspecified" })`
 - library docs/API reference/current docs -> `mcp__context7__resolve-library-id` then `mcp__context7__query-docs`
+
+### Research & Discovery (triggers: search/research/find/lookup/current/latest)
+- web search/current info/latest news -> `mcp__exa__web_search_exa`
+- advanced search/filters/date range -> `mcp__exa__web_search_advanced_exa`
+- code examples/snippets/GitHub/StackOverflow -> `mcp__exa__get_code_context_exa`
+- company research/business info/competitors -> `mcp__exa__company_research_exa`
+- LinkedIn/people search/profiles -> `mcp__exa__linkedin_search_exa`
+- deep research/comprehensive report -> `mcp__exa__deep_researcher_start` then `mcp__exa__deep_researcher_check`
+- crawl URL/fetch page/PDF content -> `mcp__exa__crawling_exa`
+- smart query expansion/summaries -> `mcp__exa__deep_search_exa`
 
 ### Implementation (triggers: implement/build/code/write/create feature)
 - TDD, write test first, red-green-refactor -> `Skill({ skill: "test-driven-development" })`


### PR DESCRIPTION
## Summary
Restored 10 git workflow slash commands (`/commit`, `/branch`, `/pr`, `/push`, `/sync`, `/review`, `/fixup`, `/update-pr`, `/commit-push`, `/clean-gone`) to `.claude/commands/` directory. Commands delegate to the existing `git-workflow` skill for a seamless CLI experience.

## Changes
- Created command wrapper files in `.claude/commands/` that invoke the git-workflow skill
- Added command files to `.agents/templates/claude/.claude/commands/` for project setup
- Updated `.agents/setup.sh` to copy commands during project initialization
- Enhanced CLAUDE.md with extended Phase 1 research guidance

## Files Changed
- `.agents/setup.sh` - Added commands copy logic (+7 lines)
- `.agents/templates/claude/.claude/commands/*.md` - 10 new command files (+70 lines)
- `CLAUDE.md` - Enhanced planning documentation (+19 lines)

## Test Plan
- [x] All 10 command files created in `.claude/commands/`
- [x] Commands added to templates folder for setup.sh
- [x] setup.sh updated with commands copy logic
- [x] Verified git status shows all files committed
- [x] Branch pushed to origin successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored 10 git workflow slash commands in .claude/commands, delegating to the git-workflow skill for a consistent CLI. New projects install them automatically; existing repos can run setup to add them.

- **New Features**
  - Added command wrappers: commit, branch, pr, push, sync, review, fixup, update-pr, commit-push, clean-gone.
  - Included templates in .agents/templates/claude/.claude/commands.
  - Updated .agents/setup.sh to copy commands during project setup; expanded CLAUDE.md research guidance.

- **Migration**
  - For existing repos, run .agents/setup.sh to install commands.
  - No changes to git-workflow behavior; commands are thin wrappers.

<sup>Written for commit 10ddcdd7d8ebc25ae6b39a09c3e34d1cf0e5783c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

