### PR TITLE
fix(skills): add YAML frontmatter to crew SKILL.md

### DIFF
--- a/.agents/skills-local/crew-claude/SKILL.md
+++ b/.agents/skills-local/crew-claude/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: crew-claude
+description: Complete development workflow for Claude Code. Defines philosophy, task classification, hard requirements, anti-patterns, and 8-phase development process.
+---
+
 # Crew Claude Skill
 
 ## MANDATORY LOADING — NO EXCEPTIONS

--- a/.agents/skills-local/crew-codex/SKILL.md
+++ b/.agents/skills-local/crew-codex/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: crew-codex
+description: Complete development workflow for Codex. Defines philosophy, task classification, hard requirements, anti-patterns, and 8-phase development process with spawn_agent.
+---
+
 # Crew Codex Skill
 
 ## MANDATORY LOADING — NO EXCEPTIONS


### PR DESCRIPTION
## Summary
Fixed missing YAML frontmatter in crew-claude and crew-codex SKILL.md files. Codex was unable to parse these skill files due to missing `---` delimiters containing name and description fields.

## Changes
- Added YAML frontmatter with name and description to crew-claude/SKILL.md
- Added YAML frontmatter with name and description to crew-codex/SKILL.md
- Format matches other skill files (git-workflow, reviewers, workflow-improver)

## Files Changed
- .agents/skills-local/crew-claude/SKILL.md (+5 lines)
- .agents/skills-local/crew-codex/SKILL.md (+5 lines)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added YAML frontmatter (name and description) to crew-claude and crew-codex SKILL.md to fix parsing/validation errors. Aligns these skills with the format used by other skill files.

<sup>Written for commit 0335af9d2326eabff6c95e11d34391b9b5718aa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

