### PR TITLE
fix(git-workflow): replace broken reviewThreads command with GraphQL scripts

### DIFF
--- a/.agents/skills-local/git-workflow/scripts/count-unresolved-threads.sh
+++ b/.agents/skills-local/git-workflow/scripts/count-unresolved-threads.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Count unresolved PR review threads via GitHub GraphQL API
+# Usage: count-unresolved-threads.sh [owner/repo#pr]
+# Examples:
+#   count-unresolved-threads.sh                    # Use current branch's PR
+#   count-unresolved-threads.sh settlemint/dalp#5473  # Specify PR directly
+# Output: Number of unresolved threads (0 = all resolved)
+
+set -euo pipefail
+
+PR_REF="${1:-}"
+
+if [[ -n "$PR_REF" && "$PR_REF" == */*#* ]]; then
+  # Parse owner/repo#pr format
+  OWNER=$(echo "$PR_REF" | cut -d'/' -f1)
+  REPO=$(echo "$PR_REF" | cut -d'/' -f2 | cut -d'#' -f1)
+  PR_NUM=$(echo "$PR_REF" | cut -d'#' -f2)
+else
+  # Get PR info from current branch
+  PR_URL=$(gh pr view --json url -q '.url' 2>/dev/null) || {
+    echo "No PR found for current branch. Use: $0 owner/repo#pr" >&2
+    exit 1
+  }
+  OWNER=$(echo "$PR_URL" | sed -n 's|.*github.com/\([^/]*\)/.*|\1|p')
+  REPO=$(echo "$PR_URL" | sed -n 's|.*github.com/[^/]*/\([^/]*\)/.*|\1|p')
+  PR_NUM=$(gh pr view --json number -q '.number')
+fi
+
+QUERY='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes { isResolved }
+      }
+    }
+  }
+}
+'
+
+gh api graphql -f query="$QUERY" -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUM" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'

--- a/.agents/skills-local/git-workflow/scripts/get-unresolved-threads.sh
+++ b/.agents/skills-local/git-workflow/scripts/get-unresolved-threads.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Get unresolved PR review threads via GitHub GraphQL API
+# Usage: get-unresolved-threads.sh [--full] [owner/repo#pr]
+# Examples:
+#   get-unresolved-threads.sh                    # Use current branch's PR
+#   get-unresolved-threads.sh settlemint/dalp#5473  # Specify PR directly
+#   get-unresolved-threads.sh --full             # Full comment body
+# Output: JSON objects with id, path, line, author, body
+
+set -euo pipefail
+
+FULL_BODY=false
+PR_REF=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --full) FULL_BODY=true ;;
+    */*#*) PR_REF="$arg" ;;
+  esac
+done
+
+if [[ -n "$PR_REF" ]]; then
+  # Parse owner/repo#pr format
+  OWNER=$(echo "$PR_REF" | cut -d'/' -f1)
+  REPO=$(echo "$PR_REF" | cut -d'/' -f2 | cut -d'#' -f1)
+  PR_NUM=$(echo "$PR_REF" | cut -d'#' -f2)
+else
+  # Get PR info from current branch
+  PR_URL=$(gh pr view --json url -q '.url' 2>/dev/null) || {
+    echo "No PR found for current branch. Use: $0 owner/repo#pr" >&2
+    exit 1
+  }
+  OWNER=$(echo "$PR_URL" | sed -n 's|.*github.com/\([^/]*\)/.*|\1|p')
+  REPO=$(echo "$PR_URL" | sed -n 's|.*github.com/[^/]*/\([^/]*\)/.*|\1|p')
+  PR_NUM=$(gh pr view --json number -q '.number')
+fi
+
+QUERY='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 1) {
+            nodes {
+              body
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+'
+
+if $FULL_BODY; then
+  JQ_FILTER='.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id: .id, path: .path, line: .line, author: .comments.nodes[0].author.login, body: .comments.nodes[0].body}'
+else
+  JQ_FILTER='.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id: .id, path: .path, line: .line, author: .comments.nodes[0].author.login, body: .comments.nodes[0].body[0:200]}'
+fi
+
+gh api graphql -f query="$QUERY" -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUM" --jq "$JQ_FILTER"

--- a/.agents/skills-local/git-workflow/scripts/resolve-thread.sh
+++ b/.agents/skills-local/git-workflow/scripts/resolve-thread.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Resolve a PR review thread via GitHub GraphQL API
+# Usage: resolve-thread.sh <thread-id>
+
+set -euo pipefail
+
+THREAD_ID="${1:-}"
+
+if [[ -z "$THREAD_ID" ]]; then
+  echo "Usage: resolve-thread.sh <thread-id>" >&2
+  echo "Get thread IDs from: get-unresolved-threads.sh" >&2
+  exit 1
+fi
+
+QUERY='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}
+'
+
+gh api graphql -f query="$QUERY" -F threadId="$THREAD_ID" --jq '.data.resolveReviewThread.thread.isResolved'

--- a/.agents/skills/git-workflow/scripts/count-unresolved-threads.sh
+++ b/.agents/skills/git-workflow/scripts/count-unresolved-threads.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Count unresolved PR review threads via GitHub GraphQL API
+# Usage: count-unresolved-threads.sh [owner/repo#pr]
+# Examples:
+#   count-unresolved-threads.sh                    # Use current branch's PR
+#   count-unresolved-threads.sh settlemint/dalp#5473  # Specify PR directly
+# Output: Number of unresolved threads (0 = all resolved)
+
+set -euo pipefail
+
+PR_REF="${1:-}"
+
+if [[ -n "$PR_REF" && "$PR_REF" == */*#* ]]; then
+  # Parse owner/repo#pr format
+  OWNER=$(echo "$PR_REF" | cut -d'/' -f1)
+  REPO=$(echo "$PR_REF" | cut -d'/' -f2 | cut -d'#' -f1)
+  PR_NUM=$(echo "$PR_REF" | cut -d'#' -f2)
+else
+  # Get PR info from current branch
+  PR_URL=$(gh pr view --json url -q '.url' 2>/dev/null) || {
+    echo "No PR found for current branch. Use: $0 owner/repo#pr" >&2
+    exit 1
+  }
+  OWNER=$(echo "$PR_URL" | sed -n 's|.*github.com/\([^/]*\)/.*|\1|p')
+  REPO=$(echo "$PR_URL" | sed -n 's|.*github.com/[^/]*/\([^/]*\)/.*|\1|p')
+  PR_NUM=$(gh pr view --json number -q '.number')
+fi
+
+QUERY='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes { isResolved }
+      }
+    }
+  }
+}
+'
+
+gh api graphql -f query="$QUERY" -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUM" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'

--- a/.agents/skills/git-workflow/scripts/get-unresolved-threads.sh
+++ b/.agents/skills/git-workflow/scripts/get-unresolved-threads.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Get unresolved PR review threads via GitHub GraphQL API
+# Usage: get-unresolved-threads.sh [--full] [owner/repo#pr]
+# Examples:
+#   get-unresolved-threads.sh                    # Use current branch's PR
+#   get-unresolved-threads.sh settlemint/dalp#5473  # Specify PR directly
+#   get-unresolved-threads.sh --full             # Full comment body
+# Output: JSON objects with id, path, line, author, body
+
+set -euo pipefail
+
+FULL_BODY=false
+PR_REF=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --full) FULL_BODY=true ;;
+    */*#*) PR_REF="$arg" ;;
+  esac
+done
+
+if [[ -n "$PR_REF" ]]; then
+  # Parse owner/repo#pr format
+  OWNER=$(echo "$PR_REF" | cut -d'/' -f1)
+  REPO=$(echo "$PR_REF" | cut -d'/' -f2 | cut -d'#' -f1)
+  PR_NUM=$(echo "$PR_REF" | cut -d'#' -f2)
+else
+  # Get PR info from current branch
+  PR_URL=$(gh pr view --json url -q '.url' 2>/dev/null) || {
+    echo "No PR found for current branch. Use: $0 owner/repo#pr" >&2
+    exit 1
+  }
+  OWNER=$(echo "$PR_URL" | sed -n 's|.*github.com/\([^/]*\)/.*|\1|p')
+  REPO=$(echo "$PR_URL" | sed -n 's|.*github.com/[^/]*/\([^/]*\)/.*|\1|p')
+  PR_NUM=$(gh pr view --json number -q '.number')
+fi
+
+QUERY='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 1) {
+            nodes {
+              body
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+'
+
+if $FULL_BODY; then
+  JQ_FILTER='.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id: .id, path: .path, line: .line, author: .comments.nodes[0].author.login, body: .comments.nodes[0].body}'
+else
+  JQ_FILTER='.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id: .id, path: .path, line: .line, author: .comments.nodes[0].author.login, body: .comments.nodes[0].body[0:200]}'
+fi
+
+gh api graphql -f query="$QUERY" -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUM" --jq "$JQ_FILTER"

--- a/.agents/skills/git-workflow/scripts/resolve-thread.sh
+++ b/.agents/skills/git-workflow/scripts/resolve-thread.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Resolve a PR review thread via GitHub GraphQL API
+# Usage: resolve-thread.sh <thread-id>
+
+set -euo pipefail
+
+THREAD_ID="${1:-}"
+
+if [[ -z "$THREAD_ID" ]]; then
+  echo "Usage: resolve-thread.sh <thread-id>" >&2
+  echo "Get thread IDs from: get-unresolved-threads.sh" >&2
+  exit 1
+fi
+
+QUERY='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}
+'
+
+gh api graphql -f query="$QUERY" -F threadId="$THREAD_ID" --jq '.data.resolveReviewThread.thread.isResolved'


### PR DESCRIPTION
## Summary
Fixed a critical bug in the git-workflow skill's `fixup` command that was using a non-existent `gh pr view --json reviewThreads` field.

## Changes
- Created 3 standalone shell scripts to fetch, count, and resolve PR review threads via GitHub GraphQL API
- Refactored SKILL.md to use scripts instead of complex inline heredocs
- Scripts support both auto-detection (current branch) and explicit `owner/repo#pr` format

## Why
The GitHub CLI doesn't expose review threads via `--json`. The GraphQL API is the correct way to access this data. Shell scripts provide better testability, reusability, and maintainability than inline commands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the broken gh pr view reviewThreads usage in the git-workflow fixup command with GraphQL scripts to fetch, count, and resolve PR review threads. This restores thread handling and makes the workflow reliable.

- **Bug Fixes**
  - Removed non-existent reviewThreads field usage from SKILL.md.
  - Updated fixup workflow to call scripts for fetching and resolving threads.
  - Verification step now uses count-unresolved-threads.sh.

- **New Features**
  - Added get-unresolved-threads.sh: lists unresolved threads (supports --full).
  - Added count-unresolved-threads.sh: returns unresolved thread count.
  - Added resolve-thread.sh: resolves a thread by ID.
  - Scripts support current-branch auto-detection or owner/repo#pr input.

<sup>Written for commit a92d8cd09555324edc8f3e1154fd358df3a59e9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

