### PR TITLE
docs(crew-claude): enforce AskUserQuestion for decision questions

### DIFF
--- a/.agents/skills-local/crew-claude/anti-patterns.md
+++ b/.agents/skills-local/crew-claude/anti-patterns.md
@@ -18,6 +18,21 @@
 - **Fake ask-questions:** checked box without invoking skill, said "requirements clear" -> MUST invoke tool. (Remote: asking is optional if ambiguity ≤ 7)
 - **Plain text questions:** loaded ask-questions skill but asked in markdown instead of `AskUserQuestion` tool -> FORBIDDEN, always use the tool when asking.
 
+### Decision Question Patterns (MUST use AskUserQuestion)
+
+These phrases in assistant messages = VIOLATION if not using the tool:
+- `Would you like me to...?` → Use AskUserQuestion with options
+- `Should we...?` / `Should I...?` → Use AskUserQuestion with yes/no or options
+- `Do you want...?` → Use AskUserQuestion with options
+- `Which would you prefer...?` → Use AskUserQuestion with the options listed
+- `Could you clarify...?` → Use AskUserQuestion
+- `What should I...?` → Use AskUserQuestion with options
+
+**ALLOWED without tool** (rhetorical/explanatory):
+- Questions analyzing the problem: "The question is whether X works with Y..."
+- Questions in code comments or documentation
+- Questions quoting the user back to them
+
 ### Gate Failures
 - Gate amnesia: output GATE-1, GATE-3, then forget the rest -> output ALL gates for your classification.
 - Gate rushing: GATE-N CHECK with all boxes checked without doing the work -> gates verify work, not skip it.

--- a/.agents/skills-local/crew-claude/hard-requirements.md
+++ b/.agents/skills-local/crew-claude/hard-requirements.md
@@ -26,6 +26,12 @@ Check `CLAUDE_CODE_REMOTE` environment variable at session start:
 - Use at least one skill per implementation task (minimum: verification-before-completion).
 - Immediately after classification, output the Classification Checklist.
 - **Use `AskUserQuestion` tool for ALL clarifying questions** - never plain text questions.
+- **Use `AskUserQuestion` tool for ALL decision-seeking questions** - phrases that seek user input MUST use the tool:
+  - "Would you like..." → AskUserQuestion
+  - "Should we/I..." (when seeking decision) → AskUserQuestion
+  - "Do you want..." → AskUserQuestion
+  - "Could you clarify..." → AskUserQuestion
+  - "Which option..." → AskUserQuestion
 - **Consider parallel Task agents** when 2+ independent implementation tasks exist.
 - **Use Task `mode` parameter** appropriately: `plan` for risky changes, `bypassPermissions` for trusted autonomous work.
 - **Parallelize independent tasks** after plan approval — tasks without `blockedBy` can run in parallel via multiple `Task()` calls in one message. See `dispatching-parallel-agents` skill.
@@ -44,6 +50,7 @@ Check `CLAUDE_CODE_REMOTE` environment variable at session start:
 - Stop outputting gates after the first few pass.
 - Check a gate box without showing proof in that same message.
 - **Ask clarifying questions in plain text** - MUST use `AskUserQuestion` tool.
+- **Ask decision questions in plain text** - if your message contains "Would you like", "Should we", "Do you want", or similar decision-seeking phrases followed by "?", you MUST use `AskUserQuestion` tool instead of inline text.
 - **Execute independent tasks sequentially** when parallel agents could be used.
 - You do NOT have the permission to change linter settings, and ignore statements are severely discouraged. Especially the no barrel files rule!
 

--- a/.agents/skills-local/crew-claude/workflows.md
+++ b/.agents/skills-local/crew-claude/workflows.md
@@ -143,6 +143,11 @@ Multi-Session Collaboration:
 - Each iteration must deepen: requirements clarity, edge cases, error handling, test strategy.
 - **Iteration tracking:** Output "Plan Refinement Iteration N of M" for each pass.
 
+**Question Format Check (self-check before sending message):**
+- Does my message contain "Would you like", "Should we/I", "Do you want", "Could you clarify", or "Which option"?
+- If YES and followed by "?" → STOP, use `AskUserQuestion` tool instead
+- If NO → proceed with message
+
 **Questions to consider (ask via `AskUserQuestion` tool if needed):**
 - Scope: What's included/excluded?
 - Behavior: How should edge cases behave?


### PR DESCRIPTION
## Summary
- Add explicit phrase patterns requiring `AskUserQuestion` tool usage
- Fix plain-text question violations found in 87.5% of analyzed sessions

## Problem
Session analysis of ~/.claude/projects from the last day revealed **25 violations across 7/8 sessions** where questions were asked without using the `AskUserQuestion` tool.

Common violation patterns:
- "Would you like me to..." (4 instances)
- "Should we..." (1 instance)
- Rhetorical questions in explanations (20 instances - less severe)

## Changes

### hard-requirements.md
- Added decision phrase list to ALWAYS section
- Added plain-text question ban to NEVER section

### anti-patterns.md
- Added "Decision Question Patterns" section with violation patterns
- Added allowed exceptions (rhetorical, code comments, quoting user)

### workflows.md
- Added self-check before sending messages in Phase 2:
  - Check for "Would you like", "Should we/I", "Do you want", "Could you clarify", "Which option"
  - If present with "?" → use `AskUserQuestion` tool

## Test Plan
- [x] Grep verification: 24 AskUserQuestion mentions, 11 phrase pattern occurrences
- [x] Codex review passed (P2 issue fixed - self-check now includes all phrases)
- [x] Documentation-only changes (no CI applicable)

<details>
<summary>Implementation Plan</summary>

$(cat /Users/roderik/.claude/plans/encapsulated-nibbling-nebula.md)

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce use of AskUserQuestion for decision-seeking questions with explicit phrase triggers and a pre-send self-check. Updates docs to ban plain-text decision/clarifying questions and outline allowed exceptions.

- **New Features**
  - Added decision phrase list to hard-requirements (ALWAYS) and plain-text ban (NEVER).
  - Documented Decision Question Patterns in anti-patterns with allowed exceptions.
  - Added workflows self-check to detect decision phrases and require the tool.

<sup>Written for commit 72f490364822ace9e05403a2f9d7ec2235a2c6a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

