### PR TITLE
fix(workflow-improver): update deleted file references

### DIFF
--- a/.agents/skills-local/workflow-improver/SKILL.md
+++ b/.agents/skills-local/workflow-improver/SKILL.md
@@ -92,11 +92,7 @@ Analyze the transcript for:
 Read these files to understand the intended workflow:
 
 1. **CLAUDE.md**: `./CLAUDE.md`
-2. **Crew skill**: `.agents/skills-local/crew-claude/SKILL.md`
-3. **Workflows**: `.agents/skills-local/crew-claude/workflows.md`
-4. **Hard requirements**: `.agents/skills-local/crew-claude/hard-requirements.md`
-5. **Anti-patterns**: `.agents/skills-local/crew-claude/anti-patterns.md`
-6. **Skill routing**: `.agents/skills-local/crew-claude/skill-routing-table.md`
+2. **Crew skill**: `.agents/skills-local/crew-claude/SKILL.md` (contains workflows, hard requirements, anti-patterns, and skill routing)
 
 ## Scoring Rubric
 


### PR DESCRIPTION
## Summary
Fix workflow-improver SKILL.md to reference the consolidated crew-claude SKILL.md instead of four deleted files.

## Changes
- Updated Configuration Files to Review section (lines 92-99)
- Removed references to deleted files: workflows.md, hard-requirements.md, anti-patterns.md, skill-routing-table.md
- Added note that these are now contained in the consolidated SKILL.md

## Context
Commit 1e560933 merged crew-claude and crew-codex skills into single SKILL.md files. The workflow-improver skill was referencing the old separate files that no longer exist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update workflow-improver SKILL.md to reference the consolidated crew-claude SKILL.md and remove links to the deleted workflows, hard-requirements, anti-patterns, and routing files. Prevents broken links and keeps guidance in one place.

<sup>Written for commit 153f38086ba6b4257b9d25f5b6ab7af6d16438fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

