### PR TITLE
fix(hooks): post-compaction skill reload and stronger CLAUDE.md enforcement

### DIFF
--- a/.agents/templates/claude/.claude/scripts/session/post-compact-reload.sh
+++ b/.agents/templates/claude/.claude/scripts/session/post-compact-reload.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Post-compaction skill reload hook
+# Fires on SessionStart — only outputs when source is "compact"
+
+INPUT=$(cat)
+SOURCE=$(echo "$INPUT" | jq -r '.source // empty')
+
+if [ "$SOURCE" = "compact" ]; then
+  cat <<'EOF'
+COMPACTION DETECTED — SKILL RELOAD REQUIRED
+
+Context was compacted. The crew-claude skill workflow (phases, gates, classification) was lost.
+
+Your IMMEDIATE next action MUST be:
+  Skill({ skill: "crew-claude" })
+
+Do NOT continue previous work until the skill is reloaded and you output:
+  CREW-CLAUDE LOADED: ✓
+
+Then resume from where you left off by checking TaskList.
+EOF
+fi

--- a/.agents/templates/claude/.claude/settings.json
+++ b/.agents/templates/claude/.claude/settings.json
@@ -18,15 +18,13 @@
             "prompt": "BLOCKED - SESSION START GATE\n\nYou CANNOT proceed with ANY user request until you:\n1. Invoke: Skill({ skill: \"crew-claude\" })\n2. Read all 6 workflow files listed in SKILL.md\n3. Output CREW-CLAUDE LOADED verification checklist\n\nThis is non-negotiable. Your FIRST action must be the Skill() invocation. Do NOT explore, read files, or start planning until the verification checklist is output."
           }
         ]
-      }
-    ],
-    "PreCompact": [
+      },
       {
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "BLOCKED - POST-COMPACTION GATE\n\nContext was compacted. You CANNOT continue work until you:\n1. Invoke: Skill({ skill: \"crew-claude\" })\n2. Read all 6 workflow files listed in SKILL.md\n3. Output CREW-CLAUDE LOADED verification checklist\n\nYour NEXT action must be the Skill() invocation. Do NOT continue previous work until verification is output."
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/session/post-compact-reload.sh"
           }
         ]
       }

--- a/.agents/templates/claude/CLAUDE.md
+++ b/.agents/templates/claude/CLAUDE.md
@@ -2,21 +2,23 @@
 
 ## You Are BLOCKED Until Skill Loaded
 
-Before ANY other action (reading files, exploring, planning, answering):
+Before ANY other action (reading files, exploring, planning, answering), you MUST invoke the crew-claude skill using the Skill tool:
 
 ```
 Skill({ skill: "crew-claude" })
 ```
 
-The skill content loads inline. Output:
+The skill content loads inline. After loading, output:
 
 ```
 CREW-CLAUDE LOADED: ✓
 ```
 
+**WARNING: Do NOT fake this output.** You must actually call the Skill tool — printing the text without invoking the tool is a violation. The skill contains the full phase workflow, gate definitions, and classification rules that govern ALL subsequent work.
+
 ---
 
-## BLOCKED Actions (until verification above is output)
+## BLOCKED Actions (until Skill tool is invoked and verification output)
 
 You may NOT:
 - Explore codebase
@@ -28,7 +30,19 @@ You may NOT:
 
 ---
 
-## Critical Workflow Summary (backup if skill load fails)
+## Post-Compaction Reload
+
+If context was compacted, the skill content is lost. You MUST reload it immediately:
+
+```
+Skill({ skill: "crew-claude" })
+```
+
+Then check `TaskList` to see where you left off and resume from that point.
+
+---
+
+## Workflow Requirements (always enforced, skill or not)
 
 ### Classification First - ALWAYS
 
@@ -40,20 +54,23 @@ Output classification BEFORE any tools/exploration:
 
 ### 9 Mandatory Gates
 
-Every implementation requires gates. Output gate check before each phase:
-- Planning (classification + research complete)
-- Refinement (questions asked via AskUserQuestion)
-- Implementation (skills loaded, tasks created)
-- Cleanup
-- Testing (test output with exit code)
-- Review (Skill({ skill: "review" }) invoked)
-- Verification (verification skill executed)
-- CI (bun run ci with exit code 0)
-- Integration (bun run test:integration with exit code 0)
+Every implementation MUST pass through ALL gates in order. You may NOT skip gates. Output `GATE: <name> — PASSED` before proceeding to the next phase:
 
-### Skills Must Be INVOKED
+1. **Planning** — classification + research complete
+2. **Refinement** — questions asked via AskUserQuestion
+3. **Implementation** — skills loaded, TaskCreate used for all work items
+4. **Cleanup** — unused code removed, no leftover artifacts
+5. **Testing** — test output shown with exit code (`bun run test`)
+6. **Review** — `Skill({ skill: "review" })` invoked, findings addressed
+7. **Verification** — `Skill({ skill: "verification-before-completion" })` invoked
+8. **CI** — `bun run ci` with exit code 0
+9. **Integration** — `bun run test:integration` with exit code 0
 
-Listing skills is NOT loading. You must call:
+Skipping a gate or claiming a gate passed without evidence is a violation.
+
+### Skills Must Be INVOKED (not mentioned)
+
+Listing skills is NOT loading them. You must call the Skill tool:
 ```
 Skill({ skill: "test-driven-development" })
 Skill({ skill: "verification-before-completion" })
@@ -62,18 +79,16 @@ Skill({ skill: "ask-questions-if-underspecified" })
 
 ### Banned Phrases
 
-Never say: "looks good", "should work", "Done!", "requirements are clear" (local), "manual review", "code is simple"
+Never say: "looks good", "should work", "Done!", "requirements are clear" (without AskUserQuestion), "manual review", "code is simple"
 
 ### Task Tracking Required
 
 Before code: `TaskCreate` + `TaskUpdate({ status: "in_progress" })`
 After code: `TaskUpdate({ status: "completed" })`
-Before completion: `TaskList` to verify all done
+Before completion: `TaskList` to verify ALL tasks are completed
 
 ---
 
 ## Now Load The Skill
-
-This summary is a backup. The full workflow loads inline with the skill.
 
 **Your next action MUST be:** `Skill({ skill: "crew-claude" })`

--- a/.claude/scripts/session/post-compact-reload.sh
+++ b/.claude/scripts/session/post-compact-reload.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Post-compaction skill reload hook
+# Fires on SessionStart — only outputs when source is "compact"
+
+INPUT=$(cat)
+SOURCE=$(echo "$INPUT" | jq -r '.source // empty')
+
+if [ "$SOURCE" = "compact" ]; then
+  cat <<'EOF'
+COMPACTION DETECTED — SKILL RELOAD REQUIRED
+
+Context was compacted. The crew-claude skill workflow (phases, gates, classification) was lost.
+
+Your IMMEDIATE next action MUST be:
+  Skill({ skill: "crew-claude" })
+
+Do NOT continue previous work until the skill is reloaded and you output:
+  CREW-CLAUDE LOADED: ✓
+
+Then resume from where you left off by checking TaskList.
+EOF
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,15 +18,13 @@
             "prompt": "BLOCKED - SESSION START GATE\n\nYou CANNOT proceed with ANY user request until you:\n1. Invoke: Skill({ skill: \"crew-claude\" })\n2. Read all 6 workflow files listed in SKILL.md\n3. Output CREW-CLAUDE LOADED verification checklist\n\nThis is non-negotiable. Your FIRST action must be the Skill() invocation. Do NOT explore, read files, or start planning until the verification checklist is output."
           }
         ]
-      }
-    ],
-    "PreCompact": [
+      },
       {
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "BLOCKED - POST-COMPACTION GATE\n\nContext was compacted. You CANNOT continue work until you:\n1. Invoke: Skill({ skill: \"crew-claude\" })\n2. Read all 6 workflow files listed in SKILL.md\n3. Output CREW-CLAUDE LOADED verification checklist\n\nYour NEXT action must be the Skill() invocation. Do NOT continue previous work until verification is output."
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/session/post-compact-reload.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,21 +2,23 @@
 
 ## You Are BLOCKED Until Skill Loaded
 
-Before ANY other action (reading files, exploring, planning, answering):
+Before ANY other action (reading files, exploring, planning, answering), you MUST invoke the crew-claude skill using the Skill tool:
 
 ```
 Skill({ skill: "crew-claude" })
 ```
 
-The skill content loads inline. Output:
+The skill content loads inline. After loading, output:
 
 ```
 CREW-CLAUDE LOADED: ✓
 ```
 
+**WARNING: Do NOT fake this output.** You must actually call the Skill tool — printing the text without invoking the tool is a violation. The skill contains the full phase workflow, gate definitions, and classification rules that govern ALL subsequent work.
+
 ---
 
-## BLOCKED Actions (until verification above is output)
+## BLOCKED Actions (until Skill tool is invoked and verification output)
 
 You may NOT:
 - Explore codebase
@@ -28,11 +30,23 @@ You may NOT:
 
 ---
 
-## Critical Workflow Summary (backup if skill load fails)
+## Post-Compaction Reload
+
+If context was compacted, the skill content is lost. You MUST reload it immediately:
+
+```
+Skill({ skill: "crew-claude" })
+```
+
+Then check `TaskList` to see where you left off and resume from that point.
+
+---
+
+## Workflow Requirements (always enforced, skill or not)
 
 ### Classification First - ALWAYS
 
-Determine classification internally BEFORE any tools/exploration (do not output to user):
+Output classification BEFORE any tools/exploration:
 - **Trivial**: single-line, typo, comment only
 - **Simple**: single file, clear scope
 - **Standard**: multi-file, behavior change
@@ -40,20 +54,23 @@ Determine classification internally BEFORE any tools/exploration (do not output 
 
 ### 9 Mandatory Gates
 
-Every implementation requires gates. Output gate check before each phase:
-- Planning (classification + research complete)
-- Refinement (questions asked via AskUserQuestion)
-- Implementation (skills loaded, tasks created)
-- Cleanup
-- Testing (test output with exit code)
-- Review (Skill({ skill: "review" }) invoked)
-- Verification (verification skill executed)
-- CI (bun run ci with exit code 0)
-- Integration (bun run test:integration with exit code 0)
+Every implementation MUST pass through ALL gates in order. You may NOT skip gates. Output `GATE: <name> — PASSED` before proceeding to the next phase:
 
-### Skills Must Be INVOKED
+1. **Planning** — classification + research complete
+2. **Refinement** — questions asked via AskUserQuestion
+3. **Implementation** — skills loaded, TaskCreate used for all work items
+4. **Cleanup** — unused code removed, no leftover artifacts
+5. **Testing** — test output shown with exit code (`bun run test`)
+6. **Review** — `Skill({ skill: "review" })` invoked, findings addressed
+7. **Verification** — `Skill({ skill: "verification-before-completion" })` invoked
+8. **CI** — `bun run ci` with exit code 0
+9. **Integration** — `bun run test:integration` with exit code 0
 
-Listing skills is NOT loading. You must call:
+Skipping a gate or claiming a gate passed without evidence is a violation.
+
+### Skills Must Be INVOKED (not mentioned)
+
+Listing skills is NOT loading them. You must call the Skill tool:
 ```
 Skill({ skill: "test-driven-development" })
 Skill({ skill: "verification-before-completion" })
@@ -62,18 +79,16 @@ Skill({ skill: "ask-questions-if-underspecified" })
 
 ### Banned Phrases
 
-Never say: "looks good", "should work", "Done!", "requirements are clear" (local), "manual review", "code is simple"
+Never say: "looks good", "should work", "Done!", "requirements are clear" (without AskUserQuestion), "manual review", "code is simple"
 
 ### Task Tracking Required
 
 Before code: `TaskCreate` + `TaskUpdate({ status: "in_progress" })`
 After code: `TaskUpdate({ status: "completed" })`
-Before completion: `TaskList` to verify all done
+Before completion: `TaskList` to verify ALL tasks are completed
 
 ---
 
 ## Now Load The Skill
-
-This summary is a backup. The full workflow loads inline with the skill.
 
 **Your next action MUST be:** `Skill({ skill: "crew-claude" })`


### PR DESCRIPTION
## Summary
- Replace `PreCompact` prompt hook (useless — gets compacted away) with a `SessionStart` command hook that detects `source=compact` and injects a crew-claude skill reload instruction
- Strengthen CLAUDE.md template: explicit "do not fake" warning, numbered gates with `GATE: <name> — PASSED` output requirement, post-compaction reload section
- Add `post-compact-reload.sh` script to both template and output directories

## Test plan
- [ ] Start a session, verify normal startup does not trigger reload message
- [ ] Trigger compaction (fill context), verify reload instruction appears after compaction
- [ ] Verify `setup.sh` produces correct settings.json (no PreCompact, SessionStart has 3 hooks)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken compaction flow by replacing the PreCompact prompt with a SessionStart command that detects compaction and forces a crew-claude skill reload. Tightens CLAUDE.md to require real skill loading and explicit gate passes.

- **Bug Fixes**
  - Replaced the ineffective PreCompact prompt with a SessionStart command hook that checks source="compact" and outputs a reload instruction.
  - Updated settings.json (template and project) to remove PreCompact and register the new hook.

- **New Features**
  - Added post-compact-reload.sh in both template and .claude to automate the reload message after compaction.
  - Strengthened CLAUDE.md: “do not fake” warning, required `GATE: <name> — PASSED` outputs for all 9 gates, a post-compaction reload section, and clearer “skills must be invoked” guidance.

<sup>Written for commit c5c20fe9b7b7c27f74cceb96d55d83bf66fae4e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

