### PR TITLE
chore(codex-review): increase model reasoning effort to xhigh

### DIFF
--- a/.agents/skills/codex-review/SKILL.md
+++ b/.agents/skills/codex-review/SKILL.md
@@ -138,7 +138,7 @@ git diff --stat | tail -1
 
 **Normal Tasks** (other cases):
 
-- Config: `model_reasoning_effort=high`, timeout 10 minutes
+- Config: `model_reasoning_effort=xhigh`, timeout 10 minutes
 
 **Evaluation Method:**
 
@@ -196,7 +196,7 @@ Go project - Difficult task:
   (timeout: 1800000)
 
 Go project - Normal task:
-  go fmt ./... && go vet ./... && codex review --uncommitted --config model_reasoning_effort=high
+  go fmt ./... && go vet ./... && codex review --uncommitted --config model_reasoning_effort=xhigh
   (timeout: 600000)
 
 Node project - Difficult task:
@@ -204,7 +204,7 @@ Node project - Difficult task:
   (timeout: 1800000)
 
 Node project - Normal task:
-  npm run lint:fix && codex review --uncommitted --config model_reasoning_effort=high
+  npm run lint:fix && codex review --uncommitted --config model_reasoning_effort=xhigh
   (timeout: 600000)
 
 Python project - Difficult task:
@@ -212,11 +212,11 @@ Python project - Difficult task:
   (timeout: 1800000)
 
 Python project - Normal task:
-  black . && ruff check --fix . && codex review --uncommitted --config model_reasoning_effort=high
+  black . && ruff check --fix . && codex review --uncommitted --config model_reasoning_effort=xhigh
   (timeout: 600000)
 
 Clean working directory:
-  codex review --commit HEAD --config model_reasoning_effort=high
+  codex review --commit HEAD --config model_reasoning_effort=xhigh
   (timeout: 600000)
 ```
 

--- a/.agents/skills/codex-review/codex-runner.md
+++ b/.agents/skills/codex-review/codex-runner.md
@@ -22,29 +22,29 @@ Receives complete command chain through Task tool's prompt parameter:
 
 1. **Lint command**: Auto-selected based on project type (go fmt, npm lint, black, etc.)
 2. **Review mode**: `--uncommitted` or `--commit HEAD` or `--base <branch>`
-3. **Difficulty config**: `--config model_reasoning_effort=high|xhigh`
+3. **Difficulty config**: `--config model_reasoning_effort=xhigh|xhigh`
 4. **Timeout**: Controlled through Task tool's timeout parameter
 
 ## Command Examples
 
 ```bash
 # Go project - Normal task
-go fmt ./... && go vet ./... && codex review --uncommitted --config model_reasoning_effort=high
+go fmt ./... && go vet ./... && codex review --uncommitted --config model_reasoning_effort=xhigh
 
 # Go project - Difficult task (deep reasoning)
 go fmt ./... && go vet ./... && codex review --uncommitted --config model_reasoning_effort=xhigh
 
 # Node project
-npm run lint:fix && codex review --uncommitted --config model_reasoning_effort=high
+npm run lint:fix && codex review --uncommitted --config model_reasoning_effort=xhigh
 
 # Python project
-black . && ruff check --fix . && codex review --uncommitted --config model_reasoning_effort=high
+black . && ruff check --fix . && codex review --uncommitted --config model_reasoning_effort=xhigh
 
 # Clean working directory - Review latest commit
-codex review --commit HEAD --config model_reasoning_effort=high
+codex review --commit HEAD --config model_reasoning_effort=xhigh
 
 # Review changes relative to main branch
-codex review --base main --config model_reasoning_effort=high
+codex review --base main --config model_reasoning_effort=xhigh
 ```
 
 ## Execution Flow


### PR DESCRIPTION
## Summary
- Increase Codex review reasoning effort from `high` to `xhigh` for normal tasks
- Standardizes all review commands to use maximum reasoning effort

## Changes
- Updated SKILL.md command examples and configuration
- Updated codex-runner.md with consistent xhigh setting
- Affects Go, Node, and Python project templates

## Test Plan
- [ ] Codex review commands execute correctly with xhigh setting
- [ ] No regression in review quality

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Codex review reasoning effort to xhigh for normal tasks and standardize all review commands to use xhigh by default. Updated SKILL.md and codex-runner.md for Go, Node, and Python templates; timeouts remain unchanged.

<sup>Written for commit 7081e579ce49fe4c1a061273ecb3e51d1d669d63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

