### PR TITLE
docs(crew): update gates from 8 to 9 and remove GATE-N numbering

### DIFF
--- a/.agents/skills-local/crew-claude/anti-patterns.md
+++ b/.agents/skills-local/crew-claude/anti-patterns.md
@@ -34,10 +34,10 @@ These phrases in assistant messages = VIOLATION if not using the tool:
 - Questions quoting the user back to them
 
 ### Gate Task Failures
-- Gate task amnesia: create [GATE-1], [GATE-3], then forget the rest -> create ALL gate tasks for your classification with blockedBy chain.
+- Gate task amnesia: create Planning, Implementation, then forget the rest -> create ALL gate tasks for your classification with blockedBy chain.
 - Gate task rushing: marking gate completed without doing the work -> gates verify work, not skip it.
 - Proofless completion: `status: completed` without proof in description -> add `PASS: [key]=[evidence] | ...` to description.
-- Early gate only: stop at [GATE-3] because "implementation is done" -> [GATE-4] through [GATE-9] still required.
+- Early gate only: stop at Implementation because "implementation is done" -> Cleanup through Integration still required.
 - False completion: marking gate completed when requirements not met -> keep in_progress with `BLOCKED: [reason]` in description.
 - Gate task skip: not creating gate tasks at all -> MUST create all required gates after classification.
 
@@ -47,9 +47,9 @@ These phrases in assistant messages = VIOLATION if not using the tool:
 - **Codex skip:** "my review skill passed" without running `codex review --uncommitted` -> BLOCKED.
 
 ### Iteration Sub-Task Failures
-- **Iteration skip:** Started [GATE-2] without creating iteration sub-tasks → create [GATE-2.1] through [GATE-2.5]
-- **Premature gate completion:** Marked [GATE-2] complete before all iteration sub-tasks complete → check sub-tasks first
-- **Missing sub-tasks:** Standard task without iteration sub-tasks for GATE-2/6/7 → create them
+- **Iteration skip:** Started Refinement without creating iteration sub-tasks → create Refinement iteration 1 through 5
+- **Premature gate completion:** Marked Refinement complete before all iteration sub-tasks complete → check sub-tasks first
+- **Missing sub-tasks:** Standard task without iteration sub-tasks for Refinement/Review/Verification → create them
 - **Text iteration tracking:** Output "Iteration N of M" instead of using sub-tasks → use sub-tasks, not text
 
 ### Verification Failures
@@ -57,7 +57,7 @@ These phrases in assistant messages = VIOLATION if not using the tool:
 - Partial verification: "syntax check passed" as full verification -> run project CI if available.
 - Stale evidence: "tests passed earlier" -> run fresh verification before completion claim.
 - Load without execute: loaded verification skill but never ran it -> execute and show output.
-- CI skip: claiming done without running `bun run ci` or fallback -> [GATE-8] must be completed for all classifications.
+- CI skip: claiming done without running `bun run ci` or fallback -> CI must be completed for all classifications.
 
 ### Implementation Failures
 - **Sequential when parallel possible:** executing 2+ independent tasks one-by-one with Bash -> use parallel Task agents.
@@ -93,10 +93,10 @@ Applies to: CI failures, test failures, lint errors, type errors, build failures
 Before each phase, ask yourself:
 
 **Before any action**: "Did I output classification and create gate tasks?"
-**Before exploration**: "Did I create [GATE-1] and update to in_progress?" (if in plan mode)
-**Before writing plan**: "Did I complete [GATE-1] and update [GATE-2] to in_progress?" (if in plan mode)
-**Before Write/Edit**: "Did I complete [GATE-3] and create implementation tasks?"
-**Before claiming done**: "Does TaskList show all gate tasks ([GATE-1] through [GATE-9]) as completed with PASS in description?"
+**Before exploration**: "Did I create Planning and update to in_progress?" (if in plan mode)
+**Before writing plan**: "Did I complete Planning and update Refinement to in_progress?" (if in plan mode)
+**Before Write/Edit**: "Did I complete Implementation and create implementation tasks?"
+**Before claiming done**: "Does TaskList show all gate tasks (Planning through Integration) as completed with PASS in description?"
 
 If the answer to any question is "no", STOP and create/update the missing gate tasks first.
 
@@ -106,4 +106,4 @@ If the answer to any question is "no", STOP and create/update the missing gate t
 - Missing dependencies: parallel tasks that should be sequential -> define blockedBy relationships.
 - Tool confusion: mixing Tasks and TodoWrite in same session -> use one system consistently per session.
 - Gate task orphans: creating gate tasks without completing them -> all gate tasks must show status: completed with "PASS:" before done.
-- Gate dependency skip: creating gates without blockedBy chain -> gates must have proper dependency order ([GATE-2] blockedBy [GATE-1], etc.).
+- Gate dependency skip: creating gates without blockedBy chain -> gates must have proper dependency order (Refinement blockedBy Planning, etc.).

--- a/.agents/skills-local/crew-claude/hard-requirements.md
+++ b/.agents/skills-local/crew-claude/hard-requirements.md
@@ -14,14 +14,14 @@ Check `CLAUDE_CODE_REMOTE` environment variable at session start:
 
 **ALWAYS**
 - **Output classification checklist as ABSOLUTE FIRST action** - before any tools, exploration, or planning.
-- **If Plan Mode active, classification precedes exploration** - create gate tasks and update [GATE-1] after classification.
+- **If Plan Mode active, classification precedes exploration** - create gate tasks and update Planning after classification.
 - **Classification determines which gates are required** - Trivial needs fewer, Standard needs more.
 - **Task tracking before implementation:** Use `TaskCreate` to create tasks, `TaskUpdate({ status: "in_progress" })` before starting work.
 - **Task completion after implementation:** Use `TaskUpdate({ status: "completed" })` after each task is done.
 - **Task dependencies:** Use `TaskUpdate({ addBlockedBy: [...] })` to establish task ordering.
 - **Fallback:** If Tasks tools unavailable (older Conductor), use `TodoWrite({ status: "in_progress/completed" })`.
 - Load skills via `Skill({ skill: "name" })` tool call - listing is not loading.
-- **Create gate tasks after classification** — number depends on classification (Trivial: 4, Simple: 8, Standard: 9; Plan Mode: GATE-1,2 initially, rest after approval). See Gate Task Creation section.
+- **Create gate tasks after classification** — number depends on classification (Trivial: 4, Simple: 8, Standard: 9; Plan Mode: Planning and Refinement initially, rest after approval). See Gate Task Creation section.
 - Provide verification evidence (command output/test results with exit code 0) before claiming done.
 - Use at least one skill per implementation task (minimum: verification-before-completion).
 - Immediately after classification, output the Classification Checklist.
@@ -58,13 +58,13 @@ Check `CLAUDE_CODE_REMOTE` environment variable at session start:
 
 **Checklist is not loading.** You must invoke `Skill({ skill: "name" })` tool.
 
-Before GATE-3, you MUST have tool invocations for:
+Before Implementation, you MUST have tool invocations for:
 ```
 Skill({ skill: "test-driven-development" })
 Skill({ skill: "verification-before-completion" })
 ```
 
-If Standard, also before GATE-2:
+If Standard, also before Refinement:
 ```
 Skill({ skill: "ask-questions-if-underspecified" })
 ```
@@ -101,10 +101,10 @@ Immediately after classification, create gate tasks via TodoWrite. See task-clas
 
 | Classification | Gates to Create |
 |---------------|-----------------|
-| **Trivial** | GATE-3, GATE-7, GATE-8, GATE-9 (4 gates) |
-| **Simple** | GATE-1,2,3,5,6,7,8,9 (8 gates, skip GATE-4) |
-| **Standard** | All 9 gates + iteration sub-tasks for GATE-2,6,7 |
-| **Plan Mode** | GATE-1,2 initially; GATE-3+ after approval |
+| **Trivial** | Implementation, Verification, CI, Integration (4 gates) |
+| **Simple** | All except Cleanup (8 gates) |
+| **Standard** | All 9 gates + iteration sub-tasks for Refinement, Review, Verification |
+| **Plan Mode** | Planning, Refinement initially; rest after approval |
 
 ### Gate Task Status
 
@@ -124,35 +124,35 @@ Before each phase, update the corresponding gate task. Do not proceed if BLOCKED
 
 **Gate requirements (update task description with proof when complete):**
 
-- **[GATE-1] Planning**: `PASS: Classification=[type] | Request=understood | Research=[tools used] | Docs=checked | Web=[done/N/A]`
+- **Planning**: `PASS: Classification=[type] | Request=understood | Research=[tools used] | Docs=checked | Web=[done/N/A]`
   - Requirements: classification stated + user request understood + research complete (mcp__octocode__* for code, mcp__context7__* for docs, mcp__exa__* for web/company research).
 
-- **[GATE-2] Refinement**: `PASS: AskQuestions=[invoked] | Questions=[count or N/A if Remote]`
+- **Refinement**: `PASS: AskQuestions=[invoked] | Questions=[count or N/A if Remote]`
   - Requirements: `Skill({ skill: "ask-questions-if-underspecified" })` tool call visible. **Local:** `AskUserQuestion` tool used. **Remote:** questions optional unless genuinely ambiguous.
 
-- **[GATE-3] Implementation**: `PASS: TDD=[loaded] | Tasks=[IDs created] | Backfill=[done/N/A]`
+- **Implementation**: `PASS: TDD=[loaded] | Tasks=[IDs created] | Backfill=[done/N/A]`
   - Requirements: `Skill({ skill: "test-driven-development" })` tool call visible + **backfill check done (if modifying existing file without tests → tests added first)** + Tasks created (or TodoWrite fallback) + task status set to in_progress + parallel agents considered for 2+ independent tasks.
 
-- **[GATE-4] Cleanup**: `PASS: Tasks=[all complete] | Cleanup=[skills run]`
+- **Cleanup**: `PASS: Tasks=[all complete] | Cleanup=[skills run]`
   - Requirements: all implementation tasks complete (TaskList shows no pending tasks for current work).
 
-- **[GATE-5] Testing**: `PASS: Tests=[N passed, N failed] | Exit=[code]`
+- **Testing**: `PASS: Tests=[N passed, N failed] | Exit=[code]`
   - Requirements: test file exists + test output with exit code shown (or explicit "no tests possible" justification).
 
-- **[GATE-6] Review**: `PASS: Review=[invoked] | Codex=[P1:N, P2:N fixed]`
+- **Review**: `PASS: Review=[invoked] | Codex=[P1:N, P2:N fixed]`
   - Requirements: `Skill({ skill: "review" })` tool call visible + review output shown + `codex review --uncommitted` executed (Simple+) with P1/P2 issues fixed. Standard tasks also require `differential-review` and security review. "Manual review" is NOT acceptable.
 
-- **[GATE-7] Verification**: `PASS: Commands=[run] | Exit=[0] | Tasks=[all completed]`
+- **Verification**: `PASS: Commands=[run] | Exit=[0] | Tasks=[all completed]`
   - Requirements: verification commands run IN THIS MESSAGE with exit code 0 shown + all tasks marked completed.
 
-- **[GATE-8] CI**: `PASS: CI=[command] | Exit=[0]`
+- **CI**: `PASS: CI=[command] | Exit=[0]`
   - Requirements: `bun run ci` (or `npm/pnpm run ci`, or fallback: lint+test+build) executed IN THIS MESSAGE with exit code 0 shown.
   - **NOTE:** CI commands use turborepo—run from repository root folder.
   - **NOTE:** Infrastructure services may be required—launch with `bun dev:up` (do not use docker-compose directly).
 
-- **[GATE-9] Integration**: `PASS: Integration=[Exit 0 or N/A]`
+- **Integration**: `PASS: Integration=[Exit 0 or N/A]`
   - Requirements: Run `bun run test:integration` if script exists in package.json. Include result (`Exit 0`) or note `N/A` if unavailable.
-  - **Prerequisite:** GATE-8 must pass first—do not attempt integration tests if CI fails.
+  - **Prerequisite:** CI must pass first—do not attempt integration tests if CI fails.
   - **NOTE:** Infrastructure services may be required—launch with `bun dev:up` before running.
 
 **Loading ≠ Following:** Invoking a skill means you MUST follow its instructions. Loading TDD then writing code without tests = violation.
@@ -170,17 +170,17 @@ Before claiming done, the task list must show all gate tasks as completed. No ex
 When `system-reminder` indicates "Plan mode is active":
 
 1. **First**: Output classification checklist (same as always)
-2. **Then**: Create gate tasks and update [GATE-1] to in_progress, then completed when research done
-3. **Then**: Update [GATE-2] to in_progress, then completed when plan written
+2. **Then**: Create gate tasks and update Planning to in_progress, then completed when research done
+3. **Then**: Update Refinement to in_progress, then completed when plan written
 4. **Finally**: Call ExitPlanMode when plan is complete
 
 **Plan Mode maps to workflow phases:**
-- [GATE-1] → Phase 1 (Planning)
-- [GATE-2] → Phase 2 (Plan Refinement)
+- Planning → Phase 1 (Planning)
+- Refinement → Phase 2 (Plan Refinement)
 - After approval → Phase 3+ (Implementation onwards, create remaining gate tasks)
 
 **Plan Mode does NOT exempt you from:**
 - Classification output (still FIRST)
-- Gate task creation (create [GATE-1] and [GATE-2] minimum, rest after approval)
-- Skill loading (ask-questions-if-underspecified before [GATE-2] completion)
+- Gate task creation (create Planning and Refinement minimum, rest after approval)
+- Skill loading (ask-questions-if-underspecified before Refinement completion)
 - AskUserQuestion tool usage (never plain text questions)

--- a/.agents/skills-local/crew-claude/iterations/parallel-review-dispatch.md
+++ b/.agents/skills-local/crew-claude/iterations/parallel-review-dispatch.md
@@ -145,7 +145,7 @@ Run `TaskList()` to see all pending fix tasks
 ### Overall Status: [PASS / BLOCKED]
 ```
 
-## Step 5: Update [GATE-6] Task
+## Step 5: Update Review Task
 
 Update the gate task with review results:
 
@@ -178,7 +178,7 @@ If any reviewer returns a `NEEDS_*` verdict:
    TaskUpdate({ taskId: "FIX-001", status: "completed" })
    ```
 3. **Re-run ONLY failed reviewer(s)** — single Task() call
-4. **Update [GATE-6] task description** with new verdicts
+4. **Update Review task description** with new verdicts
 5. **Repeat** until all PASS or user accepts current state
 
 ## Example Flow
@@ -206,7 +206,7 @@ Phase 6 Start
     │
     ├── TaskList: All completed
     │
-    └── TaskUpdate [GATE-6] to completed with "PASS: ..."
+    └── TaskUpdate Review to completed with "PASS: ..."
 ```
 
 ## Parallelism Checklist

--- a/.agents/skills-local/crew-claude/task-classification.md
+++ b/.agents/skills-local/crew-claude/task-classification.md
@@ -11,8 +11,8 @@ Classify before implementation. When in doubt, classify up.
 4. Uncertain => up.
 
 ### Categories (minimum steps / may skip)
-- **Trivial:** single-line/typo/comment only. Steps: Create gate tasks (GATE-3,7,8,9 only) -> TaskCreate -> TaskUpdate(in_progress) -> Implementation -> Update [GATE-3] -> Verification -> Update [GATE-7,8,9] -> TaskUpdate(completed). May skip: plan refinement, review, deep reasoning.
-- **Simple:** single file, clear scope; new file ok. Steps: Create 8 gate tasks (skip GATE-4) -> TaskCreate -> TaskUpdate(in_progress), Planning (1 pass) -> Update [GATE-1], Implementation -> Update [GATE-3], Testing/syntax check -> Update [GATE-5], Verification skill, codex review -> Update [GATE-6,7,8,9], TaskUpdate(completed). May skip: deep reasoning, multi-iteration review.
+- **Trivial:** single-line/typo/comment only. Steps: Create gate tasks (Implementation, Verification, CI, Integration only) -> TaskCreate -> TaskUpdate(in_progress) -> Implementation -> Update Implementation -> Verification -> Update Verification, CI, Integration -> TaskUpdate(completed). May skip: plan refinement, review, deep reasoning.
+- **Simple:** single file, clear scope; new file ok. Steps: Create 8 gate tasks (skip Cleanup) -> TaskCreate -> TaskUpdate(in_progress), Planning (1 pass) -> Update Planning, Implementation -> Update Implementation, Testing/syntax check -> Update Testing, Verification skill, codex review -> Update Review, Verification, CI, Integration, TaskUpdate(completed). May skip: deep reasoning, multi-iteration review.
 - **Standard:** multi-file/behavior change/architectural/security-sensitive. Steps: Create all 9 gate tasks -> all phases with gate task updates, 5+ iterations each, mcp__codex for planning, differential-review, codex review. Skip none.
 
 ### Task Management Tools
@@ -36,25 +36,25 @@ Output only `CLASSIFICATION: [type]` then immediately create gate tasks. No verb
 #### Trivial — 4 gates
 ```typescript
 TodoWrite([
-  { content: "[GATE-3] Implementation", status: "pending", activeForm: "Implementing" },
-  { content: "[GATE-7] Verification", status: "pending", activeForm: "Verifying" },
-  { content: "[GATE-8] CI", status: "pending", activeForm: "Running CI" },
-  { content: "[GATE-9] Integration", status: "pending", activeForm: "Running integration tests" },
+  { content: "Implementation", status: "pending", activeForm: "Implementing" },
+  { content: "Verification", status: "pending", activeForm: "Verifying" },
+  { content: "CI", status: "pending", activeForm: "Running CI" },
+  { content: "Integration", status: "pending", activeForm: "Running integration tests" },
 ])
 ```
 Skills: verification-before-completion
 
-#### Simple — 8 gates (skip GATE-4)
+#### Simple — 8 gates (skip Cleanup)
 ```typescript
 TodoWrite([
-  { content: "[GATE-1] Planning", status: "pending", activeForm: "Planning" },
-  { content: "[GATE-2] Refinement", status: "pending", activeForm: "Refining" },
-  { content: "[GATE-3] Implementation", status: "pending", activeForm: "Implementing" },
-  { content: "[GATE-5] Testing", status: "pending", activeForm: "Testing" },
-  { content: "[GATE-6] Review", status: "pending", activeForm: "Reviewing" },
-  { content: "[GATE-7] Verification", status: "pending", activeForm: "Verifying" },
-  { content: "[GATE-8] CI", status: "pending", activeForm: "Running CI" },
-  { content: "[GATE-9] Integration", status: "pending", activeForm: "Running integration tests" },
+  { content: "Planning", status: "pending", activeForm: "Planning" },
+  { content: "Refinement", status: "pending", activeForm: "Refining" },
+  { content: "Implementation", status: "pending", activeForm: "Implementing" },
+  { content: "Testing", status: "pending", activeForm: "Testing" },
+  { content: "Review", status: "pending", activeForm: "Reviewing" },
+  { content: "Verification", status: "pending", activeForm: "Verifying" },
+  { content: "CI", status: "pending", activeForm: "Running CI" },
+  { content: "Integration", status: "pending", activeForm: "Running integration tests" },
 ])
 ```
 Skills: verification-before-completion, test-driven-development, ask-questions-if-underspecified
@@ -62,38 +62,38 @@ Skills: verification-before-completion, test-driven-development, ask-questions-i
 #### Standard — 9 gates with iteration sub-tasks
 ```typescript
 TodoWrite([
-  { content: "[GATE-1] Planning", status: "pending", activeForm: "Planning" },
-  { content: "[GATE-2] Refinement", status: "pending", activeForm: "Refining" },
-  { content: "[GATE-3] Implementation", status: "pending", activeForm: "Implementing" },
-  { content: "[GATE-4] Cleanup", status: "pending", activeForm: "Cleaning up" },
-  { content: "[GATE-5] Testing", status: "pending", activeForm: "Testing" },
-  { content: "[GATE-6] Review", status: "pending", activeForm: "Reviewing" },
-  { content: "[GATE-7] Verification", status: "pending", activeForm: "Verifying" },
-  { content: "[GATE-8] CI", status: "pending", activeForm: "Running CI" },
-  { content: "[GATE-9] Integration", status: "pending", activeForm: "Running integration tests" },
+  { content: "Planning", status: "pending", activeForm: "Planning" },
+  { content: "Refinement", status: "pending", activeForm: "Refining" },
+  { content: "Implementation", status: "pending", activeForm: "Implementing" },
+  { content: "Cleanup", status: "pending", activeForm: "Cleaning up" },
+  { content: "Testing", status: "pending", activeForm: "Testing" },
+  { content: "Review", status: "pending", activeForm: "Reviewing" },
+  { content: "Verification", status: "pending", activeForm: "Verifying" },
+  { content: "CI", status: "pending", activeForm: "Running CI" },
+  { content: "Integration", status: "pending", activeForm: "Running integration tests" },
 ])
 ```
 Skills: verification-before-completion, test-driven-development, ask-questions-if-underspecified, systematic-debugging (if modifying existing code), differential-review
 
-**Iteration sub-tasks (Standard only):** When starting GATE-2, GATE-6, or GATE-7, create 5 iteration sub-tasks:
+**Iteration sub-tasks (Standard only):** When starting Refinement, Review, or Verification, create 5 iteration sub-tasks:
 ```typescript
-// Example for GATE-2 Refinement
+// Example for Refinement
 TodoWrite([
-  { content: "[GATE-2] Refinement", status: "in_progress", activeForm: "Refining" },
-  { content: "[GATE-2.1] Refinement iteration 1", status: "pending", activeForm: "Iteration 1" },
-  { content: "[GATE-2.2] Refinement iteration 2", status: "pending", activeForm: "Iteration 2" },
-  { content: "[GATE-2.3] Refinement iteration 3", status: "pending", activeForm: "Iteration 3" },
-  { content: "[GATE-2.4] Refinement iteration 4", status: "pending", activeForm: "Iteration 4" },
-  { content: "[GATE-2.5] Refinement iteration 5", status: "pending", activeForm: "Iteration 5" },
+  { content: "Refinement", status: "in_progress", activeForm: "Refining" },
+  { content: "Refinement iteration 1", status: "pending", activeForm: "Iteration 1" },
+  { content: "Refinement iteration 2", status: "pending", activeForm: "Iteration 2" },
+  { content: "Refinement iteration 3", status: "pending", activeForm: "Iteration 3" },
+  { content: "Refinement iteration 4", status: "pending", activeForm: "Iteration 4" },
+  { content: "Refinement iteration 5", status: "pending", activeForm: "Iteration 5" },
 ])
 ```
 Parent gate can only be completed when all iteration sub-tasks are completed.
 
-#### Plan Mode — GATE-1,2 only; remaining gates after approval
+#### Plan Mode — Planning and Refinement only; remaining gates after approval
 ```typescript
 TodoWrite([
-  { content: "[GATE-1] Planning", status: "pending", activeForm: "Planning" },
-  { content: "[GATE-2] Refinement", status: "pending", activeForm: "Refining" },
+  { content: "Planning", status: "pending", activeForm: "Planning" },
+  { content: "Refinement", status: "pending", activeForm: "Refining" },
 ])
-// After plan approval, create [GATE-3] through [GATE-9]
+// After plan approval, create Implementation through Integration gates
 ```

--- a/.agents/skills-local/crew-claude/workflows.md
+++ b/.agents/skills-local/crew-claude/workflows.md
@@ -7,11 +7,11 @@ Mandatory for implementation tasks. Creating any new file = implementation task.
 When `system-reminder` indicates "Plan mode is active":
 
 1. Output `CLASSIFICATION: [type]`
-2. Create gate tasks via TodoWrite: `[GATE-1] Planning`, `[GATE-2] Refinement`
-3. Mark [GATE-1] in_progress → do research → mark completed
-4. Mark [GATE-2] in_progress → write plan → mark completed
+2. Create gate tasks via TodoWrite: `Planning`, `Refinement`
+3. Mark Planning in_progress → do research → mark completed
+4. Mark Refinement in_progress → write plan → mark completed
 5. Call ExitPlanMode
-6. After approval: create remaining gates ([GATE-3] through [GATE-9])
+6. After approval: create remaining gates (Implementation through Integration)
 
 ---
 
@@ -29,20 +29,20 @@ Use TodoWrite for all task tracking. Task list is the source of truth.
 - MANY small tasks > few large tasks
 
 ### Phase 1: Planning
-Mark [GATE-1] in_progress, then completed when done.
+Mark Planning in_progress, then completed when done.
 - Gather context (Explore Task for large codebases)
 - Check docs (mcp__context7__*) and web (mcp__exa__*)
 - Draft plan with file paths and tasks
 
 ### Phase 2: Plan Refinement
-Mark [GATE-2] in_progress. **Standard tasks:** create 5 iteration sub-tasks.
+Mark Refinement in_progress. **Standard tasks:** create 5 iteration sub-tasks.
 - `Skill({ skill: "ask-questions-if-underspecified" })`
 - Use `AskUserQuestion` tool (Local: always ask; Remote: only if ambiguous)
 - Mark each iteration sub-task completed as you go
-- Mark [GATE-2] completed when all iterations done
+- Mark Refinement completed when all iterations done
 
 ### Phase 3: Implementation
-Mark [GATE-3] in_progress, then completed when skills loaded and tasks created.
+Mark Implementation in_progress, then completed when skills loaded and tasks created.
 - `Skill({ skill: "test-driven-development" })`
 - `Skill({ skill: "verification-before-completion" })`
 - Create implementation tasks: `[T001] [P] Description with file path`
@@ -50,20 +50,20 @@ Mark [GATE-3] in_progress, then completed when skills loaded and tasks created.
 - If 2+ tasks marked `[P]`, dispatch parallel Task agents
 
 ### Phase 4: Cleanup
-Mark [GATE-4] in_progress, then completed.
+Mark Cleanup in_progress, then completed.
 - `code-simplifier`, `deslop`, `knip` (JS/TS only)
 
 ### Phase 5: Testing
-Mark [GATE-5] in_progress, then completed with test output.
+Mark Testing in_progress, then completed with test output.
 - Run `bun run ci` from repository root
 - Show exit code
 
 ### Phase 6: Review
-Mark [GATE-6] in_progress. **Standard tasks:** create 5 iteration sub-tasks.
+Mark Review in_progress. **Standard tasks:** create 5 iteration sub-tasks.
 - `Skill({ skill: "review" })`
 - `codex review --uncommitted` (required for Simple+)
 - Mark each iteration sub-task completed as you go
-- Mark [GATE-6] completed when all iterations done
+- Mark Review completed when all iterations done
 
 ### Codex AI Review (Simple/Standard)
 
@@ -71,19 +71,19 @@ Run after review skill: `codex review --uncommitted`
 - Fix P1/P2 issues before proceeding
 
 ### Phase 7: Verification
-Mark [GATE-7] in_progress. **Standard tasks:** create 5 iteration sub-tasks.
+Mark Verification in_progress. **Standard tasks:** create 5 iteration sub-tasks.
 - Execute `Skill({ skill: "verification-before-completion" })`
 - Run verification commands with exit code 0
 - Mark each iteration sub-task completed as you go
-- Mark [GATE-7] completed when all iterations done
+- Mark Verification completed when all iterations done
 
 ### Phase 8: CI Validation
-Mark [GATE-8] in_progress, then completed with CI results.
+Mark CI in_progress, then completed with CI results.
 - Run `bun run ci` from repository root
 - Show exit code 0
 
 ### Phase 9: Integration Tests
-Mark [GATE-9] in_progress, then completed.
+Mark Integration in_progress, then completed.
 - Run `bun run test:integration` (if available)
 - Show exit code 0 or note N/A
 

--- a/.agents/skills-local/crew-codex/anti-patterns.md
+++ b/.agents/skills-local/crew-codex/anti-patterns.md
@@ -13,7 +13,7 @@
 - **Fake questions:** claimed to ask questions but skipped them -> activate skill. (Remote: asking is optional if ambiguity ≤ 7)
 
 ### Gate Failures
-- Gate rushing: GATE-N CHECK with all boxes checked without doing the work -> gates verify work, not skip it.
+- Gate rushing: gate CHECK with all boxes checked without doing the work -> gates verify work, not skip it.
 - Proofless checkboxes: `[x] Requirement` without a brief note -> add `— PROOF: [what you did]`.
 
 ### Phase Skipping

--- a/.agents/skills-local/crew-codex/hard-requirements.md
+++ b/.agents/skills-local/crew-codex/hard-requirements.md
@@ -64,23 +64,23 @@ ITERATIONS: as needed
 Before each phase, output a gate check. Do not proceed if a gate is BLOCKED.
 
 Gate requirements (Standard/Complex):
-- GATE-1 Planning: classification stated + research complete.
-- GATE-2 Plan Refinement: clarify ambiguities; questions optional if clear.
-- GATE-3 Implementation: start work; use TDD/testing if risk warrants.
-- GATE-4 Cleanup: ensure implementation is tidy.
-- GATE-5 Testing: run relevant tests if they exist and behavior changes.
-- GATE-6 Review: do a quick review or `/review` for risky/wide changes.
-- GATE-7 Verification: list verification commands run or explicitly note skips.
-- GATE-8 CI Validation: run CI for risky/wide changes or when requested; otherwise note skip.
+- Planning: classification stated + research complete.
+- Refinement: clarify ambiguities; questions optional if clear.
+- Implementation: start work; use TDD/testing if risk warrants.
+- Cleanup: ensure implementation is tidy.
+- Testing: run relevant tests if they exist and behavior changes.
+- Review: do a quick review or `/review` for risky/wide changes.
+- Verification: list verification commands run or explicitly note skips.
+- CI: run CI for risky/wide changes or when requested; otherwise note skip.
   - **NOTE:** CI commands use turborepo—run from repository root folder.
   - **NOTE:** Infrastructure services may be required—launch with `bun dev:up` (do not use docker-compose directly).
-- GATE-DONE Completion: verification summary + gates list.
+- Completion: verification summary + gates list.
 
 **Activation ≠ Following:** Invoking a skill means you should follow its instructions.
 
 Gate format (use verbatim when gates are used):
 ```
-GATE-[N] CHECK:
+[Gate Name] CHECK:
 - [x] Requirement 1 — PROOF: [brief note or output if run]
 - [x] Requirement 2 — PROOF: [brief note or output if run]
 - [ ] Requirement 3 (BLOCKED: reason)
@@ -105,13 +105,13 @@ Before saying "done" or "complete", confirm:
 When `system-reminder` indicates "Plan mode is active":
 
 1. **First**: Output classification checklist (same as always)
-2. **Then**: Output PLAN-GATE-1 before exploration
-3. **Then**: Output PLAN-GATE-2 before writing plan
+2. **Then**: Output Understanding gate before exploration
+3. **Then**: Output Design gate before writing plan
 4. **Finally**: Output the plan (plan-only response when required)
 
 **Plan Mode maps to workflow phases:**
-- PLAN-GATE-1 → Phase 1 (Planning)
-- PLAN-GATE-2 → Phase 2 (Plan Refinement)
+- Understanding → Phase 1 (Planning)
+- Design → Phase 2 (Plan Refinement)
 - After approval → Phase 3+ (Implementation onwards)
 
 **Plan Mode does NOT exempt you from:**

--- a/.agents/skills-local/crew-codex/workflows.md
+++ b/.agents/skills-local/crew-codex/workflows.md
@@ -6,9 +6,9 @@ Mandatory for implementation tasks. Creating any new file = implementation task.
 
 When `system-reminder` indicates "Plan mode is active", use this dedicated gate structure:
 
-**PLAN-GATE-1: Understanding**
+**Understanding**
 ```
-PLAN-GATE-1 CHECK:
+Understanding CHECK:
 - [ ] Classification stated (Trivial/Simple/Standard/Complex)
 - [ ] User request understood
 - [ ] Codebase exploration complete (mcp__octocode__* for code search, Explore agent for structure)
@@ -17,9 +17,9 @@ PLAN-GATE-1 CHECK:
 STATUS: PASS | BLOCKED
 ```
 
-**PLAN-GATE-2: Design**
+**Design**
 ```
-PLAN-GATE-2 CHECK:
+Design CHECK:
 - [ ] Implementation approach documented
 - [ ] Critical files identified
 - [ ] Questions asked (plain text) if ambiguous
@@ -27,11 +27,11 @@ PLAN-GATE-2 CHECK:
 STATUS: PASS | BLOCKED
 ```
 
-**After Plan Approval**: Regular workflow resumes at GATE-3 (Implementation phase).
+**After Plan Approval**: Regular workflow resumes at Implementation phase.
 
 **Plan Mode maps to workflow phases:**
-- PLAN-GATE-1 → Phase 1 (Planning)
-- PLAN-GATE-2 → Phase 2 (Plan Refinement)
+- Understanding → Phase 1 (Planning)
+- Design → Phase 2 (Plan Refinement)
 - After approval → Phase 3+ (Implementation onwards)
 
 ---
@@ -71,7 +71,7 @@ STATUS: PASS | BLOCKED
 - Use latest package versions (@latest/:latest). Verify on npmjs.com, hub.docker.com, pypi.org. If pinned older, note current version.
 
 ### Phase 1: Planning
-- Use GATE-1 for Standard/Complex work.
+- Use Planning gate for Standard/Complex work.
 - Gather context (Explore Task for large codebases; direct tools for small).
 - Repo-wide search if needed (MCP tools if configured, or local rg/git).
 - Check docs (local docs/README or MCP if available).
@@ -84,7 +84,7 @@ STATUS: PASS | BLOCKED
 - If Linear configured: find issue, then comment plan.
 
 ### Phase 2: Plan Refinement
-- Use GATE-2 for Standard/Complex work.
+- Use Refinement gate for Standard/Complex work.
 - Ask questions only if requirements are unclear.
 
 **Local Mode (interactive):**
@@ -108,18 +108,18 @@ STATUS: PASS | BLOCKED
 - Compatibility: Version constraints? Breaking changes?
 
 ### Phase 3: Implementation
-- Use GATE-3 for Standard/Complex work.
+- Use Implementation gate for Standard/Complex work.
 - Use TDD/tests when risk is medium/high or behavior changes materially.
 - **Backfill check:** add minimal tests for risky bug fixes if none exist.
 - Break work into tasks if it helps; keep it lightweight.
 
 ### Phase 4: Cleanup
-- Use GATE-4 for Standard/Complex work.
+- Use Cleanup gate for Standard/Complex work.
 - Use relevant cleanup skills if available (`$code-simplifier`, `$deslop`, `$knip`).
 - For non-JS/TS files: note "cleanup skills N/A" but still output gate.
 
 ### Phase 5: Testing
-- Use GATE-5 for Standard/Complex work.
+- Use Testing gate for Standard/Complex work.
 - Run relevant tests when behavior changes and tests exist.
 - **NOTE:** These commands use turborepo and must be run from the repository root folder.
 - **NOTE:** Infrastructure services may be required for tests. Launch with `bun dev:up` (do not use docker-compose directly).
@@ -129,7 +129,7 @@ STATUS: PASS | BLOCKED
 - Output optional unless requested or failures occur.
 
 ### Phase 6: Review
-- Use GATE-6 for Standard/Complex work.
+- Use Review gate for Standard/Complex work.
 - Review for bugs/regressions/missing tests on risky changes; `/review` is optional.
 - Security review if auth/data/payments (use `$semgrep`/`$codeql` if available).
 -
@@ -137,7 +137,7 @@ STATUS: PASS | BLOCKED
 #### Parallel Review Iterations (optional)
 
 ### Phase 7: Verification
-- Use GATE-7 for Standard/Complex work.
+- Use Verification gate for Standard/Complex work.
 - Execute verification commands when applicable; summarize results.
 - Run completion validation.
 - Document results (test counts, warnings) when available.
@@ -146,7 +146,7 @@ STATUS: PASS | BLOCKED
 -
 
 ### Phase 8: CI Validation (final step when applicable)
-- Use GATE-8 for Standard/Complex work.
+- Use CI gate for Standard/Complex work.
 - Run CI for risky/wide changes or when requested; otherwise skip with rationale:
   1. `bun run ci` (if available)
   2. `npm run ci` / `pnpm run ci` (if bun unavailable)
@@ -154,6 +154,6 @@ STATUS: PASS | BLOCKED
 - **NOTE:** All CI commands use turborepo and must be run from the repository root folder.
 - **NOTE:** Infrastructure services may be required. Launch with `bun dev:up` (do not use docker-compose directly).
 - Output optional unless requested or failures occur.
-- If no CI/lint/test/build scripts exist, or CI is skipped for low-risk/docs: document this explicitly in GATE-8.
+- If no CI/lint/test/build scripts exist, or CI is skipped for low-risk/docs: document this explicitly in CI gate.
 - This phase runs AFTER Phase 7 verification.
-- **GATE-DONE:** List gates used (if any) + verification summary before completion claim.
+- **Completion:** List gates used (if any) + verification summary before completion claim.

--- a/.agents/templates/claude/CLAUDE.md
+++ b/.agents/templates/claude/CLAUDE.md
@@ -46,17 +46,18 @@ Output classification BEFORE any tools/exploration:
 - **Standard**: multi-file, behavior change
 - **Complex**: architectural, security-sensitive
 
-### 8 Mandatory Gates
+### 9 Mandatory Gates
 
 Every implementation requires gates. Output gate check before each phase:
-- GATE-1: Planning (classification + research complete)
-- GATE-2: Plan Refinement (questions asked via AskUserQuestion)
-- GATE-3: Implementation (skills loaded, tasks created)
-- GATE-4: Cleanup
-- GATE-5: Testing (test output with exit code)
-- GATE-6: Review (Skill({ skill: "review" }) invoked)
-- GATE-7: Verification (verification skill executed)
-- GATE-8: CI Validation (bun run ci with exit code 0)
+- Planning (classification + research complete)
+- Refinement (questions asked via AskUserQuestion)
+- Implementation (skills loaded, tasks created)
+- Cleanup
+- Testing (test output with exit code)
+- Review (Skill({ skill: "review" }) invoked)
+- Verification (verification skill executed)
+- CI (bun run ci with exit code 0)
+- Integration (bun run test:integration with exit code 0)
 
 ### Skills Must Be INVOKED
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,17 +46,18 @@ Output classification BEFORE any tools/exploration:
 - **Standard**: multi-file, behavior change
 - **Complex**: architectural, security-sensitive
 
-### 8 Mandatory Gates
+### 9 Mandatory Gates
 
 Every implementation requires gates. Output gate check before each phase:
-- GATE-1: Planning (classification + research complete)
-- GATE-2: Plan Refinement (questions asked via AskUserQuestion)
-- GATE-3: Implementation (skills loaded, tasks created)
-- GATE-4: Cleanup
-- GATE-5: Testing (test output with exit code)
-- GATE-6: Review (Skill({ skill: "review" }) invoked)
-- GATE-7: Verification (verification skill executed)
-- GATE-8: CI Validation (bun run ci with exit code 0)
+- Planning (classification + research complete)
+- Refinement (questions asked via AskUserQuestion)
+- Implementation (skills loaded, tasks created)
+- Cleanup
+- Testing (test output with exit code)
+- Review (Skill({ skill: "review" }) invoked)
+- Verification (verification skill executed)
+- CI (bun run ci with exit code 0)
+- Integration (bun run test:integration with exit code 0)
 
 ### Skills Must Be INVOKED
 


### PR DESCRIPTION
## Summary

- Updates "8 Mandatory Gates" to "9 Mandatory Gates" across all documentation
- Adds Integration gate (`bun run test:integration`) as the 9th gate
- Removes `GATE-N:` prefixes from gate lists for cleaner task output

## Changes

Updated files in `.agents/`:
- `templates/claude/CLAUDE.md` - Source template with 9 gates
- `skills-local/crew-claude/` - hard-requirements.md, task-classification.md, workflows.md, anti-patterns.md
- `skills-local/crew-codex/` - hard-requirements.md, workflows.md, anti-patterns.md

Regenerated:
- `CLAUDE.md` - via `.agents/setup.sh --docs-only`

## Test Plan

- [x] Verified template has 9 gates listed
- [x] Verified top-level CLAUDE.md regenerated correctly
- [x] Confirmed no GATE-N prefixes remain in gate lists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated docs to move from 8 to 9 gates by adding an Integration step and switching from numbered gates to named gates for clearer task output. Applies across crew-claude, crew-codex, and the CLAUDE template.

- **New Features**
  - Added Integration gate (bun run test:integration). Runs after CI and records exit code or N/A.

- **Refactors**
  - Replaced GATE-N prefixes with named gates (Planning → Integration) across crew docs.
  - Regenerated CLAUDE.md to reflect 9 gates and the new naming.

<sup>Written for commit 3c7354dce3d5c657659549e29d1807b3cb3f29f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

