### PR TITLE
feat(git-workflow): add run-e2e command to trigger e2e tests

### DIFF
--- a/.agents/templates/claude/.claude/commands/run-e2e.md
+++ b/.agents/templates/claude/.claude/commands/run-e2e.md
@@ -1,0 +1,6 @@
+---
+name: run-e2e
+description: Trigger e2e tests by toggling PR label
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "run-e2e $ARGUMENTS" })`

--- a/.claude/commands/run-e2e.md
+++ b/.claude/commands/run-e2e.md
@@ -1,0 +1,6 @@
+---
+name: run-e2e
+description: Trigger e2e tests by toggling PR label
+---
+
+Invoke: `Skill({ skill: "git-workflow", args: "run-e2e $ARGUMENTS" })`


### PR DESCRIPTION
## Summary

- Add `/run-e2e` command that toggles `run-playwright-tests` label on PR to trigger e2e tests on CI
- Integrate `run-e2e` into fixup workflow (step 5, after push) so e2e tests run automatically after fixing PR comments
- Label is removed then re-added to ensure fresh CI trigger even if label already exists

## Changes

- `.claude/commands/run-e2e.md` - New command wrapper
- `.agents/templates/claude/.claude/commands/run-e2e.md` - Template version
- `.agents/skills/git-workflow/SKILL.md` - Added run-e2e command section + integrated into fixup workflow

## Test Plan

- [ ] Run `/run-e2e` on a branch with a PR - should toggle label
- [ ] Run `/run-e2e` on a branch without PR - should show error
- [ ] Run `/fixup` workflow - should include e2e trigger after push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a /run-e2e command to trigger Playwright e2e tests in CI by toggling the run-playwright-tests label on the PR. The fixup workflow now runs e2e automatically after push.

- **New Features**
  - New run-e2e command and template.
  - Integrated into git-workflow: added a post-push step in fixup.
  - Removes then re-adds the label to force a fresh CI run.
  - Shows an error when no PR exists.

- **Migration**
  - Requires an open PR on the current branch.
  - GitHub CLI must be authenticated with write access.

<sup>Written for commit 00e32f12c98976769fc3fc6a294969f60a1a120a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

