### PR TITLE
fix(workflow-improver): remove disable-model-invocation restriction

### DIFF
--- a/.agents/skills-local/workflow-improver/SKILL.md
+++ b/.agents/skills-local/workflow-improver/SKILL.md
@@ -3,7 +3,6 @@ name: workflow-improver
 description: Evaluate session using OpenAI eval-skills framework (Outcome/Process/Style/Efficiency). Analyzes session transcript vs Claude Code config to score performance and generate improvement recommendations. Creates GitHub issue with rubric scores and actionable plan.
 context: fork
 agent: Explore
-disable-model-invocation: true
 allowed-tools:
   - Read
   - Glob


### PR DESCRIPTION
## Problem
The `workflow-improver` skill had `disable-model-invocation: true`, preventing Claude from invoking it via the `Skill()` tool. This restriction prevented the skill from being used in session analysis workflows.

## Solution
Removed the `disable-model-invocation: true` line from the skill's frontmatter.

## Impact
The skill can now be invoked by Claude agents, enabling automated session analysis and improvement recommendations through the standard `Skill({ skill: "workflow-improver" })` interface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the disable-model-invocation flag from the workflow-improver skill so agents can call it via Skill({ skill: "workflow-improver" }). This enables automated session analysis and improvement recommendations in standard workflows.

<sup>Written for commit 1260a8b75ba9f9fdc326661debcdf3e8e5bcc2f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

