### PR TITLE
fix(setup): allow setup.json updates from upstream

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -106,12 +106,6 @@ download_agents() {
 update_agents() {
     echo "Updating .agents..."
 
-    # Preserve user's setup.json if it differs from default
-    local user_config=""
-    if [[ -f "$TARGET_AGENTS_DIR/setup.json" ]]; then
-        user_config=$(cat "$TARGET_AGENTS_DIR/setup.json")
-    fi
-
     # Remove existing .agents (except skills which are gitignored anyway)
     if [[ -d "$TARGET_AGENTS_DIR" ]]; then
         rm -rf "$TARGET_AGENTS_DIR"
@@ -119,12 +113,6 @@ update_agents() {
 
     # Download fresh
     download_agents
-
-    # Restore user config if they had customizations
-    if [[ -n "$user_config" ]]; then
-        echo "$user_config" > "$TARGET_AGENTS_DIR/setup.json"
-        echo "Preserved your setup.json customizations"
-    fi
 }
 
 ensure_agents_dir() {


### PR DESCRIPTION
## Problem

The `update_agents()` function in `setup.sh` overwrites the freshly downloaded `setup.json` with the old local version, preventing users from receiving upstream updates when running `bash setup.sh --update`.

## Solution

Removed the setup.json preservation logic that was preventing updates. The fresh `setup.json` from the repository is now applied during updates.

## Files Changed
- `setup.sh` - Removed lines 109-127 (setup.json preservation logic in `update_agents()`)

## Testing

- Verified bash syntax with `bash -n setup.sh`
- Ran shellcheck validation
- Commit history preserved in main branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure bash setup.sh --update applies the latest setup.json from upstream instead of restoring the local file. Removed the preservation logic in update_agents() so users receive configuration updates.

<sup>Written for commit 00bfd6642a9f4c2908590a280020ad9d2fda019b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

