### PR TITLE
fix(setup): replace readarray with bash 3 compatible while-read loop

### DIFF
--- a/.agents/setup.sh
+++ b/.agents/setup.sh
@@ -351,8 +351,10 @@ install_skills() {
         fi
         repos+=("$repo")
 
-        local skills
-        readarray -t skills < <(jq -r ".skills[$i].skills[]" "$CONFIG_FILE")
+        local skills=()
+        while IFS= read -r skill; do
+            skills+=("$skill")
+        done < <(jq -r ".skills[$i].skills[]" "$CONFIG_FILE")
         local skill_flags=""
         for skill in "${skills[@]}"; do
             if [[ ! "$skill" =~ ^[a-zA-Z0-9._-]+$ ]]; then


### PR DESCRIPTION
## Summary
- Fix setup script failing on macOS due to `readarray` not available in bash 3.2

## Problem
The `.agents/setup.sh` script used `readarray` at line 355 to parse skill names from JSON. `readarray` (aka `mapfile`) was introduced in bash 4.0, but macOS ships with bash 3.2.57 by default, causing the script to fail.

## Solution
Replaced `readarray -t skills < <(jq ...)` with the bash 3 compatible `while IFS= read -r` loop pattern, which is already used elsewhere in the same file (lines 416-427) for reading postInstall commands.

## Changes
- `.agents/setup.sh`: Replace readarray with while-read loop

## Test Plan
- [x] Syntax check passes: `bash -n .agents/setup.sh`
- [x] Script runs successfully: `.agents/setup.sh --docs-only`
- [x] Tested on bash 3.2.57 (macOS default)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes setup script failure on macOS by replacing bash 4-only readarray with a bash 3-compatible while IFS= read -r loop for parsing skill names. This makes .agents/setup.sh run on the default macOS bash 3.2.

<sup>Written for commit e1d2133df465cba037adc5411632ec046a1bc0ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

