### PR TITLE
fix(setup): auto-refresh setup.json on every invocation

### DIFF
--- a/.agents/skills/vercel-react-best-practices/AGENTS.md
+++ b/.agents/skills/vercel-react-best-practices/AGENTS.md
@@ -6,7 +6,7 @@ January 2026
 
 > **Note:**  
 > This document is mainly for agents and LLMs to follow when maintaining,  
-> generating, or refactoring React and Next.js codebases at Vercel. Humans  
+> generating, or refactoring React and Next.js codebases. Humans  
 > may also find it useful, but guidance here is optimized for automation  
 > and consistency by AI-assisted workflows.
 

--- a/setup.sh
+++ b/setup.sh
@@ -103,6 +103,22 @@ download_agents() {
     rm -rf "$tmp_dir"
 }
 
+refresh_setup_json() {
+    echo "Checking for setup.json updates..."
+    local tmp_file repo_name
+    tmp_file=$(mktemp)
+    repo_name="${REPO##*/}"
+
+    if curl -sL "$ARCHIVE_URL" | tar -xzf - -O "${repo_name}-${BRANCH}/.agents/setup.json" > "$tmp_file" 2>/dev/null; then
+        if ! diff -q "$tmp_file" "$TARGET_AGENTS_DIR/setup.json" >/dev/null 2>&1; then
+            cp "$tmp_file" "$TARGET_AGENTS_DIR/setup.json"
+            echo "  Updated setup.json with latest configuration"
+        fi
+    fi
+
+    rm -f "$tmp_file"
+}
+
 update_agents() {
     echo "Updating .agents..."
 
@@ -123,6 +139,7 @@ ensure_agents_dir() {
     fi
 
     if agents_ready; then
+        refresh_setup_json
         return
     fi
 


### PR DESCRIPTION
## Summary
Fixes an issue where new install steps from `setup.json` updates weren't picked up when running the README oneliner on existing installations.

## Problem
When users ran the README oneliner:
```bash
curl -sL https://github.com/settlemint/agent-marketplace/archive/refs/heads/main.tar.gz | tar -xzf - --to-stdout "agent-marketplace-main/setup.sh" | bash
```

The script would check if `.agents/` already existed via `agents_ready()`. If true, it would skip downloading fresh content and use the stale local `setup.json`, missing new install steps like worktrunk commands (PR #261).

## Solution
Added `refresh_setup_json()` function that:
- Downloads setup.json from the GitHub archive
- Uses `diff -q` to check if it differs from local version
- Only updates if changed (idempotent)
- Runs every time `agents_ready()` returns true

This ensures setup.json is always fresh without requiring users to know about the `--update` flag.

## Testing
- ✅ Verified bash syntax with `bash -n`
- ✅ Verified function exists and is callable
- ✅ Tested fresh update: setup.json updated with worktrunk commands
- ✅ Tested idempotency: second run shows no update (files unchanged)
- ✅ Tested offline scenario: function completes without error
- ✅ Shellcheck passed with no warnings
- ✅ Codex review: no functional regressions or correctness issues

## Files Changed
- `setup.sh`: Added `refresh_setup_json()` function (15 lines) and one-line call in `ensure_agents_dir()`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure setup.json is refreshed on every run when .agents already exists, so existing installs pick up new steps from upstream without a full re-download. Uses a diff to update only when content changes.

- **Bug Fixes**
  - Added refresh_setup_json() to fetch setup.json from the GitHub archive and replace it only if different.
  - Invoked during ensure_agents_dir() when agents_ready is true.
  - Fixes stale installs where the README oneliner missed new steps (e.g., worktrunk commands).

<sup>Written for commit 03157285ee42f9a210825c6906f596e0b7418774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

