### PR TITLE
docs(crew-skills): add explicit test backfilling requirements

### DIFF
--- a/.agents/skills-local/crew-claude/hard-requirements.md
+++ b/.agents/skills-local/crew-claude/hard-requirements.md
@@ -64,6 +64,20 @@ Skill({ skill: "ask-questions-if-underspecified" })
 
 **Self-check:** Search your context for `<invoke name="Skill">`. If not found, you have not loaded skills.
 
+### Test Backfilling (MANDATORY)
+
+When modifying existing code:
+- **If file has no tests → add tests BEFORE modifying**
+- This is not optional: "Existing code has no tests → You're improving it. Add tests."
+- Applies to: bug fixes, refactors, behavior changes, any file touch
+- **Minimum coverage:** Test the behavior you're changing/touching
+
+**Self-check before modifying any file:**
+1. Does a test file exist for this file? (e.g., `foo.ts` → `foo.test.ts`)
+2. If no → create test file, add tests for existing behavior first
+3. If yes → verify tests cover the code you're about to change
+4. Only then proceed with TDD for new changes
+
 ### Classification Checklist (MANDATORY)
 
 Output immediately after classification:
@@ -96,7 +110,7 @@ Before each phase, output a gate check. Do not proceed if BLOCKED. Do not skip g
 Gate requirements:
 - GATE-1 Planning: classification stated + checklist output + research complete (mcp__octocode__* for code, mcp__context7__* for docs, mcp__exa__* for web/company research).
 - GATE-2 Plan Refinement: `Skill({ skill: "ask-questions-if-underspecified" })` tool call visible. **Local:** `AskUserQuestion` tool used. **Remote:** questions optional unless genuinely ambiguous.
-- GATE-3 Implementation: `Skill({ skill: "test-driven-development" })` tool call visible + Tasks created (or TodoWrite fallback) + task status set to in_progress + parallel agents considered for 2+ independent tasks (with appropriate `name` and `mode`).
+- GATE-3 Implementation: `Skill({ skill: "test-driven-development" })` tool call visible + **backfill check done (if modifying existing file without tests → tests added first)** + Tasks created (or TodoWrite fallback) + task status set to in_progress + parallel agents considered for 2+ independent tasks (with appropriate `name` and `mode`).
 - GATE-4 Cleanup: all implementation tasks complete (TaskList shows no pending tasks for current work).
 - GATE-5 Testing: test file exists + test output with exit code shown (or explicit "no tests possible" justification).
 - GATE-6 Review: `Skill({ skill: "review" })` tool call visible + review output shown. "Manual review" is NOT acceptable.

--- a/.agents/skills-local/crew-claude/workflows.md
+++ b/.agents/skills-local/crew-claude/workflows.md
@@ -158,6 +158,10 @@ Multi-Session Collaboration:
   - `Skill({ skill: "verification-before-completion" })` - load now, execute in Phase 7.
 - **Self-check before proceeding:** Search context for `<invoke name="Skill">`. If not found, STOP.
 - **Loading = Commitment:** Once you invoke a skill, you MUST follow its instructions. No exceptions.
+- **Backfill check:** Before modifying any existing file:
+  1. Check if test file exists (e.g., `foo.ts` → `foo.test.ts`)
+  2. If no tests → add tests for existing behavior FIRST
+  3. Then proceed with TDD for new changes
 - **Task generation (use strict format above):**
   1. Break work into **MANY small atomic tasks** — prefer 10+ tasks over 3 vague ones
   2. Each task = single file + clear action: `[T001] [P] Create User model in src/models/user.ts`

--- a/.agents/skills-local/crew-codex/hard-requirements.md
+++ b/.agents/skills-local/crew-codex/hard-requirements.md
@@ -57,6 +57,20 @@ $ask-questions-if-underspecified
 
 **Self-check:** Confirm you explicitly invoked required skills (or documented unavailability) in the transcript.
 
+### Test Backfilling (MANDATORY)
+
+When modifying existing code:
+- **If file has no tests → add tests BEFORE modifying**
+- This is not optional: "Existing code has no tests → You're improving it. Add tests."
+- Applies to: bug fixes, refactors, behavior changes, any file touch
+- **Minimum coverage:** Test the behavior you're changing/touching
+
+**Self-check before modifying any file:**
+1. Does a test file exist for this file? (e.g., `foo.ts` → `foo.test.ts`)
+2. If no → create test file, add tests for existing behavior first
+3. If yes → verify tests cover the code you're about to change
+4. Only then proceed with TDD for new changes
+
 ### Classification Checklist (MANDATORY)
 
 Output immediately after classification:
@@ -89,7 +103,7 @@ Before each phase, output a gate check. Do not proceed if a gate is BLOCKED. Do 
 Gate requirements:
 - GATE-1 Planning: classification stated + checklist output + research complete (mcp__octocode__* for code, mcp__context7__* for docs, mcp__exa__* for web/company research).
 - GATE-2 Plan Refinement: explicit `$ask-questions-if-underspecified` invocation (Standard/Complex). **Local:** at least one clarifying question asked. **Remote:** questions optional unless genuinely ambiguous.
-- GATE-3 Implementation: explicit `$test-driven-development` + `$verification-before-completion` invocation + TODO list started + parallel-thread check documented.
+- GATE-3 Implementation: explicit `$test-driven-development` + `$verification-before-completion` invocation + **backfill check done (if modifying existing file without tests → tests added first)** + TODO list started + parallel-thread check documented.
 - GATE-4 Cleanup: all implementation TODOs complete.
 - GATE-5 Testing: test file exists + test output with exit code shown (or explicit "no tests possible" justification).
 - GATE-6 Review: run `/review` (preferred) or provide a structured review checklist with file/line references; show output. Manual review is NOT acceptable.

--- a/.agents/skills-local/crew-codex/workflows.md
+++ b/.agents/skills-local/crew-codex/workflows.md
@@ -120,6 +120,10 @@ STATUS: PASS | BLOCKED
 - **STOP: Output GATE-3 before proceeding.**
 - **REQUIRED:** Activate `$test-driven-development` and `$verification-before-completion`.
 - **Self-check before proceeding:** Confirm explicit skill invocations are in the transcript.
+- **Backfill check:** Before modifying any existing file:
+  1. Check if test file exists (e.g., `foo.ts` → `foo.test.ts`)
+  2. If no tests → add tests for existing behavior FIRST
+  3. Then proceed with TDD for new changes
 - **Task generation (use strict format above):**
   1. Break work into **MANY small atomic tasks** — prefer 10+ tasks over 3 vague ones
   2. Each task = single file + clear action: `[T001] [P] Create User model in src/models/user.ts`


### PR DESCRIPTION
## Summary

Adds explicit test backfilling requirements to crew-claude and crew-codex skills to ensure tests are added when modifying existing code without tests.

## Changes

- Added "Test Backfilling (MANDATORY)" section to `hard-requirements.md` for both crew-claude and crew-codex
- Updated GATE-3 requirements to include backfill check
- Added backfill check step to Phase 3 in `workflows.md`
- Provides a 4-step self-check before modifying any existing file

## Why

The backfilling requirement existed but was buried in the TDD skill's rationalization table (line 270). This change:
1. Makes the rule explicit and prominent in crew skill files
2. Adds enforcement at GATE-3 level
3. Provides redundancy in Phase 3 workflow

## Files Changed

- `.agents/skills-local/crew-claude/hard-requirements.md`
- `.agents/skills-local/crew-claude/workflows.md`
- `.agents/skills-local/crew-codex/hard-requirements.md`
- `.agents/skills-local/crew-codex/workflows.md`

## Test Plan

- [x] Markdown files render correctly
- [x] No syntax errors in gate format
- [x] Changes apply consistently to both crew-claude and crew-codex

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes test backfilling a clear, enforced rule in crew-claude and crew-codex. Ensures tests are added before changing untested files by updating GATE-3 and Phase 3 workflow.

- **New Features**
  - Added a "Test Backfilling (MANDATORY)" section to hard-requirements for both skills.
  - Updated GATE-3 to require a backfill check before modifying files without tests.
  - Added a Phase 3 workflow step with a simple 4-step self-check for backfilling.

<sup>Written for commit 8b74759badcb5246a628d1d356cb33b21981ee9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

