### PR TITLE
fix(workflow-improver): change skill agent from Explore to general-purpose

### DIFF
--- a/.agents/skills-local/workflow-improver/SKILL.md
+++ b/.agents/skills-local/workflow-improver/SKILL.md
@@ -2,7 +2,7 @@
 name: workflow-improver
 description: Evaluate session using OpenAI eval-skills framework (Outcome/Process/Style/Efficiency). Analyzes session transcript vs Claude Code config to score performance and generate improvement recommendations. Creates GitHub issue with rubric scores and actionable plan.
 context: fork
-agent: Explore
+agent: general-purpose
 allowed-tools:
   - Read
   - Glob


### PR DESCRIPTION
## Summary

Fixed workflow-improver skill that was failing to execute properly when invoked as a skill. The skill was using `agent: Explore` which is designed for cautious read-only exploration.

## Problem

When invoked with `/workflow-improver`, the Explore agent would see CLAUDE.md instructions in the target project (to load crew-claude first) and become confused about its task, asking clarifying questions instead of executing the workflow analysis.

## Solution

Changed the skill's agent configuration from `agent: Explore` to `agent: general-purpose`. This allows the skill to execute its instructions directly without getting distracted by project configuration.

## Changes

- `.agents/skills-local/workflow-improver/SKILL.md` - Changed line 5 from `agent: Explore` to `agent: general-purpose`

## Testing

Run `/workflow-improver` in the muscat project (or any other project) and verify:
1. The skill executes the session analysis workflow
2. No clarifying questions are asked
3. GitHub issue creation works as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches workflow-improver to use the general-purpose agent so it runs the analysis and creates the GitHub issue without getting stuck on CLAUDE.md hints. Prevents clarifying questions when invoking /workflow-improver.

- **Bug Fixes**
  - Updated SKILL.md: agent changed from Explore to general-purpose.
  - Removes confusion from CLAUDE.md/crew-claude instructions; workflow executes directly.

<sup>Written for commit b0e5971d4a4cd1657a907371fe5797efd04ac425. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

