### PR TITLE
docs(skills): add bash guidelines to crew-claude and crew-codex

### DIFF
--- a/.agents/skills-local/crew-claude/bash-guidelines.md
+++ b/.agents/skills-local/crew-claude/bash-guidelines.md
@@ -1,0 +1,12 @@
+# Bash Guidelines
+
+## IMPORTANT: Avoid commands that cause output buffering issues
+- DO NOT pipe output through `head`, `tail`, `less`, or `more` when monitoring or checking command output
+- DO NOT use `| head -n X` or `| tail -n X` to truncate output - these cause buffering problems
+- Instead, let commands complete fully, or use `--max-lines` flags if the command supports them
+- For log monitoring, prefer reading files directly rather than piping through filters
+
+## When checking command output:
+- Run commands directly without pipes when possible
+- If you need to limit output, use command-specific flags (e.g., `git log -n 10` instead of `git log | head -10`)
+- Avoid chained pipes that can cause output to buffer indefinitely

--- a/.agents/skills-local/crew-codex/bash-guidelines.md
+++ b/.agents/skills-local/crew-codex/bash-guidelines.md
@@ -1,0 +1,6 @@
+# Bash Guidelines
+
+## Output buffering
+- Avoid piping through `head`, `tail`, `less`, `more` - causes buffering issues
+- Let commands complete fully, or use command-specific flags (e.g., `git log -n 10` not `git log | head -10`)
+- Read files directly rather than piping through filters


### PR DESCRIPTION
## Summary
- Add `bash-guidelines.md` to both crew-claude and crew-codex skills
- Guidelines warn against piping through `head`, `tail`, `less`, `more` due to output buffering issues
- Recommend using command-specific flags instead (e.g., `git log -n 10` not `git log | head -10`)

## Changes
- `.agents/skills-local/crew-claude/bash-guidelines.md` - Full detailed version
- `.agents/skills-local/crew-codex/bash-guidelines.md` - Concise version adapted to codex style

## Test Plan
- [x] Files created with correct content
- [x] Content verified matches plan
- [x] No CI scripts in this repo (docs-only)

<details>
<summary>Implementation Plan</summary>

Add Bash guidelines about avoiding output buffering issues to both `crew-claude` and `crew-codex` skills as new standalone files.

**Key guidelines:**
- Avoid piping through `head`, `tail`, `less`, `more` - causes buffering issues
- Let commands complete fully, or use command-specific flags
- Read files directly rather than piping through filters

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Bash guidelines to crew-claude and crew-codex to prevent output buffering and stuck pipes. Recommend using command-specific flags (e.g., git log -n 10) instead of piping through head, tail, less, or more.

<sup>Written for commit 8bd335bf75edef75959f7dc9bd9cd51d687b05a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

