### PR TITLE
docs(crew-skills): add failure deflection anti-pattern and sync template

### DIFF
--- a/.agents/skills-local/crew-claude/anti-patterns.md
+++ b/.agents/skills-local/crew-claude/anti-patterns.md
@@ -53,6 +53,22 @@
 - **Overly permissive mode:** using `mode: "bypassPermissions"` for risky/security tasks -> use `mode: "plan"` for changes requiring review.
 - **Mode omission:** not specifying mode when context requires it -> explicitly set `mode` based on task risk level.
 
+### Failure Deflection (CRITICAL)
+
+**THIS IS THE MOST SEVERE ANTI-PATTERN. ZERO TOLERANCE.**
+
+Applies to: CI failures, test failures, lint errors, type errors, build failures, ANY verification failure.
+
+- **"Pre-existing issues":** claiming failures are "not related to my changes" or "pre-existing in the codebase" -> ABSOLUTELY FORBIDDEN. Main branch ALWAYS passes (otherwise PRs cannot merge). If anything fails, YOUR changes broke it.
+- **"My tests pass":** claiming success because "the specific tests I created pass" while ignoring other failures -> UNACCEPTABLE. ALL tests must pass. 19 passing tests mean nothing if 1 test fails.
+- **"Module resolution issues":** claiming type errors or import failures are "pre-existing module issues" -> LIES. The codebase compiles on main. You broke it.
+- **Blame shifting:** any variation of "those errors existed before" or "that's a different module" -> LIES. You own the ENTIRE outcome. Fix it or revert your changes.
+- **Scope limitation:** "not in scope of this PR" for ANY failure -> WRONG. If it fails, it IS in scope. Period.
+- **Partial success claims:** "implementation is complete, just some unrelated issues" -> NOTHING is complete until everything passes.
+- **Selective reporting:** showing only your passing tests while hiding lint/type/other failures -> DISHONEST. Show ALL output.
+
+**The rule is absolute:** If ANY verification (tests, lint, types, build, CI) does not pass, you have NOT completed the task. There are no exceptions. There are no "pre-existing issues" in a working main branch. If it fails now, you fix it now.
+
 ### Evidence Failures
 - Implied evidence: "I ran the tests" without showing output -> paste actual command output.
 - Exit code assumption: "command succeeded" without checking -> show exit code 0 explicitly.

--- a/.agents/skills-local/crew-claude/hard-requirements.md
+++ b/.agents/skills-local/crew-claude/hard-requirements.md
@@ -146,8 +146,9 @@ Before saying "done" or "complete", confirm evidence for:
 - Verification command exit code 0
 - CI phase executed (GATE-8) with exit code 0
 
-**Banned phrases:** "looks good", "should work", "Done!", "that's it", "it's just a port", "direct translation", "1:1 conversion", "straightforward", "manual review", "reviewed the code"
+**Banned phrases:** "looks good", "should work", "Done!", "that's it", "it's just a port", "direct translation", "1:1 conversion", "straightforward", "manual review", "reviewed the code", "pre-existing", "not related to my changes", "unrelated to this PR", "existing issue", "those errors existed before", "module resolution issues in the codebase", "the specific tests I created pass"
 - **Local only banned:** "requirements are clear" (allowed in Remote Mode when genuinely clear)
+- **Failure deflection (ZERO TOLERANCE):** Any claim that failures (tests, lint, types, build, CI) are "pre-existing" or "not related to my changes" is ABSOLUTELY FORBIDDEN. Main always passes. If anything fails, you broke it. Fix it.
 
 **Required completion format:** evidence summary + verification output + gates passed list + iteration counts
 

--- a/.agents/skills-local/crew-codex/anti-patterns.md
+++ b/.agents/skills-local/crew-codex/anti-patterns.md
@@ -45,6 +45,22 @@
 - **Sequential when parallel possible:** executing 2+ independent tasks one-by-one -> use `spawn_agent` or parallel Codex threads.
 - **Thread avoidance:** "file operations are quick" to skip parallelization -> if tasks are independent, use `spawn_agent` with role presets.
 
+### Failure Deflection (CRITICAL)
+
+**THIS IS THE MOST SEVERE ANTI-PATTERN. ZERO TOLERANCE.**
+
+Applies to: CI failures, test failures, lint errors, type errors, build failures, ANY verification failure.
+
+- **"Pre-existing issues":** claiming failures are "not related to my changes" or "pre-existing in the codebase" -> ABSOLUTELY FORBIDDEN. Main branch ALWAYS passes (otherwise PRs cannot merge). If anything fails, YOUR changes broke it.
+- **"My tests pass":** claiming success because "the specific tests I created pass" while ignoring other failures -> UNACCEPTABLE. ALL tests must pass. 19 passing tests mean nothing if 1 test fails.
+- **"Module resolution issues":** claiming type errors or import failures are "pre-existing module issues" -> LIES. The codebase compiles on main. You broke it.
+- **Blame shifting:** any variation of "those errors existed before" or "that's a different module" -> LIES. You own the ENTIRE outcome. Fix it or revert your changes.
+- **Scope limitation:** "not in scope of this PR" for ANY failure -> WRONG. If it fails, it IS in scope. Period.
+- **Partial success claims:** "implementation is complete, just some unrelated issues" -> NOTHING is complete until everything passes.
+- **Selective reporting:** showing only your passing tests while hiding lint/type/other failures -> DISHONEST. Show ALL output.
+
+**The rule is absolute:** If ANY verification (tests, lint, types, build, CI) does not pass, you have NOT completed the task. There are no exceptions. There are no "pre-existing issues" in a working main branch. If it fails now, you fix it now.
+
 ### Evidence Failures
 - Implied evidence: "I ran the tests" without showing output -> paste actual command output.
 - Exit code assumption: "command succeeded" without checking -> show exit code 0 explicitly.

--- a/.agents/skills-local/crew-codex/hard-requirements.md
+++ b/.agents/skills-local/crew-codex/hard-requirements.md
@@ -138,8 +138,9 @@ Before saying "done" or "complete", confirm evidence for:
 - Verification command exit code 0
 - CI phase executed (GATE-8) with exit code 0
 
-**Banned phrases:** "looks good", "should work", "Done!", "that's it", "it's just a port", "direct translation", "1:1 conversion", "straightforward", "manual review", "reviewed the code"
+**Banned phrases:** "looks good", "should work", "Done!", "that's it", "it's just a port", "direct translation", "1:1 conversion", "straightforward", "manual review", "reviewed the code", "pre-existing", "not related to my changes", "unrelated to this PR", "existing issue", "those errors existed before", "module resolution issues in the codebase", "the specific tests I created pass"
 - **Local only banned:** "requirements are clear" (allowed in Remote Mode when genuinely clear)
+- **Failure deflection (ZERO TOLERANCE):** Any claim that failures (tests, lint, types, build, CI) are "pre-existing" or "not related to my changes" is ABSOLUTELY FORBIDDEN. Main always passes. If anything fails, you broke it. Fix it.
 
 **Required completion format:** evidence summary + verification output + gates passed list + iteration counts
 

--- a/.agents/skills/remotion-best-practices/SKILL.md
+++ b/.agents/skills/remotion-best-practices/SKILL.md
@@ -41,3 +41,5 @@ Read individual rule files for detailed explanations and code examples:
 - [rules/transitions.md](rules/transitions.md) - Scene transition patterns for Remotion
 - [rules/trimming.md](rules/trimming.md) - Trimming patterns for Remotion - cut the beginning or end of animations
 - [rules/videos.md](rules/videos.md) - Embedding videos in Remotion - trimming, volume, speed, looping, pitch
+- [rules/parameters.md](rules/parameters.md) - Make a video parametrizable by adding a Zod schema
+- [rules/maps.md](rules/maps.md) - Add a map using Mapbox and animate it

--- a/.agents/skills/remotion-best-practices/rules/compositions.md
+++ b/.agents/skills/remotion-best-practices/rules/compositions.md
@@ -10,20 +10,11 @@ A `<Composition>` defines the component, width, height, fps and duration of a re
 It normally is placed in the `src/Root.tsx` file.
 
 ```tsx
-import { Composition } from "remotion";
-import { MyComposition } from "./MyComposition";
+import {Composition} from 'remotion';
+import {MyComposition} from './MyComposition';
 
 export const RemotionRoot = () => {
-  return (
-    <Composition
-      id="MyComposition"
-      component={MyComposition}
-      durationInFrames={100}
-      fps={30}
-      width={1080}
-      height={1080}
-    />
-  );
+  return <Composition id="MyComposition" component={MyComposition} durationInFrames={100} fps={30} width={1080} height={1080} />;
 };
 ```
 
@@ -33,8 +24,8 @@ Pass `defaultProps` to provide initial values for your component.
 Values must be JSON-serializable (`Date`, `Map`, `Set`, and `staticFile()` are supported).
 
 ```tsx
-import { Composition } from "remotion";
-import { MyComposition, MyCompositionProps } from "./MyComposition";
+import {Composition} from 'remotion';
+import {MyComposition, MyCompositionProps} from './MyComposition';
 
 export const RemotionRoot = () => {
   return (
@@ -45,10 +36,12 @@ export const RemotionRoot = () => {
       fps={30}
       width={1080}
       height={1080}
-      defaultProps={{
-        title: "Hello World",
-        color: "#ff0000",
-      } satisfies MyCompositionProps}
+      defaultProps={
+        {
+          title: 'Hello World',
+          color: '#ff0000',
+        } satisfies MyCompositionProps
+      }
     />
   );
 };
@@ -62,7 +55,7 @@ Use `<Folder>` to organize compositions in the sidebar.
 Folder names can only contain letters, numbers, and hyphens.
 
 ```tsx
-import { Composition, Folder } from "remotion";
+import {Composition, Folder} from 'remotion';
 
 export const RemotionRoot = () => {
   return (
@@ -87,18 +80,11 @@ export const RemotionRoot = () => {
 Use `<Still>` for single-frame images. It does not require `durationInFrames` or `fps`.
 
 ```tsx
-import { Still } from "remotion";
-import { Thumbnail } from "./Thumbnail";
+import {Still} from 'remotion';
+import {Thumbnail} from './Thumbnail';
 
 export const RemotionRoot = () => {
-  return (
-    <Still
-      id="Thumbnail"
-      component={Thumbnail}
-      width={1280}
-      height={720}
-    />
-  );
+  return <Still id="Thumbnail" component={Thumbnail} width={1280} height={720} />;
 };
 ```
 
@@ -107,13 +93,10 @@ export const RemotionRoot = () => {
 Use `calculateMetadata` to make dimensions, duration, or props dynamic based on data.
 
 ```tsx
-import { Composition, CalculateMetadataFunction } from "remotion";
-import { MyComposition, MyCompositionProps } from "./MyComposition";
+import {Composition, CalculateMetadataFunction} from 'remotion';
+import {MyComposition, MyCompositionProps} from './MyComposition';
 
-const calculateMetadata: CalculateMetadataFunction<MyCompositionProps> = async ({
-  props,
-  abortSignal,
-}) => {
+const calculateMetadata: CalculateMetadataFunction<MyCompositionProps> = async ({props, abortSignal}) => {
   const data = await fetch(`https://api.example.com/video/${props.videoId}`, {
     signal: abortSignal,
   }).then((res) => res.json());
@@ -136,7 +119,7 @@ export const RemotionRoot = () => {
       fps={30}
       width={1080}
       height={1080}
-      defaultProps={{ videoId: "abc123" }}
+      defaultProps={{videoId: 'abc123'}}
       calculateMetadata={calculateMetadata}
     />
   );
@@ -144,3 +127,15 @@ export const RemotionRoot = () => {
 ```
 
 The function can return `props`, `durationInFrames`, `width`, `height`, `fps`, and codec-related defaults. It runs once before rendering begins.
+
+## Nesting compositions within another
+
+To add a composition within another composition, you can use the `<Sequence>` component with a `width` and `height` prop to specify the size of the composition.
+
+```tsx
+<AbsoluteFill>
+  <Sequence width={COMPOSITION_WIDTH} height={COMPOSITION_HEIGHT}>
+    <CompositionComponent />
+  </Sequence>
+</AbsoluteFill>
+```

--- a/.agents/skills/remotion-best-practices/rules/maps.md
+++ b/.agents/skills/remotion-best-practices/rules/maps.md
@@ -1,0 +1,403 @@
+---
+name: maps
+description: Make map animations with Mapbox
+metadata:
+  tags: map, map animation, mapbox
+---
+
+Maps can be added to a Remotion video with Mapbox.  
+The [Mapbox documentation](https://docs.mapbox.com/mapbox-gl-js/api/) has the API reference.
+
+## Prerequisites
+
+Mapbox and `@turf/turf` need to be installed.
+
+Search the project for lockfiles and run the correct command depending on the package manager:
+
+If `package-lock.json` is found, use the following command:
+
+```bash
+npm i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `bun.lock` is found, use the following command:
+
+```bash
+bun i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `yarn.lock` is found, use the following command:
+
+```bash
+yarn add mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `pnpm-lock.yaml` is found, use the following command:
+
+```bash
+pnpm i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+The user needs to create a free Mapbox account and create an access token by visiting https://console.mapbox.com/account/access-tokens/.
+
+The mapbox token needs to be added to the `.env` file:
+
+```txt title=".env"
+REMOTION_MAPBOX_TOKEN==pk.your-mapbox-access-token
+```
+
+## Adding a map
+
+Here is a basic example of a map in Remotion.
+
+```tsx
+import {useEffect, useMemo, useRef, useState} from 'react';
+import {AbsoluteFill, useDelayRender, useVideoConfig} from 'remotion';
+import mapboxgl, {Map} from 'mapbox-gl';
+
+export const lineCoordinates = [
+  [6.56158447265625, 46.059891147620725],
+  [6.5691375732421875, 46.05679376154153],
+  [6.5842437744140625, 46.05059898938315],
+  [6.594886779785156, 46.04702502069337],
+  [6.601066589355469, 46.0460718554722],
+  [6.6089630126953125, 46.0365370783104],
+  [6.6185760498046875, 46.018420689207964],
+];
+
+mapboxgl.accessToken = process.env.REMOTION_MAPBOX_TOKEN as string;
+
+export const MyComposition = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const {delayRender, continueRender} = useDelayRender();
+
+  const {width, height} = useVideoConfig();
+  const [handle] = useState(() => delayRender('Loading map...'));
+  const [map, setMap] = useState<Map | null>(null);
+
+  useEffect(() => {
+    const _map = new Map({
+      container: ref.current!,
+      zoom: 11.53,
+      center: [6.5615, 46.0598],
+      pitch: 65,
+      bearing: 0,
+      style: '⁠mapbox://styles/mapbox/standard',
+      interactive: false,
+      fadeDuration: 0,
+    });
+
+    _map.on('style.load', () => {
+      // Hide all features from the Mapbox Standard style
+      const hideFeatures = [
+        'showRoadsAndTransit',
+        'showRoads',
+        'showTransit',
+        'showPedestrianRoads',
+        'showRoadLabels',
+        'showTransitLabels',
+        'showPlaceLabels',
+        'showPointOfInterestLabels',
+        'showPointsOfInterest',
+        'showAdminBoundaries',
+        'showLandmarkIcons',
+        'showLandmarkIconLabels',
+        'show3dObjects',
+        'show3dBuildings',
+        'show3dTrees',
+        'show3dLandmarks',
+        'show3dFacades',
+      ];
+      for (const feature of hideFeatures) {
+        _map.setConfigProperty('basemap', feature, false);
+      }
+
+      _map.setConfigProperty('basemap', 'colorMotorways', 'rgba(0, 0, 0, 0)');
+      _map.setConfigProperty('basemap', 'colorRoads', 'rgba(0, 0, 0, 0)');
+      _map.setConfigProperty('basemap', 'colorTrunks', 'rgba(0, 0, 0, 0)');
+
+      _map.addSource('trace', {
+        type: 'geojson',
+        data: {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'LineString',
+            coordinates: lineCoordinates,
+          },
+        },
+      });
+      _map.addLayer({
+        type: 'line',
+        source: 'trace',
+        id: 'line',
+        paint: {
+          'line-color': 'black',
+          'line-width': 5,
+        },
+        layout: {
+          'line-cap': 'round',
+          'line-join': 'round',
+        },
+      });
+    });
+
+    _map.on('load', () => {
+      continueRender(handle);
+      setMap(_map);
+    });
+  }, [handle, lineCoordinates]);
+
+  const style: React.CSSProperties = useMemo(() => ({width, height, position: 'absolute'}), [width, height]);
+
+  return <AbsoluteFill ref={ref} style={style} />;
+};
+```
+
+The following is important in Remotion:
+
+- Animations must be driven by `useCurrentFrame()` and animations that Mapbox brings itself should be disabled. For example, the `fadeDuration` prop should be set to `0`, `interactive` should be set to `false`, etc.
+- Loading the map should be delayed using `useDelayRender()` and the map should be set to `null` until it is loaded.
+- The element containing the ref MUST have an explicit width and height and `position: "absolute"`.
+- Do not add a `_map.remove();` cleanup function.
+
+## Drawing lines
+
+Unless I request it, do not add a glow effect to the lines.
+Unless I request it, do not add additional points to the lines.
+
+## Map style
+
+By default, use the `mapbox://styles/mapbox/standard` style.  
+Hide the labels from the base map style.
+
+Unless I request otherwise, remove all features from the Mapbox Standard style.
+
+```tsx
+// Hide all features from the Mapbox Standard style
+const hideFeatures = [
+  'showRoadsAndTransit',
+  'showRoads',
+  'showTransit',
+  'showPedestrianRoads',
+  'showRoadLabels',
+  'showTransitLabels',
+  'showPlaceLabels',
+  'showPointOfInterestLabels',
+  'showPointsOfInterest',
+  'showAdminBoundaries',
+  'showLandmarkIcons',
+  'showLandmarkIconLabels',
+  'show3dObjects',
+  'show3dBuildings',
+  'show3dTrees',
+  'show3dLandmarks',
+  'show3dFacades',
+];
+for (const feature of hideFeatures) {
+  _map.setConfigProperty('basemap', feature, false);
+}
+
+_map.setConfigProperty('basemap', 'colorMotorways', 'transparent');
+_map.setConfigProperty('basemap', 'colorRoads', 'transparent');
+_map.setConfigProperty('basemap', 'colorTrunks', 'transparent');
+```
+
+## Animating the camera
+
+You can animate the camera along the line by adding a `useEffect` hook that updates the camera position based on the current frame.
+
+Unless I ask for it, do not jump between camera angles.
+
+```tsx
+import * as turf from '@turf/turf';
+import {interpolate} from 'remotion';
+import {Easing} from 'remotion';
+import {useCurrentFrame, useVideoConfig, useDelayRender} from 'remotion';
+
+const animationDuration = 20;
+const cameraAltitude = 4000;
+```
+
+```tsx
+const frame = useCurrentFrame();
+const {fps} = useVideoConfig();
+const {delayRender, continueRender} = useDelayRender();
+
+useEffect(() => {
+  if (!map) {
+    return;
+  }
+  const handle = delayRender('Moving point...');
+
+  const routeDistance = turf.length(turf.lineString(lineCoordinates));
+
+  const progress = interpolate(frame / fps, [0.00001, animationDuration], [0, 1], {
+    easing: Easing.inOut(Easing.sin),
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  const camera = map.getFreeCameraOptions();
+
+  const alongRoute = turf.along(turf.lineString(lineCoordinates), routeDistance * progress).geometry.coordinates;
+
+  camera.lookAtPoint({
+    lng: alongRoute[0],
+    lat: alongRoute[1],
+  });
+
+  map.setFreeCameraOptions(camera);
+  map.once('idle', () => continueRender(handle));
+}, [lineCoordinates, fps, frame, handle, map]);
+```
+
+Notes:
+
+IMPORTANT: Keep the camera by default so north is up.
+IMPORTANT: For multi-step animations, set all properties at all stages (zoom, position, line progress) to prevent jumps. Override initial values.
+
+- The progress is clamped to a minimum value to avoid the line being empty, which can lead to turf errors
+- See [Timing](./timing.md) for more options for timing.
+- Consider the dimensions of the composition and make the lines thick enough and the label font size large enough to be legible for when the composition is scaled down.
+
+## Animating lines
+
+### Straight lines (linear interpolation)
+
+To animate a line that appears straight on the map, use linear interpolation between coordinates. Do NOT use turf's `lineSliceAlong` or `along` functions, as they use geodesic (great circle) calculations which appear curved on a Mercator projection.
+
+```tsx
+const frame = useCurrentFrame();
+const {durationInFrames} = useVideoConfig();
+
+useEffect(() => {
+  if (!map) return;
+
+  const animationHandle = delayRender('Animating line...');
+
+  const progress = interpolate(frame, [0, durationInFrames - 1], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.inOut(Easing.cubic),
+  });
+
+  // Linear interpolation for a straight line on the map
+  const start = lineCoordinates[0];
+  const end = lineCoordinates[1];
+  const currentLng = start[0] + (end[0] - start[0]) * progress;
+  const currentLat = start[1] + (end[1] - start[1]) * progress;
+
+  const lineData: GeoJSON.Feature<GeoJSON.LineString> = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'LineString',
+      coordinates: [start, [currentLng, currentLat]],
+    },
+  };
+
+  const source = map.getSource('trace') as mapboxgl.GeoJSONSource;
+  if (source) {
+    source.setData(lineData);
+  }
+
+  map.once('idle', () => continueRender(animationHandle));
+}, [frame, map, durationInFrames]);
+```
+
+### Curved lines (geodesic/great circle)
+
+To animate a line that follows the geodesic (great circle) path between two points, use turf's `lineSliceAlong`. This is useful for showing flight paths or the actual shortest distance on Earth.
+
+```tsx
+import * as turf from '@turf/turf';
+
+const routeLine = turf.lineString(lineCoordinates);
+const routeDistance = turf.length(routeLine);
+
+const currentDistance = Math.max(0.001, routeDistance * progress);
+const slicedLine = turf.lineSliceAlong(routeLine, 0, currentDistance);
+
+const source = map.getSource('route') as mapboxgl.GeoJSONSource;
+if (source) {
+  source.setData(slicedLine);
+}
+```
+
+## Markers
+
+Add labels, and markers where appropriate.
+
+```tsx
+_map.addSource('markers', {
+  type: 'geojson',
+  data: {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {name: 'Point 1'},
+        geometry: {type: 'Point', coordinates: [-118.2437, 34.0522]},
+      },
+    ],
+  },
+});
+
+_map.addLayer({
+  id: 'city-markers',
+  type: 'circle',
+  source: 'markers',
+  paint: {
+    'circle-radius': 40,
+    'circle-color': '#FF4444',
+    'circle-stroke-width': 4,
+    'circle-stroke-color': '#FFFFFF',
+  },
+});
+
+_map.addLayer({
+  id: 'labels',
+  type: 'symbol',
+  source: 'markers',
+  layout: {
+    'text-field': ['get', 'name'],
+    'text-font': ['DIN Pro Bold', 'Arial Unicode MS Bold'],
+    'text-size': 50,
+    'text-offset': [0, 0.5],
+    'text-anchor': 'top',
+  },
+  paint: {
+    'text-color': '#FFFFFF',
+    'text-halo-color': '#000000',
+    'text-halo-width': 2,
+  },
+});
+```
+
+Make sure they are big enough. Check the composition dimensions and scale the labels accordingly.
+For a composition size of 1920x1080, the label font size should be at least 40px.
+
+IMPORTANT: Keep the `text-offset` small enough so it is close to the marker. Consider the marker circle radius. For a circle radius of 40, this is a good offset:
+
+```tsx
+"text-offset": [0, 0.5],
+```
+
+## 3D buildings
+
+To enable 3D buildings, use the following code:
+
+```tsx
+_map.setConfigProperty('basemap', 'show3dObjects', true);
+_map.setConfigProperty('basemap', 'show3dLandmarks', true);
+_map.setConfigProperty('basemap', 'show3dBuildings', true);
+```
+
+## Rendering
+
+When rendering a map animation, make sure to render with the following flags:
+
+```
+npx remotion render --gl=angle --concurrency=1
+```

--- a/.agents/skills/remotion-best-practices/rules/parameters.md
+++ b/.agents/skills/remotion-best-practices/rules/parameters.md
@@ -1,0 +1,98 @@
+---
+name: parameters
+description: Make a video parametrizable by adding a Zod schema
+metadata:
+  tags: parameters, zod, schema
+---
+
+To make a video parametrizable, a Zod schema can be added to a composition.
+
+First, `zod` must be installed - it must be exactly version `3.22.3`.
+
+Search the project for lockfiles and run the correct command depending on the package manager:
+
+If `package-lock.json` is found, use the following command:
+
+```bash
+npm i zod@3.22.3
+```
+
+If `bun.lockb` is found, use the following command:
+
+```bash
+bun i zod@3.22.3
+```
+
+If `yarn.lock` is found, use the following command:
+
+```bash
+yarn add zod@3.22.3
+```
+
+If `pnpm-lock.yaml` is found, use the following command:
+
+```bash
+pnpm i zod@3.22.3
+```
+
+Then, a Zod schema can be defined alongside the component:
+
+```tsx title="src/MyComposition.tsx"
+import {z} from 'zod';
+
+export const MyCompositionSchema = z.object({
+  title: z.string(),
+});
+
+const MyComponent: React.FC<z.infer<typeof MyCompositionSchema>> = () => {
+  return (
+    <div>
+      <h1>{props.title}</h1>
+    </div>
+  );
+};
+```
+
+In the root file, the schema can be passed to the composition:
+
+```tsx title="src/Root.tsx"
+import {Composition} from 'remotion';
+import {MycComponent, MyCompositionSchema} from './MyComposition';
+
+export const RemotionRoot = () => {
+  return <Composition id="MyComposition" component={MyComponent} durationInFrames={100} fps={30} width={1080} height={1080} defaultProps={{title: 'Hello World'}} schema={MyCompositionSchema} />;
+};
+```
+
+Now, the user can edit the parameter visually in the sidebar.
+
+All schemas that are supported by Zod are supported by Remotion.
+
+Remotion requires that the top-level type is a z.object(), because the collection of props of a React component is always an object.
+
+## Color picker
+
+For adding a color picker, use `zColor()` from `@remotion/zod-types`.
+
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/zod-types # If project uses npm
+bunx remotion add @remotion/zod-types # If project uses bun
+yarn remotion add @remotion/zod-types # If project uses yarn
+pnpm exec remotion add @remotion/zod-types # If project uses pnpm
+```
+
+Then import `zColor` from `@remotion/zod-types`:
+
+```tsx
+import {zColor} from '@remotion/zod-types';
+```
+
+Then use it in the schema:
+
+```tsx
+export const MyCompositionSchema = z.object({
+  color: zColor(),
+});
+```

--- a/.agents/skills/remotion-best-practices/rules/sequencing.md
+++ b/.agents/skills/remotion-best-practices/rules/sequencing.md
@@ -104,3 +104,15 @@ Sequences can be nested for complex timing:
   </Sequence>
 </Sequence>
 ```
+
+## Nesting compositions within another
+
+To add a composition within another composition, you can use the `<Sequence>` component with a `width` and `height` prop to specify the size of the composition.
+
+```tsx
+<AbsoluteFill>
+  <Sequence width={COMPOSITION_WIDTH} height={COMPOSITION_HEIGHT}>
+    <CompositionComponent />
+  </Sequence>
+</AbsoluteFill>
+```

--- a/.agents/templates/claude/.claude/settings.json
+++ b/.agents/templates/claude/.claude/settings.json
@@ -6,11 +6,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/web/session-start/setup.sh"
-          },
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/web/session-start/setup.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
           {
             "type": "prompt",
-            "prompt": "MANDATORY: Load the crew-claude skill now by invoking: Skill({ skill: \"crew-claude\" }). Then read all files listed in the SKILL.md and output the CREW-CLAUDE LOADED verification checklist before proceeding with any work."
+            "prompt": "BLOCKED - SESSION START GATE\n\nYou CANNOT proceed with ANY user request until you:\n1. Invoke: Skill({ skill: \"crew-claude\" })\n2. Read all 6 workflow files listed in SKILL.md\n3. Output CREW-CLAUDE LOADED verification checklist\n\nThis is non-negotiable. Your FIRST action must be the Skill() invocation. Do NOT explore, read files, or start planning until the verification checklist is output."
           }
         ]
       }
@@ -21,7 +26,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "CONTEXT COMPACTING: After compaction completes, you MUST reload the crew-claude skill by invoking: Skill({ skill: \"crew-claude\" }) and reading all files listed in the SKILL.md. Output the CREW-CLAUDE LOADED verification checklist before continuing work."
+            "prompt": "BLOCKED - POST-COMPACTION GATE\n\nContext was compacted. You CANNOT continue work until you:\n1. Invoke: Skill({ skill: \"crew-claude\" })\n2. Read all 6 workflow files listed in SKILL.md\n3. Output CREW-CLAUDE LOADED verification checklist\n\nYour NEXT action must be the Skill() invocation. Do NOT continue previous work until verification is output."
           }
         ]
       }
@@ -32,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/validation/warn-write.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/validation/warn-write.sh"
           }
         ]
       },
@@ -41,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/validation/warn-edit.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/validation/warn-edit.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Add zero-tolerance "Failure Deflection" anti-pattern to both crew-claude and crew-codex skills
- Sync settings.json template with the committed version
- Update remotion-best-practices skill rules

## Changes

### Failure Deflection Anti-Pattern (CRITICAL)

Added the strongest possible discouragement against claiming failures are "pre-existing" or "not related to my changes". This applies to:

- CI failures
- Test failures  
- Lint errors
- Type errors
- Build failures
- ANY verification failure

**New banned phrases:**
- "pre-existing"
- "not related to my changes"
- "unrelated to this PR"
- "existing issue"
- "those errors existed before"
- "module resolution issues in the codebase"
- "the specific tests I created pass"

**The rule:** If ANY verification does not pass, the task is NOT complete. Main always passes. If it fails now, you broke it. Fix it.

### Template Sync

- Fixed settings.json template to match committed version (quoted `$CLAUDE_PROJECT_DIR` paths, separate SessionStart hook blocks)

### Remotion Best Practices

- Updated compositions, sequencing rules
- Added maps and parameters rules

## Test Plan

- [x] Changes are documentation/configuration only
- [x] No code changes requiring tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a zero-tolerance “Failure Deflection” anti-pattern to crew-claude and crew-codex to prevent dismissing verification failures. Syncs the .claude settings template and expands Remotion best-practices with new maps and parameters guides plus rule updates.

- **New Features**
  - Failure Deflection anti-pattern added to both crew skills; bans phrases like “pre-existing” and “not related to my changes”; any failing tests/lint/types/build/CI means the task isn’t done.
  - Remotion best-practices: new rules for maps (Mapbox) and parameters (Zod) with examples.

- **Refactors**
  - Synced .claude settings.json: quoted "$CLAUDE_PROJECT_DIR" paths; split SessionStart hooks with stricter gating prompts; updated post-compaction and write/edit warnings.
  - Updated compositions and sequencing docs with nesting guidance and small code style fixes.

<sup>Written for commit 560e16bbbe3cd6c3dda4923e5bb80dd3bf9c83f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

